### PR TITLE
modified label y positioning

### DIFF
--- a/lib/util/Label.js
+++ b/lib/util/Label.js
@@ -94,6 +94,7 @@ module.exports.getExternalLabelBounds = function(semantic, element) {
 
   return _.extend({
     x: mid.x - size.width / 2,
-    y: mid.y - size.height / 2
+    // removed the size alteration, as it was mucking up label positions
+    y: mid.y// - size.height / 2
   }, size);
 };


### PR DESCRIPTION
Not sure exactly what's going on with the positioning of the labels, but noticed it was 10px off on the y axis when importing a .bpmn file that I had just exported. Just removing the extra size.height value seems to fix it.
