### PR TITLE
fix(Viewer): retina-logo

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -80,12 +80,12 @@ function Viewer(options) {
 
   var a = $('<a href="http://bpmn.io" target="_blank" class="bjs-powered-by" title="Powered by bpmn.io" />').css({
     position: 'absolute',
-    bottom: 15,
+    bottom: 25,
     right: 15,
     zIndex: 100
   });
 
-  var logo = $('<img/>').attr('src', 'data:image/png;base64,' + logoData).appendTo(a);
+  var logo = $('<img/>').attr('src', 'data:image/png;base64,' + logoData).css({ width: 25 }).appendTo(a);
 
   a.appendTo(container);
 


### PR DESCRIPTION
Display logo at half width for crisp edges on hi-res screens.

Fixes #119 