### PR TITLE
fix: handle empty model

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -168,6 +168,11 @@ Viewer.prototype.importXML = function(xml, done) {
       err = checkValidationError(err);
       return done(err);
     }
+	
+    if(context.parseRoot.element.diagrams === undefined) {
+      err = new Error("No diagrams to display");
+      return done(err);
+    }
 
     var parseWarnings = context.warnings;
 

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -169,8 +169,8 @@ Viewer.prototype.importXML = function(xml, done) {
       return done(err);
     }
 	
-    if(context.parseRoot.element.diagrams === undefined) {
-      err = new Error("No diagrams to display");
+	if(!context.parseRoot.element.diagrams) {
+      err = new Error('No diagrams to display');
       return done(err);
     }
 

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -40,9 +40,21 @@ describe('Modeler', function() {
   });
 
 
-  it('should import empty definitions', function(done) {
+  it('should not import empty definitions', function(done) {
     var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
-    createModeler(xml, done);
+	
+	// given
+    createModeler(xml, function(err, warnings, modeler) {
+
+      // when
+      modeler.importXML(xml, function(err, warnings) {
+        // then
+        expect(err.message).to.equal('No diagrams to display');
+ 
+        done();
+      });
+
+    });
   });
 
 

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -28,13 +28,6 @@ describe('Viewer', function() {
     createViewer(xml, done);
   });
 
-
-  it('should import empty definitions', function(done) {
-    var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
-    createViewer(xml, done);
-  });
-
-
   it('should re-import simple process', function(done) {
 
     var xml = require('../fixtures/bpmn/simple.bpmn');
@@ -87,7 +80,7 @@ describe('Viewer', function() {
       // given
       var viewer = new Viewer({ container: container });
 
-      var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
+      var xml = require('../fixtures/bpmn/simple.bpmn');
 
       var events = [];
 
@@ -126,7 +119,7 @@ describe('Viewer', function() {
       // given
       var viewer = new Viewer({ container: container });
 
-      var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
+      var xml = require('../fixtures/bpmn/simple.bpmn');
 
       // when
       viewer.on('foo', 1000, function() {
@@ -337,7 +330,7 @@ describe('Viewer', function() {
     it('should export svg', function(done) {
 
       // given
-      var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
+      var xml = require('../fixtures/bpmn/simple.bpmn');
 
       createViewer(xml, function(err, warnings, viewer) {
 
@@ -451,7 +444,7 @@ describe('Viewer', function() {
     ];
 
     // given
-    var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
+    var xml = require('../fixtures/bpmn/simple.bpmn');
 
     var viewer;
 
@@ -554,7 +547,7 @@ describe('Viewer', function() {
 	it('should throw error due to missing diagrams', function(done) {
 
       var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
-        
+
       // given
       viewer = new Viewer({ container: container, additionalModules: testModules });
 
@@ -573,7 +566,7 @@ describe('Viewer', function() {
   describe('#destroy', function() {
 
     it('should remove traces in document tree', function() {
-
+		
       // given
       var viewer = new Viewer({
         container: container

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -459,7 +459,6 @@ describe('Viewer', function() {
       viewer.destroy();
     });
 
-
     it('should override default modules', function(done) {
 
       // given
@@ -550,6 +549,22 @@ describe('Viewer', function() {
         done(err);
       });
 
+    });
+	
+	it('should throw error due to missing diagrams', function(done) {
+
+      var xml = require('../fixtures/bpmn/empty-definitions.bpmn');
+        
+      // given
+      viewer = new Viewer({ container: container, additionalModules: testModules });
+
+      // when
+      viewer.importXML(xml, function(err) {
+          // then
+          expect(err.message).to.equal('No diagrams to display');
+          done();
+      });
+        
     });
 
   });

--- a/test/spec/util/ModelUtilSpec.js
+++ b/test/spec/util/ModelUtilSpec.js
@@ -12,7 +12,7 @@ var ModelUtil = require('../../../lib/util/ModelUtil');
 
 describe('ModelUtil', function() {
 
-  var diagramXML = require('../../fixtures/bpmn/empty-definitions.bpmn');
+  var diagramXML = require('../../fixtures/bpmn/simple.bpmn');
 
   beforeEach(bootstrapModeler(diagramXML, { modules: [ coreModule, modelingModule ] }));
 


### PR DESCRIPTION
Return an error message in case the XML does not contain any valid diagrams
Closes #417