### PR TITLE
Patched code to enable rendering of data collection marker

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1443,7 +1443,7 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
 
       var semantic = getSemantic(element);
 
-      if (isCollection(semantic) || isCollection(element)) {
+      if (isCollection(semantic)) {
         renderDataItemCollection(parentGfx, element);
       }
 

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1443,7 +1443,7 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
 
       var semantic = getSemantic(element);
 
-      if (isCollection(semantic)) {
+      if (isCollection(semantic) || isCollection(element)) {
         renderDataItemCollection(parentGfx, element);
       }
 

--- a/lib/features/modeling/behavior/CreateDataObjectBehavior.js
+++ b/lib/features/modeling/behavior/CreateDataObjectBehavior.js
@@ -23,8 +23,10 @@ function CreateDataObjectBehavior(eventBus, bpmnFactory, moddle) {
       // create a DataObject every time a DataObjectReference is created
       var dataObject = bpmnFactory.create('bpmn:DataObject');
 
-      if (shape.isCollection || shape.businessObject.isCollection)
+      if (shape.isCollection) {
+        shape.businessObject.isCollection = true;
         dataObject.isCollection = true;
+      }
 
       // set the reference to the DataObject
       shape.businessObject.dataObjectRef = dataObject;

--- a/lib/features/modeling/behavior/CreateDataObjectBehavior.js
+++ b/lib/features/modeling/behavior/CreateDataObjectBehavior.js
@@ -23,6 +23,9 @@ function CreateDataObjectBehavior(eventBus, bpmnFactory, moddle) {
       // create a DataObject every time a DataObjectReference is created
       var dataObject = bpmnFactory.create('bpmn:DataObject');
 
+      if (shape.isCollection || shape.businessObject.isCollection)
+        dataObject.isCollection = true;
+
       // set the reference to the DataObject
       shape.businessObject.dataObjectRef = dataObject;
     }

--- a/lib/import/BpmnTreeWalker.js
+++ b/lib/import/BpmnTreeWalker.js
@@ -390,6 +390,8 @@ function BpmnTreeWalker(handler, translate) {
       } else if (is(e, 'bpmn:DataStoreReference')) {
         handleDataElement(e, context);
       } else if (is(e, 'bpmn:DataObjectReference')) {
+        if (e.dataObjectRef && e.dataObjectRef.isCollection)
+          e.isCollection = true;
         handleDataElement(e, context);
       } else {
         logError(


### PR DESCRIPTION
The support for data collections in `bpmn-js` is currently incomplete and/or broken. More specifically, the class `BpmnRenderer` does not add the corresponding marker to the data object shape when attribute `isCollection` is set to true.

To describe the workaround that I found, let us assume that we set up the modeler's palette with the following snippet (based on the custom elements example):

```
'create.data-object-collection': createAction(
    'bpmn:DataObjectReference', 'data-object', 'bpmn-icon-data-object',
            'Create data object collection', {isCollection: true}
)
```
With the above, I can create a data object element with the attribute `isCollection` set to true. I found that `BpmnRenderer` decides whether to add the collection marker to the data object shape or not in lines 144-148:

```
var semantic = getSemantic(element);

if (isCollection(semantic)) {
   renderDataItemCollection(parentGfx, element);
} 
```

Hence, I patched the same lines of code as follows:

```
var semantic = getSemantic(element);

if (isCollection(semantic) || isCollection(element)) {
   renderDataItemCollection(parentGfx, element);
} 
```

which forces the `BpmnRenderer` to add the marker in the corresponding data object shape. 

What I found is that `element` (i.e. the `Shape` associated with the BPMN data object) carries the attribute `isCollection`, which is fine. However, the test `isCollection` occurs not at the level of `element` but deeper (i.e. in child objects).

I think of two possible options:
1.  The element factory is setting the attribute `isCollection` at the wrong level, i.e. `isCollection` is currently attached to a `Shape` object, but should be attached to the shape's `businessObject`, or
2. The verification of the condition `isCollection` should be done on `element` as suggested by my patch.

One additional problem I found in `bpmn-js` is that the attribute `isCollection` is not serialized in the BPMN XML document associated with a model. That is why I still believe that the problem could be on the way the element factory attaches the attribute `isCollection`.
