### PR TITLE
fix(release): Stronger check for jQuery before unwraping.

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -365,7 +365,7 @@ Viewer.prototype.attachTo = function(parentNode) {
   this.detach();
 
   // unwrap jQuery if provided
-  if (parentNode.get) {
+  if (parentNode.get && parentNode.constructor.prototype.jquery) {
     parentNode = parentNode.get(0);
   }
 


### PR DESCRIPTION
Other libraries exits that adds the `.get()` functionality to element nodes, in my case Mootools which behaves in a different fashion resulting in multiple errors.
 
Since the comment indicates that the condition is only for JQuery users, it should only fire if the lib is present. 
