### PR TITLE
fix(context-pad): fix context pad positioning in special case

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -77,9 +77,10 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         padRect = pad.getBoundingClientRect();
 
     var top = padRect.top - diagramRect.top;
+    var left = padRect.left - diagramRect.left;
 
     var pos = {
-      x: padRect.left,
+      x: left,
       y: top + padRect.height + Y_OFFSET
     };
 


### PR DESCRIPTION
context pad was misplaced when the canvas is placed with a left offset within the parent