### PR TITLE
fix(modelling) allow move of a seclection in different pools

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -420,7 +420,10 @@ function canDrop(element, target, position) {
   }
 
   if (is(element, 'bpmn:MessageFlow')) {
-    return is(target, 'bpmn:Collaboration');
+    return is(target, 'bpmn:Collaboration')
+          // re #524: allow message flow move as part of a selection
+          || element.source.parent == target
+          || element.target.parent == target;
   }
 
   return false;

--- a/test/fixtures/bpmn/features/modeling/issue524-move-elements-from-different-pools.bpmn
+++ b/test/fixtures/bpmn/features/modeling/issue524-move-elements-from-different-pools.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_01hoeuv">
+    <bpmn:participant id="Participant_1" name="Participant_1" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" name="Participant_2" processRef="Process_2" />
+    <bpmn:messageFlow id="MessageFlow_1v3u2fb" sourceRef="Task_A" targetRef="Task_B" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Task_A" name="Task_A" />
+  </bpmn:process>
+  <bpmn:process id="Process_2">
+    <bpmn:task id="Task_B" name="Task_B" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_01hoeuv">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1">
+        <dc:Bounds x="114" y="49" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_2_di" bpmnElement="Participant_2">
+        <dc:Bounds x="114" y="370" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_B_di" bpmnElement="Task_B">
+        <dc:Bounds x="277" y="436" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_A_di" bpmnElement="Task_A">
+        <dc:Bounds x="277" y="97" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_1v3u2fb_di" bpmnElement="MessageFlow_1v3u2fb">
+        <di:waypoint xsi:type="dc:Point" x="327" y="177" />
+        <di:waypoint xsi:type="dc:Point" x="327" y="436" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="300" y="275" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -890,6 +890,31 @@ describe('features/modeling/rules - BpmnRules', function() {
   });
 
 
+  describe('selection move (issue #524)', function() {
+
+    var testXML = require('../../../fixtures/bpmn/features/modeling/issue524-move-elements-from-different-pools.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+    it('is allowed when parent does not change', inject(function(elementRegistry) {
+
+      // when
+      var elements = [
+        elementRegistry.get('Task_A'),
+        elementRegistry.get('Task_B'),
+        elementRegistry.get('MessageFlow_1v3u2fb')
+      ];
+
+      var target = 'Participant_1';
+
+      // then
+      expectCanMove(elements, target, {
+        attach: false,
+        move: true
+      });
+    }));
+  });
+
   describe('event move', function() {
 
     var testXML = require('../../../fixtures/bpmn/boundary-events.bpmn');


### PR DESCRIPTION
The move was prevented by MessageFlow element being included in the moved selection.

I have eased the restrictions on MessageFlow canDrop rules somewhat to satisfy a new test.

    Fixes #524