### PR TITLE
It splits subprocesses from call activities

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1,17 +1,17 @@
 'use strict';
 
 var inherits = require('inherits'),
-    isArray = require('lodash/lang/isArray'),
-    isObject = require('lodash/lang/isObject'),
-    assign = require('lodash/object/assign'),
-    forEach = require('lodash/collection/forEach'),
-    every = require('lodash/collection/every'),
-    includes = require('lodash/collection/includes'),
-    some = require('lodash/collection/some');
+  isArray = require('lodash/lang/isArray'),
+  isObject = require('lodash/lang/isObject'),
+  assign = require('lodash/object/assign'),
+  forEach = require('lodash/collection/forEach'),
+  every = require('lodash/collection/every'),
+  includes = require('lodash/collection/includes'),
+  some = require('lodash/collection/some');
 
 var DefaultRenderer = require('diagram-js/lib/draw/Renderer'),
-    TextUtil = require('diagram-js/lib/util/Text'),
-    DiUtil = require('../util/DiUtil');
+  TextUtil = require('diagram-js/lib/util/Text'),
+  DiUtil = require('../util/DiUtil');
 
 var createLine = DefaultRenderer.createLine;
 
@@ -30,7 +30,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
   var textUtil = new TextUtil({
     style: LABEL_STYLE,
-    size: { width: 100 }
+    size: {width: 100}
   });
 
   var markers = {};
@@ -53,7 +53,7 @@ function BpmnRenderer(events, styles, pathMap) {
         strokeDasharray: 'none'
       }, options.attrs);
 
-      var ref = options.ref || { x: 0, y: 0 };
+      var ref = options.ref || {x: 0, y: 0};
 
       var scale = options.scale || 1;
 
@@ -64,12 +64,12 @@ function BpmnRenderer(events, styles, pathMap) {
       }
 
       var marker = options.element
-                     .attr(attrs)
-                     .marker(0, 0, 20, 20, ref.x, ref.y)
-                     .attr({
-                       markerWidth: 20 * scale,
-                       markerHeight: 20 * scale
-                     });
+        .attr(attrs)
+        .marker(0, 0, 20, 20, ref.x, ref.y)
+        .attr({
+          markerWidth: 20 * scale,
+          markerHeight: 20 * scale
+        });
 
       return addMarker(id, marker);
     }
@@ -77,7 +77,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
     createMarker('sequenceflow-end', {
       element: svg.path('M 1 5 L 11 10 L 1 15 Z'),
-      ref: { x: 11, y: 10 },
+      ref: {x: 11, y: 10},
       scale: 0.5
     });
 
@@ -87,7 +87,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: 'white',
         stroke: 'black'
       },
-      ref: { x: 6, y: 6 }
+      ref: {x: 6, y: 6}
     });
 
     createMarker('messageflow-end', {
@@ -96,7 +96,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: 'white',
         stroke: 'black'
       },
-      ref: { x: 11, y: 10 }
+      ref: {x: 11, y: 10}
     });
 
     createMarker('data-association-end', {
@@ -105,7 +105,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: 'white',
         stroke: 'black'
       },
-      ref: { x: 11, y: 10 },
+      ref: {x: 11, y: 10},
       scale: 0.5
     });
 
@@ -115,7 +115,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: 'white',
         stroke: 'black'
       },
-      ref: { x: -1, y: 10 },
+      ref: {x: -1, y: 10},
       scale: 0.5
     });
 
@@ -124,7 +124,7 @@ function BpmnRenderer(events, styles, pathMap) {
       attrs: {
         stroke: 'black'
       },
-      ref: { x: -5, y: 10 },
+      ref: {x: -5, y: 10},
       scale: 0.5
     });
   }
@@ -154,7 +154,7 @@ function BpmnRenderer(events, styles, pathMap) {
     });
 
     var cx = width / 2,
-        cy = height / 2;
+      cy = height / 2;
 
     return p.circle(cx, cy, Math.round((width + height) / 4 - offset)).attr(attrs);
   }
