### PR TITLE
Added functionality to copy properties while replaceing element

### DIFF
--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -97,12 +97,16 @@ function BpmnReplace(bpmnFactory, moddle, popupMenu, replace, selection, modelin
       newElement.isExpanded = isExpanded(oldBusinessObject);
     }
 
-    businessObject.name = oldBusinessObject.name;
+    var oldProps=moddle.getElementDescriptor(oldBusinessObject).propertiesByName;
+    var newProps=moddle.getElementDescriptor(businessObject).propertiesByName;
+    forEach(oldProps, function(prop,key){
+      if(oldBusinessObject.hasOwnProperty(key) && newProps.hasOwnProperty(key)){
+        if(['id'].indexOf(key)==-1){
+          businessObject[key]=oldBusinessObject[key];
+        }
+      }
 
-    // retain loop characteristics if the target element is not an event sub process
-    if (!isEventSubProcess(businessObject)) {
-      businessObject.loopCharacteristics = oldBusinessObject.loopCharacteristics;
-    }
+    });
 
     newElement = replace.replaceElement(element, newElement);
 


### PR DESCRIPTION
This is an additional functionality for copiing all properties of an bpmn-element to another while replaceing ist (i.e. Change task type)

The code checks whether the old properties fit to the new element.