### PR TITLE
fix(replace):ComplexGateway can have default sequence flows

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -291,6 +291,7 @@ ReplaceMenuProvider.prototype._createSequenceFlowEntries = function(element, rep
       if (businessObject.sourceRef.default !== businessObject &&
             (is(businessObject.sourceRef, 'bpmn:ExclusiveGateway') ||
              is(businessObject.sourceRef, 'bpmn:InclusiveGateway') ||
+             is(businessObject.sourceRef, 'bpmn:ComplexGateway') ||
              is(businessObject.sourceRef, 'bpmn:Activity'))) {
 
         menuEntries.push(self._createMenuEntry(entry, element, function() {
@@ -318,6 +319,7 @@ ReplaceMenuProvider.prototype._createSequenceFlowEntries = function(element, rep
         // conditional flows
       if ((is(businessObject.sourceRef, 'bpmn:ExclusiveGateway') ||
            is(businessObject.sourceRef, 'bpmn:InclusiveGateway') ||
+           is(businessObject.sourceRef, 'bpmn:ComplexGateway') ||
            is(businessObject.sourceRef, 'bpmn:Activity')) &&
            businessObject.sourceRef.default === businessObject) {
 

--- a/test/spec/features/popup-menu/ReplaceMenuProvider.defaultFlowsFromComplexGateways.bpmn
+++ b/test/spec/features/popup-menu/ReplaceMenuProvider.defaultFlowsFromComplexGateways.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Task_1">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="ComplexGateway_1" targetRef="Task_1" />
+    <bpmn:ComplexGateway id="ComplexGateway_1" default="SequenceFlow_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:ComplexGateway>
+    <bpmn:task id="Task_2">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ComplexGateway_1" targetRef="Task_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="230" y="25" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint xsi:type="dc:Point" x="156" y="65" />
+        <di:waypoint xsi:type="dc:Point" x="230" y="65" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="55" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ComplexGateway_1_di" bpmnElement="ComplexGateway_1">
+        <dc:Bounds x="106" y="40" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="86" y="90" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="230" y="134" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint xsi:type="dc:Point" x="131" y="90" />
+        <di:waypoint xsi:type="dc:Point" x="131" y="174" />
+        <di:waypoint xsi:type="dc:Point" x="230" y="174" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="86" y="122" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -979,6 +979,49 @@ describe('features/popup-menu - replace menu provider', function() {
     });
 
 
+    describe('default flows from complex gateways', function() {
+
+      var diagramXML = require('./ReplaceMenuProvider.defaultFlowsFromComplexGateways.bpmn');
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        modules: testModules
+      }));
+
+
+      it('should show default replace option', inject(function(elementRegistry, popupMenu) {
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_2');
+
+        // when
+        openPopup(sequenceFlow);
+
+        var sequenceFlowEntry = queryEntry(popupMenu, 'replace-with-sequence-flow'),
+            defaultFlowEntry = queryEntry(popupMenu, 'replace-with-default-flow');
+
+        // then
+        expect(sequenceFlowEntry).to.not.exist;
+        expect(defaultFlowEntry).to.exist;
+      }));
+
+
+      it('should NOT show default replace option', inject(function(elementRegistry, popupMenu) {
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+        // when
+        openPopup(sequenceFlow);
+
+        var sequenceFlowEntry = queryEntry(popupMenu, 'replace-with-sequence-flow'),
+            defaultFlowEntry = queryEntry(popupMenu, 'replace-with-default-flow');
+
+        // then
+        expect(sequenceFlowEntry).to.exist;
+        expect(defaultFlowEntry).to.not.exist;
+      }));
+
+    });
+
+
     describe('conditional flows', function() {
 
       var diagramXML = require('./ReplaceMenuProvider.conditionalFlows.bpmn');


### PR DESCRIPTION
The [BPMN 2.0 specification](http://www.omg.org/spec/BPMN/2.0/) states "a Sequence Flow that has an
Exclusive, Inclusive or Complex Gateway or an Activity as its source
can also be defined with as default."

This commit will honor that statement by allowing sequence flows from
Complex Gateway to be defined as default.