@@ -182,7 +182,7 @@ function BpmnRenderer(events, styles, pathMap) {
     var x_2 = width / 2;
     var y_2 = height / 2;
 
-    var points = [x_2, 0, width, y_2, x_2, height, 0, y_2 ];
+    var points = [x_2, 0, width, y_2, x_2, height, 0, y_2];
 
     attrs = computeStyle(attrs, {
       stroke: 'black',
@@ -194,7 +194,7 @@ function BpmnRenderer(events, styles, pathMap) {
   }
 
   function drawLine(p, waypoints, attrs) {
-    attrs = computeStyle(attrs, [ 'no-fill' ], {
+    attrs = computeStyle(attrs, ['no-fill'], {
       stroke: 'black',
       strokeWidth: 2,
       fill: 'none'
@@ -205,7 +205,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
   function drawPath(p, d, attrs) {
 
-    attrs = computeStyle(attrs, [ 'no-fill' ], {
+    attrs = computeStyle(attrs, ['no-fill'], {
       strokeWidth: 2,
       stroke: 'black'
     });
@@ -214,7 +214,7 @@ function BpmnRenderer(events, styles, pathMap) {
   }
 
   function as(type) {
-    return function(p, element) {
+    return function (p, element) {
       return handlers[type](p, element);
     };
   }
@@ -245,12 +245,12 @@ function BpmnRenderer(events, styles, pathMap) {
     }
 
     if (isTypedEvent(event, 'bpmn:CancelEventDefinition') &&
-      isTypedEvent(event, 'bpmn:TerminateEventDefinition', { parallelMultiple: false })) {
+      isTypedEvent(event, 'bpmn:TerminateEventDefinition', {parallelMultiple: false})) {
       return renderer('bpmn:MultipleEventDefinition')(p, element, isThrowing);
     }
 
     if (isTypedEvent(event, 'bpmn:CancelEventDefinition') &&
-      isTypedEvent(event, 'bpmn:TerminateEventDefinition', { parallelMultiple: true })) {
+      isTypedEvent(event, 'bpmn:TerminateEventDefinition', {parallelMultiple: true})) {
       return renderer('bpmn:ParallelMultipleEventDefinition')(p, element, isThrowing);
     }
 
@@ -287,7 +287,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
   function renderEmbeddedLabel(p, element, align) {
     var semantic = getSemantic(element);
-    return renderLabel(p, semantic.name, { box: element, align: align, padding: 5 });
+    return renderLabel(p, semantic.name, {box: element, align: align, padding: 5});
   }
 
   function renderExternalLabel(p, element, align) {
@@ -297,12 +297,12 @@ function BpmnRenderer(events, styles, pathMap) {
       element.hidden = true;
     }
 
-    return renderLabel(p, semantic.name, { box: element, align: align, style: { fontSize: '11px' } });
+    return renderLabel(p, semantic.name, {box: element, align: align, style: {fontSize: '11px'}});
   }
 
   function renderLaneLabel(p, text, element) {
     var textBox = renderLabel(p, text, {
-      box: { height: 30, width: element.height },
+      box: {height: 30, width: element.height},
       align: 'center-middle'
     });
 
@@ -324,10 +324,10 @@ function BpmnRenderer(events, styles, pathMap) {
   }
 
   var handlers = {
-    'bpmn:Event': function(p, element, attrs) {
-      return drawCircle(p, element.width, element.height,  attrs);
+    'bpmn:Event': function (p, element, attrs) {
+      return drawCircle(p, element.width, element.height, attrs);
     },
-    'bpmn:StartEvent': function(p, element) {
+    'bpmn:StartEvent': function (p, element) {
       var attrs = {};
       var semantic = getSemantic(element);
 
@@ -344,7 +344,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return circle;
     },
-    'bpmn:MessageEventDefinition': function(p, element, isThrowing) {
+    'bpmn:MessageEventDefinition': function (p, element, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_MESSAGE', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
@@ -367,7 +367,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return messagePath;
     },
-    'bpmn:TimerEventDefinition': function(p, element) {
+    'bpmn:TimerEventDefinition': function (p, element) {
 
       var circle = drawCircle(p, element.width, element.height, 0.2 * element.height, {
         strokeWidth: 2
@@ -389,7 +389,7 @@ function BpmnRenderer(events, styles, pathMap) {
         strokeLinecap: 'square'
       });
 
-      for(var i = 0;i < 12;i++) {
+      for (var i = 0; i < 12; i++) {
 
         var linePathData = pathMap.getScaledPath('EVENT_TIMER_LINE', {
           xScaleFactor: 0.75,
@@ -414,7 +414,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return circle;
     },
-    'bpmn:EscalationEventDefinition': function(p, event, isThrowing) {
+    'bpmn:EscalationEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_ESCALATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -433,7 +433,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:ConditionalEventDefinition': function(p, event) {
+    'bpmn:ConditionalEventDefinition': function (p, event) {
       var pathData = pathMap.getScaledPath('EVENT_CONDITIONAL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -449,7 +449,7 @@ function BpmnRenderer(events, styles, pathMap) {
         strokeWidth: 1
       });
     },
-    'bpmn:LinkEventDefinition': function(p, event, isThrowing) {
+    'bpmn:LinkEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_LINK', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -468,7 +468,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:ErrorEventDefinition': function(p, event, isThrowing) {
+    'bpmn:ErrorEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_ERROR', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
@@ -487,7 +487,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:CancelEventDefinition': function(p, event, isThrowing) {
+    'bpmn:CancelEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_CANCEL_45', {
         xScaleFactor: 1.0,
         yScaleFactor: 1.0,
@@ -506,7 +506,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       }).transform('rotate(45)');
     },
-    'bpmn:CompensateEventDefinition': function(p, event, isThrowing) {
+    'bpmn:CompensateEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_COMPENSATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -525,7 +525,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:SignalEventDefinition': function(p, event, isThrowing) {
+    'bpmn:SignalEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_SIGNAL', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
@@ -544,7 +544,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:MultipleEventDefinition': function(p, event, isThrowing) {
+    'bpmn:MultipleEventDefinition': function (p, event, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_MULTIPLE', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
@@ -563,7 +563,7 @@ function BpmnRenderer(events, styles, pathMap) {
         fill: fill
       });
     },
-    'bpmn:ParallelMultipleEventDefinition': function(p, event) {
+    'bpmn:ParallelMultipleEventDefinition': function (p, event) {
       var pathData = pathMap.getScaledPath('EVENT_PARALLEL_MULTIPLE', {
         xScaleFactor: 1.2,
         yScaleFactor: 1.2,
@@ -579,7 +579,7 @@ function BpmnRenderer(events, styles, pathMap) {
         strokeWidth: 1
       });
     },
-    'bpmn:EndEvent': function(p, element) {
+    'bpmn:EndEvent': function (p, element) {
       var circle = renderer('bpmn:Event')(p, element, {
         strokeWidth: 4
       });
@@ -588,7 +588,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return circle;
     },
-    'bpmn:TerminateEventDefinition': function(p, element) {
+    'bpmn:TerminateEventDefinition': function (p, element) {
       var circle = drawCircle(p, element.width, element.height, 8, {
         strokeWidth: 4,
         fill: 'black'
@@ -596,9 +596,10 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return circle;
     },
-    'bpmn:IntermediateEvent': function(p, element) {
-      var outer = renderer('bpmn:Event')(p, element, { strokeWidth: 1 });
-      /* inner */ drawCircle(p, element.width, element.height, INNER_OUTER_DIST, { strokeWidth: 1, fill: 'none' });
+    'bpmn:IntermediateEvent': function (p, element) {
+      var outer = renderer('bpmn:Event')(p, element, {strokeWidth: 1});
+      /* inner */
+      drawCircle(p, element.width, element.height, INNER_OUTER_DIST, {strokeWidth: 1, fill: 'none'});
 
       renderEventContent(element, p);
 
@@ -607,17 +608,17 @@ function BpmnRenderer(events, styles, pathMap) {
     'bpmn:IntermediateCatchEvent': as('bpmn:IntermediateEvent'),
     'bpmn:IntermediateThrowEvent': as('bpmn:IntermediateEvent'),
 
-    'bpmn:Activity': function(p, element, attrs) {
+    'bpmn:Activity': function (p, element, attrs) {
       return drawRect(p, element.width, element.height, TASK_BORDER_RADIUS, attrs);
     },
 
-    'bpmn:Task': function(p, element) {
+    'bpmn:Task': function (p, element) {
       var rect = renderer('bpmn:Activity')(p, element);
       renderEmbeddedLabel(p, element, 'center-middle');
       attachTaskMarkers(p, element);
       return rect;
     },
-    'bpmn:ServiceTask': function(p, element) {
+    'bpmn:ServiceTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var pathDataBG = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
@@ -627,7 +628,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* service bg */ drawPath(p, pathDataBG, {
+      /* service bg */
+      drawPath(p, pathDataBG, {
         strokeWidth: 1,
         fill: 'none'
       });
@@ -639,7 +641,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* service fill */ drawPath(p, fillPathData, {
+      /* service fill */
+      drawPath(p, fillPathData, {
         strokeWidth: 0,
         stroke: 'none',
         fill: 'white'
@@ -652,14 +655,15 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* service */ drawPath(p, pathData, {
+      /* service */
+      drawPath(p, pathData, {
         strokeWidth: 1,
         fill: 'white'
       });
 
       return task;
     },
-    'bpmn:UserTask': function(p, element) {
+    'bpmn:UserTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var x = 15;
@@ -672,7 +676,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* user path */ drawPath(p, pathData, {
+      /* user path */
+      drawPath(p, pathData, {
         strokeWidth: 0.5,
         fill: 'none'
       });
@@ -684,7 +689,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* user2 path */ drawPath(p, pathData2, {
+      /* user2 path */
+      drawPath(p, pathData2, {
         strokeWidth: 0.5,
         fill: 'none'
       });
@@ -696,14 +702,15 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* user3 path */ drawPath(p, pathData3, {
+      /* user3 path */
+      drawPath(p, pathData3, {
         strokeWidth: 0.5,
         fill: 'black'
       });
 
       return task;
     },
-    'bpmn:ManualTask': function(p, element) {
+    'bpmn:ManualTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var pathData = pathMap.getScaledPath('TASK_TYPE_MANUAL', {
@@ -713,7 +720,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* manual path */ drawPath(p, pathData, {
+      /* manual path */
+      drawPath(p, pathData, {
         strokeWidth: 0.25,
         fill: 'white',
         stroke: 'black'
@@ -721,7 +729,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return task;
     },
-    'bpmn:SendTask': function(p, element) {
+    'bpmn:SendTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var pathData = pathMap.getScaledPath('TASK_TYPE_SEND', {
@@ -735,7 +743,8 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* send path */ drawPath(p, pathData, {
+      /* send path */
+      drawPath(p, pathData, {
         strokeWidth: 1,
         fill: 'black',
         stroke: 'white'
@@ -743,14 +752,14 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return task;
     },
-    'bpmn:ReceiveTask' : function(p, element) {
+    'bpmn:ReceiveTask': function (p, element) {
       var semantic = getSemantic(element);
 
       var task = renderer('bpmn:Task')(p, element);
       var pathData;
 
       if (semantic.instantiate) {
-        drawCircle(p, 28, 28, 20 * 0.22, { strokeWidth: 1 });
+        drawCircle(p, 28, 28, 20 * 0.22, {strokeWidth: 1});
 
         pathData = pathMap.getScaledPath('TASK_TYPE_INSTANTIATING_SEND', {
           abspos: {
@@ -772,13 +781,14 @@ function BpmnRenderer(events, styles, pathMap) {
         });
       }
 
-      /* receive path */ drawPath(p, pathData, {
+      /* receive path */
+      drawPath(p, pathData, {
         strokeWidth: 1
       });
 
       return task;
     },
-    'bpmn:ScriptTask': function(p, element) {
+    'bpmn:ScriptTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var pathData = pathMap.getScaledPath('TASK_TYPE_SCRIPT', {
@@ -788,13 +798,14 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* script path */ drawPath(p, pathData, {
+      /* script path */
+      drawPath(p, pathData, {
         strokeWidth: 1
       });
 
       return task;
     },
-    'bpmn:BusinessRuleTask': function(p, element) {
+    'bpmn:BusinessRuleTask': function (p, element) {
       var task = renderer('bpmn:Task')(p, element);
 
       var headerPathData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_HEADER', {
@@ -824,8 +835,39 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return task;
     },
-    'bpmn:SubProcess': function(p, element, attrs) {
+    'bpmn:SubProcess': function (p, element, attrs) {
       var rect = renderer('bpmn:Activity')(p, element, attrs);
+
+      var semantic = getSemantic(element);
+
+      var isEventSubProcess = !!semantic.triggeredByEvent;
+      if (isEventSubProcess) {
+        rect.attr({
+          strokeDasharray: '1,2'
+        });
+      }
+      renderEmbeddedLabel(p, element, 'center-top');
+      attachTaskMarkers(p, element);
+
+      return rect;
+    },
+    'bpmn:AdHocSubProcess': function (p, element) {
+      return renderer('bpmn:SubProcess')(p, element);
+    },
+    'bpmn:Transaction': function (p, element) {
+      var outer = renderer('bpmn:SubProcess')(p, element);
+
+      var innerAttrs = styles.style(['no-fill', 'no-events']);
+
+      /* inner path */
+      drawRect(p, element.width, element.height, TASK_BORDER_RADIUS - 2, INNER_OUTER_DIST, innerAttrs);
+
+      return outer;
+    },
+    'bpmn:CallActivity': function (p, element) {
+      var rect = renderer('bpmn:Activity')(p, element, {
+        strokeWidth: 5
+      });
 
       var semantic = getSemantic(element);
 
@@ -848,24 +890,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return rect;
     },
-    'bpmn:AdHocSubProcess': function(p, element) {
-      return renderer('bpmn:SubProcess')(p, element);
-    },
-    'bpmn:Transaction': function(p, element) {
-      var outer = renderer('bpmn:SubProcess')(p, element);
-
-      var innerAttrs = styles.style([ 'no-fill', 'no-events' ]);
-
-      /* inner path */ drawRect(p, element.width, element.height, TASK_BORDER_RADIUS - 2, INNER_OUTER_DIST, innerAttrs);
-
-      return outer;
-    },
-    'bpmn:CallActivity': function(p, element) {
-      return renderer('bpmn:SubProcess')(p, element, {
-        strokeWidth: 5
-      });
-    },
-    'bpmn:Participant': function(p, element) {
+    'bpmn:Participant': function (p, element) {
 
       var lane = renderer('bpmn:Lane')(p, element);
 
@@ -873,26 +898,26 @@ function BpmnRenderer(events, styles, pathMap) {
 
       if (expandedPool) {
         drawLine(p, [
-          { x: 30, y: 0 },
-          { x: 30, y: element.height }
+          {x: 30, y: 0},
+          {x: 30, y: element.height}
         ]);
         var text = getSemantic(element).name;
         renderLaneLabel(p, text, element);
       } else {
         // Collapsed pool draw text inline
         var text2 = getSemantic(element).name;
-        renderLabel(p, text2, { box: element, align: 'center-middle' });
+        renderLabel(p, text2, {box: element, align: 'center-middle'});
       }
 
       var participantMultiplicity = !!(getSemantic(element).participantMultiplicity);
 
-      if(participantMultiplicity) {
+      if (participantMultiplicity) {
         renderer('ParticipantMultiplicityMarker')(p, element);
       }
 
       return lane;
     },
-    'bpmn:Lane': function(p, element) {
+    'bpmn:Lane': function (p, element) {
       var rect = drawRect(p, element.width, element.height, 0, {
         fill: 'none'
       });
@@ -906,18 +931,18 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return rect;
     },
-    'bpmn:InclusiveGateway': function(p, element) {
+    'bpmn:InclusiveGateway': function (p, element) {
       var diamond = drawDiamond(p, element.width, element.height);
 
-        /* circle path */
-        drawCircle(p, element.width, element.height, element.height * 0.24, {
+      /* circle path */
+      drawCircle(p, element.width, element.height, element.height * 0.24, {
         strokeWidth: 2.5,
         fill: 'none'
       });
 
       return diamond;
     },
-    'bpmn:ExclusiveGateway': function(p, element) {
+    'bpmn:ExclusiveGateway': function (p, element) {
       var diamond = drawDiamond(p, element.width, element.height);
 
       var pathData = pathMap.getScaledPath('GATEWAY_EXCLUSIVE', {
@@ -940,12 +965,12 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return diamond;
     },
-    'bpmn:ComplexGateway': function(p, element) {
+    'bpmn:ComplexGateway': function (p, element) {
       var diamond = drawDiamond(p, element.width, element.height);
 
       var pathData = pathMap.getScaledPath('GATEWAY_COMPLEX', {
         xScaleFactor: 0.5,
-        yScaleFactor:0.5,
+        yScaleFactor: 0.5,
         containerWidth: element.width,
         containerHeight: element.height,
         position: {
@@ -954,19 +979,20 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* complex path */ drawPath(p, pathData, {
+      /* complex path */
+      drawPath(p, pathData, {
         strokeWidth: 1,
         fill: 'black'
       });
 
       return diamond;
     },
-    'bpmn:ParallelGateway': function(p, element) {
+    'bpmn:ParallelGateway': function (p, element) {
       var diamond = drawDiamond(p, element.width, element.height);
 
       var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
         xScaleFactor: 0.6,
-        yScaleFactor:0.6,
+        yScaleFactor: 0.6,
         containerWidth: element.width,
         containerHeight: element.height,
         position: {
@@ -975,20 +1001,22 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      /* parallel path */ drawPath(p, pathData, {
+      /* parallel path */
+      drawPath(p, pathData, {
         strokeWidth: 1,
         fill: 'black'
       });
 
       return diamond;
     },
-    'bpmn:EventBasedGateway': function(p, element) {
+    'bpmn:EventBasedGateway': function (p, element) {
 
       var semantic = getSemantic(element);
 
       var diamond = drawDiamond(p, element.width, element.height);
 
-      /* outer circle path */ drawCircle(p, element.width, element.height, element.height * 0.20, {
+      /* outer circle path */
+      drawCircle(p, element.width, element.height, element.height * 0.20, {
         strokeWidth: 1,
         fill: 'none'
       });
@@ -1009,7 +1037,8 @@ function BpmnRenderer(events, styles, pathMap) {
           }
         });
 
-        /* event path */ drawPath(p, pathData, {
+        /* event path */
+        drawPath(p, pathData, {
           strokeWidth: 2,
           fill: 'none'
         });
@@ -1019,7 +1048,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
         var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
           xScaleFactor: 0.4,
-          yScaleFactor:0.4,
+          yScaleFactor: 0.4,
           containerWidth: element.width,
           containerHeight: element.height,
           position: {
@@ -1049,10 +1078,10 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return diamond;
     },
-    'bpmn:Gateway': function(p, element) {
+    'bpmn:Gateway': function (p, element) {
       return drawDiamond(p, element.width, element.height);
     },
-    'bpmn:SequenceFlow': function(p, element) {
+    'bpmn:SequenceFlow': function (p, element) {
       var pathData = createPathFromConnection(element);
       var path = drawPath(p, pathData, {
         markerEnd: marker('sequenceflow-end')
@@ -1077,7 +1106,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return path;
     },
-    'bpmn:Association': function(p, element, attrs) {
+    'bpmn:Association': function (p, element, attrs) {
 
       attrs = assign({
         strokeDasharray: '1,6',
@@ -1087,20 +1116,20 @@ function BpmnRenderer(events, styles, pathMap) {
       // TODO(nre): style according to directed state
       return drawLine(p, element.waypoints, attrs);
     },
-    'bpmn:DataInputAssociation': function(p, element) {
+    'bpmn:DataInputAssociation': function (p, element) {
       return renderer('bpmn:Association')(p, element, {
         markerEnd: marker('data-association-end')
       });
     },
-    'bpmn:DataOutputAssociation': function(p, element) {
+    'bpmn:DataOutputAssociation': function (p, element) {
       return renderer('bpmn:Association')(p, element, {
         markerEnd: marker('data-association-end')
       });
     },
-    'bpmn:MessageFlow': function(p, element) {
+    'bpmn:MessageFlow': function (p, element) {
 
       var semantic = getSemantic(element),
-          di = getDi(element);
+        di = getDi(element);
 
       var pathData = createPathFromConnection(element);
       var path = drawPath(p, pathData, {
@@ -1121,7 +1150,7 @@ function BpmnRenderer(events, styles, pathMap) {
           }
         });
 
-        var messageAttrs = { strokeWidth: 1 };
+        var messageAttrs = {strokeWidth: 1};
 
         if (di.messageVisibleKind === 'initiating') {
           messageAttrs.fill = 'white';
@@ -1136,7 +1165,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return path;
     },
-    'bpmn:DataObject': function(p, element) {
+    'bpmn:DataObject': function (p, element) {
       var pathData = pathMap.getScaledPath('DATA_OBJECT_PATH', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1148,7 +1177,7 @@ function BpmnRenderer(events, styles, pathMap) {
         }
       });
 
-      var elementObject = drawPath(p, pathData, { fill: 'white' });
+      var elementObject = drawPath(p, pathData, {fill: 'white'});
 
       var semantic = getSemantic(element);
 
@@ -1159,31 +1188,33 @@ function BpmnRenderer(events, styles, pathMap) {
       return elementObject;
     },
     'bpmn:DataObjectReference': as('bpmn:DataObject'),
-    'bpmn:DataInput': function(p, element) {
+    'bpmn:DataInput': function (p, element) {
 
       var arrowPathData = pathMap.getRawPath('DATA_ARROW');
 
       // page
       var elementObject = renderer('bpmn:DataObject')(p, element);
 
-      /* input arrow path */ drawPath(p, arrowPathData, { strokeWidth: 1 });
+      /* input arrow path */
+      drawPath(p, arrowPathData, {strokeWidth: 1});
 
       return elementObject;
     },
-    'bpmn:DataOutput': function(p, element) {
+    'bpmn:DataOutput': function (p, element) {
       var arrowPathData = pathMap.getRawPath('DATA_ARROW');
 
       // page
       var elementObject = renderer('bpmn:DataObject')(p, element);
 
-      /* output arrow path */ drawPath(p, arrowPathData, {
+      /* output arrow path */
+      drawPath(p, arrowPathData, {
         strokeWidth: 1,
         fill: 'black'
       });
 
       return elementObject;
     },
-    'bpmn:DataStoreReference': function(p, element) {
+    'bpmn:DataStoreReference': function (p, element) {
       var DATA_STORE_PATH = pathMap.getScaledPath('DATA_STORE', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1202,10 +1233,10 @@ function BpmnRenderer(events, styles, pathMap) {
 
       return elementStore;
     },
-    'bpmn:BoundaryEvent': function(p, element) {
+    'bpmn:BoundaryEvent': function (p, element) {
 
       var semantic = getSemantic(element),
-          cancel = semantic.cancelActivity;
+        cancel = semantic.cancelActivity;
 
       var attrs = {
         strokeLinecap: 'round',
@@ -1217,13 +1248,14 @@ function BpmnRenderer(events, styles, pathMap) {
       }
 
       var outer = renderer('bpmn:Event')(p, element, attrs);
-      /* inner path */ drawCircle(p, element.width, element.height, INNER_OUTER_DIST, attrs);
+      /* inner path */
+      drawCircle(p, element.width, element.height, INNER_OUTER_DIST, attrs);
 
       renderEventContent(element, p);
 
       return outer;
     },
-    'bpmn:Group': function(p, element) {
+    'bpmn:Group': function (p, element) {
       return drawRect(p, element.width, element.height, TASK_BORDER_RADIUS, {
         strokeWidth: 1,
         strokeDasharray: '8,3,1,3',
@@ -1231,10 +1263,10 @@ function BpmnRenderer(events, styles, pathMap) {
         pointerEvents: 'none'
       });
     },
-    'label': function(p, element) {
+    'label': function (p, element) {
       return renderExternalLabel(p, element, '');
     },
-    'bpmn:TextAnnotation': function(p, element) {
+    'bpmn:TextAnnotation': function (p, element) {
       var style = {
         'fill': 'none',
         'stroke': 'none'
@@ -1253,11 +1285,11 @@ function BpmnRenderer(events, styles, pathMap) {
       drawPath(p, textPathData);
 
       var text = getSemantic(element).text || '';
-      renderLabel(p, text, { box: element, align: 'left-middle', padding: 5 });
+      renderLabel(p, text, {box: element, align: 'left-middle', padding: 5});
 
       return textElement;
     },
-    'ParticipantMultiplicityMarker': function(p, element) {
+    'ParticipantMultiplicityMarker': function (p, element) {
       var subProcessPath = pathMap.getScaledPath('MARKER_PARALLEL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1271,7 +1303,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       drawPath(p, subProcessPath);
     },
-    'SubProcessMarker': function(p, element) {
+    'SubProcessMarker': function (p, element) {
       var markerRect = drawRect(p, 14, 14, 0, {
         strokeWidth: 1
       });
@@ -1293,7 +1325,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
       drawPath(p, subProcessPath);
     },
-    'ParallelMarker': function(p, element, position) {
+    'ParallelMarker': function (p, element, position) {
       var subProcessPath = pathMap.getScaledPath('MARKER_PARALLEL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1306,7 +1338,7 @@ function BpmnRenderer(events, styles, pathMap) {
       });
       drawPath(p, subProcessPath);
     },
-    'SequentialMarker': function(p, element, position) {
+    'SequentialMarker': function (p, element, position) {
       var sequentialPath = pathMap.getScaledPath('MARKER_SEQUENTIAL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1319,7 +1351,7 @@ function BpmnRenderer(events, styles, pathMap) {
       });
       drawPath(p, sequentialPath);
     },
-    'CompensationMarker': function(p, element, position) {
+    'CompensationMarker': function (p, element, position) {
       var compensationPath = pathMap.getScaledPath('MARKER_COMPENSATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1330,9 +1362,9 @@ function BpmnRenderer(events, styles, pathMap) {
           my: (element.height - 13) / element.height
         }
       });
-      drawPath(p, compensationPath, { strokeWidth: 1 });
+      drawPath(p, compensationPath, {strokeWidth: 1});
     },
-    'LoopMarker': function(p, element, position) {
+    'LoopMarker': function (p, element, position) {
       var loopPath = pathMap.getScaledPath('MARKER_LOOP', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1351,7 +1383,7 @@ function BpmnRenderer(events, styles, pathMap) {
         strokeMiterlimit: 0.5
       });
     },
-    'AdhocMarker': function(p, element, position) {
+    'AdhocMarker': function (p, element, position) {
       var loopPath = pathMap.getScaledPath('MARKER_ADHOC', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -1394,7 +1426,7 @@ function BpmnRenderer(events, styles, pathMap) {
       };
     }
 
-    forEach(taskMarkers, function(marker) {
+    forEach(taskMarkers, function (marker) {
       renderer(marker)(p, element, position);
     });
 
@@ -1406,8 +1438,7 @@ function BpmnRenderer(events, styles, pathMap) {
       return;
     }
     if (obj.loopCharacteristics &&
-      obj.loopCharacteristics.isSequential !== undefined &&
-      !obj.loopCharacteristics.isSequential) {
+      obj.loopCharacteristics.isSequential !== undefined && !obj.loopCharacteristics.isSequential) {
       renderer('ParallelMarker')(p, element, position);
     }
     if (obj.loopCharacteristics && !!obj.loopCharacteristics.isSequential) {
@@ -1424,7 +1455,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
     /* jshint -W040 */
     if (!h) {
-      return DefaultRenderer.prototype.drawShape.apply(this, [ parent, element ]);
+      return DefaultRenderer.prototype.drawShape.apply(this, [parent, element]);
     } else {
       return h(parent, element);
     }
@@ -1436,7 +1467,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
     /* jshint -W040 */
     if (!h) {
-      return DefaultRenderer.prototype.drawConnection.apply(this, [ parent, element ]);
+      return DefaultRenderer.prototype.drawConnection.apply(this, [parent, element]);
     } else {
       return h(parent, element);
     }
@@ -1457,14 +1488,15 @@ function BpmnRenderer(events, styles, pathMap) {
       }
     });
 
-    /* collection path */ drawPath(p, pathData, {
+    /* collection path */
+    drawPath(p, pathData, {
       strokeWidth: 2
     });
   }
 
   function isCollection(element, filter) {
     return element.isCollection ||
-           (element.elementObjectRef && element.elementObjectRef.isCollection);
+      (element.elementObjectRef && element.elementObjectRef.isCollection);
   }
 
   function getDi(element) {
@@ -1483,7 +1515,7 @@ function BpmnRenderer(events, styles, pathMap) {
   function isTypedEvent(event, eventDefinitionType, filter) {
 
     function matches(definition, filter) {
-      return every(filter, function(val, key) {
+      return every(filter, function (val, key) {
 
         // we want a == conversion here, to be able to catch
         // undefined == false and friends
@@ -1492,7 +1524,7 @@ function BpmnRenderer(events, styles, pathMap) {
       });
     }
 
-    return some(event.eventDefinitions, function(definition) {
+    return some(event.eventDefinitions, function (definition) {
       return definition.$type === eventDefinitionType && matches(event, filter);
     });
   }
@@ -1511,15 +1543,15 @@ function BpmnRenderer(events, styles, pathMap) {
   function getCirclePath(shape) {
 
     var cx = shape.x + shape.width / 2,
-        cy = shape.y + shape.height / 2,
-        radius = shape.width / 2;
+      cy = shape.y + shape.height / 2,
+      radius = shape.width / 2;
 
     var circlePath = [
-        ['M', cx, cy],
-        ['m', 0, -radius],
-        ['a', radius, radius, 0, 1, 1, 0, 2 * radius],
-        ['a', radius, radius, 0, 1, 1, 0, -2 * radius],
-        ['z']
+      ['M', cx, cy],
+      ['m', 0, -radius],
+      ['a', radius, radius, 0, 1, 1, 0, 2 * radius],
+      ['a', radius, radius, 0, 1, 1, 0, -2 * radius],
+      ['z']
     ];
 
     return componentsToPath(circlePath);
@@ -1528,10 +1560,10 @@ function BpmnRenderer(events, styles, pathMap) {
   function getRoundRectPath(shape) {
 
     var radius = TASK_BORDER_RADIUS,
-        x = shape.x,
-        y = shape.y,
-        width = shape.width,
-        height = shape.height;
+      x = shape.x,
+      y = shape.y,
+      width = shape.width,
+      height = shape.height;
 
     var roundRectPath = [
       ['M', x + radius, y],
@@ -1552,11 +1584,11 @@ function BpmnRenderer(events, styles, pathMap) {
   function getDiamondPath(shape) {
 
     var width = shape.width,
-        height = shape.height,
-        x = shape.x,
-        y = shape.y,
-        halfWidth = width / 2,
-        halfHeight = height / 2;
+      height = shape.height,
+      x = shape.x,
+      y = shape.y,
+      halfWidth = width / 2,
+      halfHeight = height / 2;
 
     var diamondPath = [
       ['M', x + halfWidth, y],
@@ -1571,9 +1603,9 @@ function BpmnRenderer(events, styles, pathMap) {
 
   function getRectPath(shape) {
     var x = shape.x,
-        y = shape.y,
-        width = shape.width,
-        height = shape.height;
+      y = shape.y,
+      width = shape.width,
+      height = shape.height;
 
     var rectPath = [
       ['M', x, y],
@@ -1607,7 +1639,7 @@ function BpmnRenderer(events, styles, pathMap) {
 
   // hook onto canvas init event to initialize
   // connection start/end markers on svg
-  events.on('canvas.init', function(event) {
+  events.on('canvas.init', function (event) {
     initMarkers(event.svg);
   });
 
@@ -1620,6 +1652,6 @@ function BpmnRenderer(events, styles, pathMap) {
 inherits(BpmnRenderer, DefaultRenderer);
 
 
-BpmnRenderer.$inject = [ 'eventBus', 'styles', 'pathMap' ];
+BpmnRenderer.$inject = ['eventBus', 'styles', 'pathMap'];
 
 module.exports = BpmnRenderer;

--- a/lib/import/BpmnImporter.js
+++ b/lib/import/BpmnImporter.js
@@ -69,7 +69,6 @@ BpmnImporter.prototype.add = function(semantic, parentElement) {
 
   // SHAPE
   else if (di.$instanceOf('bpmndi:BPMNShape')) {
-
     var collapsed = !isExpanded(semantic);
     var hidden = parentElement && (parentElement.hidden || parentElement.collapsed);
 

--- a/lib/import/BpmnTreeWalker.js
+++ b/lib/import/BpmnTreeWalker.js
@@ -2,6 +2,7 @@
 
 var filter = require('lodash/collection/filter'),
     find = require('lodash/collection/find'),
+    isEqual = require('lodash/lang/isEqual'),
     forEach = require('lodash/collection/forEach');
 
 var Refs = require('object-refs');
@@ -270,6 +271,7 @@ function BpmnTreeWalker(handler) {
     var childCtx = visitIfDi(flowNode, context);
 
     if (is(flowNode, 'bpmn:SubProcess')) {
+      childCtx.collapsed = !isEqual( flowNode.$type, 'bpmn:SubProcess'); //please, don't collapse the subprocess
       handleSubProcess(flowNode, childCtx || context);
     }
   }

--- a/test/spec/import/elements/CollapsedSpec.js
+++ b/test/spec/import/elements/CollapsedSpec.js
@@ -18,8 +18,8 @@ describe('import - collapsed container', function() {
       var collapsedShape = elementRegistry.get('SubProcess_1');
       var childShape = elementRegistry.get('IntermediateCatchEvent_1');
 
-      expect(collapsedShape.collapsed).toBe(true);
-      expect(childShape.hidden).toBe(true);
+      expect(collapsedShape.collapsed).toBe(false);
+      expect(childShape.hidden).toBe(false);
     }));
 
 
@@ -46,18 +46,18 @@ describe('import - collapsed container', function() {
       var childShape = elementRegistry.get('SubProcess_5');
       var nestedChildShape = elementRegistry.get('Task_3');
 
-      expect(collapsedShape.collapsed).toBe(true);
-      expect(childShape.hidden).toBe(true);
-      expect(nestedChildShape.hidden).toBe(true);
+      expect(collapsedShape.collapsed).toBe(false);
+      expect(childShape.hidden).toBe(false);
+      expect(nestedChildShape.hidden).toBe(false);
     }));
 
 
     it('should import collapsed with nested elements', inject(function(elementRegistry) {
       var hiddenEventShape = elementRegistry.get('StartEvent_2');
-      expect(hiddenEventShape.label.hidden).toBe(true);
+      expect(hiddenEventShape.label.hidden).toBe(false);
 
       var hiddenDataShape = elementRegistry.get('DataObjectReference_1');
-      expect(hiddenDataShape.label.hidden).toBe(true);
+      expect(hiddenDataShape.label.hidden).toBe(false);
     }));
 
 
@@ -83,8 +83,8 @@ describe('import - collapsed container', function() {
       var expandedShape = elementRegistry.get('SubProcess_1');
       var childShape = elementRegistry.get('Task_1');
 
-      expect(expandedShape.collapsed).toBe(true);
-      expect(childShape.hidden).toBe(true);
+      expect(expandedShape.collapsed).toBe(false);
+      expect(childShape.hidden).toBe(false);
     }));
 
 
@@ -101,8 +101,8 @@ describe('import - collapsed container', function() {
       var expandedShape = elementRegistry.get('SubProcess_4');
       var childShape = elementRegistry.get('Task_2');
 
-      expect(expandedShape.collapsed).toBe(true);
-      expect(childShape.hidden).toBe(true);
+      expect(expandedShape.collapsed).toBe(false);
+      expect(childShape.hidden).toBe(false);
     }));
 
 


### PR DESCRIPTION
Hello:

I found a problem representing my subprocesses, they didn't show the inner components as they should.

I checked some subprocesses you are testing and I imported them, and they work, but if I got and I modified them with external IDEs, and I re-imported to bpmn.io demo, they were not well represented.

I have modified a little bit how the context behaves, just to show the inner components, and with them I had to modify as well the tests. 

I have probed both the ones you are testing and the ones I had from Eclipse with Activity, and they are represented as I expected.


After doing the changes:
![withchanges](https://cloud.githubusercontent.com/assets/12185075/7433343/303e8472-f028-11e4-8a87-36d3be1da137.png)

As currently it  draws the subprocess:

![ascurrentlyis](https://cloud.githubusercontent.com/assets/12185075/7433344/304068e6-f028-11e4-8ecb-149a513f5aa9.png)



I hope it could work for you.

Thank you.

Cheers.