### PR TITLE
Allow to hook up with diagram import via events

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -109,8 +109,8 @@ Modeler.prototype.createDiagram = function(done) {
   return this.importXML(initialDiagram, done);
 };
 
-Modeler.prototype.createModdle = function() {
-  var moddle = Viewer.prototype.createModdle.call(this);
+Modeler.prototype._createModdle = function(options) {
+  var moddle = Viewer.prototype._createModdle.call(this, options);
 
   moddle.ids = new Ids([ 32, 36, 1 ]);
 

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -101,23 +101,52 @@ var initialDiagram =
  */
 function Modeler(options) {
   Viewer.call(this, options);
+
+  // hook ID collection into the modeler
+  this.on('import.parse.complete', function(event) {
+    if (!event.error) {
+      this._collectIds(event.definitions, event.context);
+    }
+  }, this);
 }
 
 inherits(Modeler, Viewer);
 
+module.exports = Modeler;
+
+/**
+ * Create a new diagram to start modeling.
+ *
+ * @param {Function} done
+ */
 Modeler.prototype.createDiagram = function(done) {
   return this.importXML(initialDiagram, done);
 };
 
+/**
+ * Create a moddle instance, attaching ids to it.
+ *
+ * @param {Object} options
+ */
 Modeler.prototype._createModdle = function(options) {
   var moddle = Viewer.prototype._createModdle.call(this, options);
 
+  // attach ids to moddle to be able to track
+  // and validated ids in the BPMN 2.0 XML document
+  // tree
   moddle.ids = new Ids([ 32, 36, 1 ]);
 
   return moddle;
 };
 
-Modeler.prototype._parsedXML = function(definitions, context) {
+/**
+ * Collect ids processed during parsing of the
+ * definitions object.
+ *
+ * @param {ModdleElement} definitions
+ * @param {Context} context
+ */
+Modeler.prototype._collectIds = function(definitions, context) {
 
   var moddle = definitions.$model,
       ids = moddle.ids,
@@ -168,6 +197,3 @@ Modeler.prototype._modules = [].concat(
   Modeler.prototype._modules,
   Modeler.prototype._interactionModules,
   Modeler.prototype._modelingModules);
-
-
-module.exports = Modeler;

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -117,7 +117,7 @@ module.exports = Modeler;
 /**
  * Create a new diagram to start modeling.
  *
- * @param {Function} done
+ * @param {Function} [done]
  */
 Modeler.prototype.createDiagram = function(done) {
   return this.importXML(initialDiagram, done);

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -18,16 +18,11 @@ var domify = require('min-dom/lib/domify'),
 var Diagram = require('diagram-js'),
     BpmnModdle = require('bpmn-moddle');
 
+
+var inherits = require('inherits');
+
 var Importer = require('./import/Importer');
 
-
-function initListeners(diagram, listeners) {
-  var events = diagram.get('eventBus');
-
-  listeners.forEach(function(l) {
-    events.on(l.event, l.priority, l.callback, l.that);
-  });
-}
 
 function checkValidationError(err) {
 
@@ -110,38 +105,22 @@ function ensureUnit(val) {
  */
 function Viewer(options) {
 
-  this.options = options = assign({}, DEFAULT_OPTIONS, options || {});
+  options = assign({}, DEFAULT_OPTIONS, options);
 
-  this.moddle = this.createModdle();
+  this.moddle = this._createModdle(options);
 
-  var parent = options.container;
-
-  // support jquery element
-  // unwrap it if passed
-  if (parent.get) {
-    parent = parent.get(0);
-  }
-
-  // support selector
-  if (isString(parent)) {
-    parent = domQuery(parent);
-  }
-
-  var container = this.container = domify('<div class="bjs-container"></div>');
-  parent.appendChild(container);
-
-  assign(container.style, {
-    width: ensureUnit(options.width),
-    height: ensureUnit(options.height),
-    position: options.position
-  });
+  this.container = this._createContainer(options);
 
   /* <project-logo> */
 
-  addProjectLogo(container);
+  addProjectLogo(this.container);
 
   /* </project-logo> */
+
+  this._init(this.container, this.moddle, options);
 }
+
+inherits(Viewer, Diagram);
 
 module.exports = Viewer;
 
@@ -206,10 +185,6 @@ Viewer.prototype.saveXML = function(options, done) {
   this.moddle.toXML(definitions, options, done);
 };
 
-Viewer.prototype.createModdle = function() {
-  return new BpmnModdle(assign({}, this._moddleExtensions, this.options.moddleExtensions));
-};
-
 /**
  * Export the currently displayed BPMN 2.0 diagram as
  * an SVG image.
@@ -258,15 +233,9 @@ Viewer.prototype.saveSVG = function(options, done) {
  * @param {String} name
  *
  * @return {Object} diagram service instance
+ *
+ * @method Viewer#get
  */
-Viewer.prototype.get = function(name) {
-
-  if (!this.diagram) {
-    throw new Error('no diagram loaded');
-  }
-
-  return this.diagram.get(name);
-};
 
 /**
  * Invoke a function in the context of this viewer.
@@ -280,94 +249,61 @@ Viewer.prototype.get = function(name) {
  * @param {Function} fn to be invoked
  *
  * @return {Object} the functions return value
+ *
+ * @method Viewer#invoke
  */
-Viewer.prototype.invoke = function(fn) {
-
-  if (!this.diagram) {
-    throw new Error('no diagram loaded');
-  }
-
-  return this.diagram.invoke(fn);
-};
-
-Viewer.prototype.importDefinitions = function(definitions, done) {
-
-  // use try/catch to not swallow synchronous exceptions
-  // that may be raised during model parsing
-  try {
-    if (this.diagram) {
-      this.clear();
-    }
-
-    this.definitions = definitions;
-
-    var diagram = this.diagram = this._createDiagram(this.options);
-
-    this._init(diagram);
-
-    Importer.importBpmnDiagram(diagram, definitions, done);
-  } catch (e) {
-    done(e);
-  }
-};
-
-Viewer.prototype._init = function(diagram) {
-  initListeners(diagram, this.__listeners || []);
-};
-
-Viewer.prototype._createDiagram = function(options) {
-
-  var modules = [].concat(options.modules || this.getModules(), options.additionalModules || []);
-
-  // add self as an available service
-  modules.unshift({
-    bpmnjs: [ 'value', this ],
-    moddle: [ 'value', this.moddle ]
-  });
-
-  options = omit(options, 'additionalModules');
-
-  options = assign(options, {
-    canvas: assign({}, options.canvas, { container: this.container }),
-    modules: modules
-  });
-
-  return new Diagram(options);
-};
-
-
-Viewer.prototype.getModules = function() {
-  return this._modules;
-};
 
 /**
  * Remove all drawn elements from the viewer.
  *
  * After calling this method the viewer can still
  * be reused for opening another diagram.
+ *
+ * @method Viewer#clear
  */
-Viewer.prototype.clear = function() {
-  var diagram = this.diagram;
 
-  if (diagram) {
-    diagram.destroy();
+Viewer.prototype.importDefinitions = function(definitions, done) {
+
+  // use try/catch to not swallow synchronous exceptions
+  // that may be raised during model parsing
+  try {
+
+    if (this.definitions) {
+      // clear existing rendered diagram
+      this.clear();
+    }
+
+    // update definitions
+    this.definitions = definitions;
+
+    // perform graphical import
+    Importer.importBpmnDiagram(this, definitions, done);
+  } catch (e) {
+
+    // handle synchronous errors
+    done(e);
   }
 };
 
+Viewer.prototype.getModules = function() {
+  return this._modules;
+};
+
 /**
- * Destroy the viewer instance and remove all its remainders
- * from the document tree.
+ * Destroy the viewer instance and remove all its
+ * remainders from the document tree.
  */
 Viewer.prototype.destroy = function() {
-  // clear underlying diagram
-  this.clear();
 
-  // remove container
+  // diagram destroy
+  Diagram.prototype.destroy.call(this);
+
+  // dom detach
   domRemove(this.container);
 };
 
 /**
- * Register an event listener on the viewer
+ * Register an event listener
  *
  * Remove a previously added listener via {@link #off(event, callback)}.
  *
@@ -376,49 +312,78 @@ Viewer.prototype.destroy = function() {
  * @param {Function} callback
  * @param {Object} [that]
  */
-Viewer.prototype.on = function(event, priority, callback, that) {
-  var diagram = this.diagram,
-      listeners = this.__listeners = this.__listeners || [];
-
-  if (typeof priority === 'function') {
-    that = callback;
-    callback = priority;
-    priority = 1000;
-  }
-
-  listeners.push({ event: event, priority: priority, callback: callback, that: that });
-
-  if (diagram) {
-    return diagram.get('eventBus').on(event, priority, callback, that);
-  }
+Viewer.prototype.on = function(event, priority, callback, target) {
+  return this.get('eventBus').on(event, priority, callback, target);
 };
 
 /**
- * De-register an event callback
+ * De-register an event listener
  *
  * @param {String} event
  * @param {Function} callback
  */
 Viewer.prototype.off = function(event, callback) {
-  var filter,
-      diagram = this.diagram;
-
-  if (callback) {
-    filter = function(l) {
-      return !(l.event === event && l.callback === callback);
-    };
-  } else {
-    filter = function(l) {
-      return l.event !== event;
-    };
-  }
-
-  this.__listeners = (this.__listeners || []).filter(filter);
-
-  if (diagram) {
-    diagram.get('eventBus').off(event, callback);
-  }
+  this.get('eventBus').off(event, callback);
 };
+
+
+Viewer.prototype._init = function(container, moddle, options) {
+
+  var baseModules = options.modules || this.getModules(),
+      additionalModules = options.additionalModules || [],
+      staticModules = [
+        {
+          bpmnjs: [ 'value', this ],
+          moddle: [ 'value', moddle ]
+        }
+      ];
+
+  var diagramModules = [].concat(staticModules, baseModules, additionalModules);
+
+  var diagramOptions = assign(omit(options, 'additionalModules'), {
+    canvas: assign({}, options.canvas, { container: container }),
+    modules: diagramModules
+  });
+
+  // invoke diagram constructor
+  Diagram.call(this, diagramOptions);
+};
+
+Viewer.prototype._createContainer = function(options) {
+
+  var parent = options.container,
+      container;
+
+  // support jquery element
+  // unwrap it if passed
+  if (parent.get) {
+    parent = parent.get(0);
+  }
+
+  // support selector
+  if (isString(parent)) {
+    parent = domQuery(parent);
+  }
+
+  container = domify('<div class="bjs-container"></div>');
+
+  assign(container.style, {
+    width: ensureUnit(options.width),
+    height: ensureUnit(options.height),
+    position: options.position
+  });
+
+  parent.appendChild(container);
+
+  return container;
+};
+
+Viewer.prototype._createModdle = function(options) {
+  var moddleOptions = assign({}, this._moddleExtensions, options.moddleExtensions);
+
+  return new BpmnModdle(moddleOptions);
+};
+
 
 // modules the viewer is composed of
 Viewer.prototype._modules = [

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -144,9 +144,12 @@ module.exports = Viewer;
  * You can use these events to hook into the life-cycle.
  *
  * @param {String} xml the BPMN 2.0 xml
- * @param {Function} done invoked with (err, warnings=[])
+ * @param {Function} [done] invoked with (err, warnings=[])
  */
 Viewer.prototype.importXML = function(xml, done) {
+
+  // done is optional
+  done = done || function() {};
 
   var self = this;
 

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -126,10 +126,22 @@ module.exports = Viewer;
 
 
 /**
- * Import and render a BPMN 2.0 diagram.
+ * Parse and render a BPMN 2.0 diagram.
  *
  * Once finished the viewer reports back the result to the
  * provided callback function with (err, warnings).
+ *
+ * ## Life-Cycle Events
+ *
+ * During import the viewer will fire life-cycle events:
+ *
+ *   * import.parse.start (about to read model from xml)
+ *   * import.parse.complete (model read; may have worked or not)
+ *   * import.render.start (graphical import start)
+ *   * import.render.complete (graphical import finished)
+ *   * import.done (everything done)
+ *
+ * You can use these events to hook into the life-cycle.
  *
  * @param {String} xml the BPMN 2.0 xml
  * @param {Function} done invoked with (err, warnings=[])
@@ -138,21 +150,34 @@ Viewer.prototype.importXML = function(xml, done) {
 
   var self = this;
 
+  // hook in pre-parse listeners +
+  // allow xml manipulation
+  xml = this._emit('import.parse.start', { xml: xml }) || xml;
+
   this.moddle.fromXML(xml, 'bpmn:Definitions', function(err, definitions, context) {
+
+    // hook in post parse listeners +
+    // allow definitions manipulation
+    definitions = self._emit('import.parse.complete', {
+      error: err,
+      definitions: definitions,
+      context: context
+    }) || definitions;
 
     if (err) {
       err = checkValidationError(err);
-      return done(err);
-    }
 
-    if (typeof self._parsedXML === 'function') {
-      self._parsedXML(definitions, context);
+      self._emit('import.done', { error: err });
+
+      return done(err);
     }
 
     var parseWarnings = context.warnings;
 
     self.importDefinitions(definitions, function(err, importWarnings) {
-      var allWarnings = parseWarnings.concat(importWarnings || []);
+      var allWarnings = [].concat(parseWarnings, importWarnings || []);
+
+      self._emit('import.done', { error: err, warnings: allWarnings });
 
       done(err, allWarnings);
     });
@@ -347,6 +372,18 @@ Viewer.prototype._init = function(container, moddle, options) {
 
   // invoke diagram constructor
   Diagram.call(this, diagramOptions);
+};
+
+/**
+ * Emit an event on the underlying {@link EventBus}
+ *
+ * @param  {String} type
+ * @param  {Object} event
+ *
+ * @return {Object} event processing result (if any)
+ */
+Viewer.prototype._emit = function(type, event) {
+  return this.get('eventBus').fire(type, event);
 };
 
 Viewer.prototype._createContainer = function(options) {

--- a/lib/import/Importer.js
+++ b/lib/import/Importer.js
@@ -21,7 +21,13 @@ function importBpmnDiagram(diagram, definitions, done) {
   var error,
       warnings = [];
 
-  function parse(definitions) {
+  /**
+   * Walk the diagram semantically, importing (=drawing)
+   * all elements you encounter.
+   *
+   * @param {ModdleElement} definitions
+   */
+  function render(definitions) {
 
     var visitor = {
 
@@ -40,19 +46,24 @@ function importBpmnDiagram(diagram, definitions, done) {
 
     var walker = new BpmnTreeWalker(visitor, translate);
 
-    // import
+    // traverse BPMN 2.0 document model,
+    // starting at definitions
     walker.handleDefinitions(definitions);
   }
 
-  eventBus.fire('import.start', { definitions: definitions });
+  eventBus.fire('import.render.start', { definitions: definitions });
 
   try {
-    parse(definitions);
+    render(definitions);
   } catch (e) {
     error = e;
   }
 
-  eventBus.fire(error ? 'import.error' : 'import.success', { error: error, warnings: warnings });
+  eventBus.fire('import.render.complete', {
+    error: error,
+    warnings: warnings
+  });
+
   done(error, warnings);
 }
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -76,7 +76,12 @@ function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
       _locals = _locals();
     }
 
-    _options = merge({ container: testContainer }, OPTIONS, _options);
+    _options = merge({
+      container: testContainer,
+      canvas: {
+        deferUpdate: false
+      }
+    }, OPTIONS, _options);
 
     if (_locals) {
       var mockModule = {};

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -769,6 +769,23 @@ describe('Viewer', function() {
       });
     });
 
+
+    it('should work without callback', function(done) {
+
+      // given
+      var viewer = new Viewer({ container: container });
+
+      var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      // when
+      viewer.importXML(xml);
+
+      // then
+      viewer.on('import.done', function(event) {
+        done();
+      });
+    });
+
   });
 
 

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -91,45 +91,6 @@ describe('Viewer', function() {
   });
 
 
-  describe('import events', function() {
-
-    it('should fire <import.*> events', function(done) {
-
-      // given
-      var viewer = new Viewer({ container: container });
-
-      var xml = require('../fixtures/bpmn/simple.bpmn');
-
-      var events = [];
-
-      viewer.on('import.start', function() {
-        events.push('import.start');
-      });
-
-      viewer.on('import.success', function() {
-        events.push('import.success');
-      });
-
-      viewer.on('import.error', function() {
-        events.push('import.error');
-      });
-
-      // when
-      viewer.importXML(xml, function(err) {
-
-        // then
-        expect(events).to.eql([
-          'import.start',
-          'import.success'
-        ]);
-
-        done(err);
-      });
-    });
-
-  });
-
-
   describe('overlay support', function() {
 
     it('should allow to add overlays', function(done) {
@@ -760,6 +721,52 @@ describe('Viewer', function() {
         done();
       });
 
+    });
+
+  });
+
+
+  describe('#importXML', function() {
+
+    it('should emit <import.*> events', function(done) {
+
+      // given
+      var viewer = new Viewer({ container: container });
+
+      var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      var events = [];
+
+      viewer.on([
+        'import.parse.start',
+        'import.parse.complete',
+        'import.render.start',
+        'import.render.complete',
+        'import.done'
+      ], function(e) {
+        // log event type + event arguments
+        events.push([
+          e.type,
+          Object.keys(e).filter(function(key) {
+            return key !== 'type';
+          })
+        ]);
+      });
+
+      // when
+      viewer.importXML(xml, function(err) {
+
+        // then
+        expect(events).to.eql([
+          [ 'import.parse.start', [ 'xml' ] ],
+          [ 'import.parse.complete', ['error', 'definitions', 'context' ] ],
+          [ 'import.render.start', [ 'definitions' ] ],
+          [ 'import.render.complete', [ 'error', 'warnings' ] ],
+          [ 'import.done', [ 'error', 'warnings' ] ]
+        ]);
+
+        done(err);
+      });
     });
 
   });

--- a/test/spec/import/ImporterSpec.js
+++ b/test/spec/import/ImporterSpec.js
@@ -45,7 +45,7 @@ describe('import - Importer', function() {
 
   describe('events', function() {
 
-    it('should fire <import.start> and <import.success>', function(done) {
+    it('should fire <import.render.start> and <import.render.complete>', function(done) {
 
       // given
       var xml = require('../../fixtures/bpmn/import/process.bpmn');
@@ -55,13 +55,13 @@ describe('import - Importer', function() {
       var eventBus = diagram.get('eventBus');
 
       // log events
-      eventBus.on('import.start', function(event) {
+      eventBus.on('import.render.start', function(event) {
         expect(event.definitions).to.exist;
 
         eventCount++;
       });
 
-      eventBus.on('import.success', function(event) {
+      eventBus.on('import.render.complete', function(event) {
         expect(event).to.have.property('error');
         expect(event).to.have.property('warnings');
 


### PR DESCRIPTION
This builds on top of #495 and makes sure that users of bpmn-js can hook up to diagram import via events:

* makes `#importXML` callback optional
* emit well defined events during import:

```
* import.parse.start
* import.parse.complete
* import.render.start
* import.render.complete
* import.done
```

__This is a BREAKING CHANGE__.