### PR TITLE
Add 'viewerId' option to prevent duplicated marker IDs in multiple bpmn-js instances

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -39,9 +39,12 @@ var LABEL_STYLE = {
 };
 
 
-function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
+function BpmnRenderer(eventBus, styles, pathMap, canvas, config, priority) {
 
   BaseRenderer.call(this, eventBus, priority);
+
+  // Unique identifier of bpmn-js instance provided by user
+  var viewerId = config.viewerId;
 
   var textUtil = new TextUtil({
     style: LABEL_STYLE,
@@ -99,8 +102,16 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
     markers[id] = marker;
   }
 
+  function generateMarkerId(type, fill, stroke) {
+    if (viewerId) {
+      return type + '-' + fill + '-' + stroke + '-' + viewerId;
+    } else {
+      return type + '-' + fill + '-' + stroke;
+    }
+  }
+
   function marker(type, fill, stroke) {
-    var id = type + '-' + fill + '-' + stroke;
+    var id = generateMarkerId(type, fill, stroke);
 
     if (!markers[id]) {
       createMarker(type, fill, stroke);
@@ -110,7 +121,7 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
   }
 
   function createMarker(type, fill, stroke) {
-    var id = type + '-' + fill + '-' + stroke;
+    var id = generateMarkerId(type, fill, stroke);
 
     if (type === 'sequenceflow-end') {
       var sequenceflowEnd = svgCreate('path');
@@ -1755,7 +1766,7 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
 
 inherits(BpmnRenderer, BaseRenderer);
 
-BpmnRenderer.$inject = [ 'eventBus', 'styles', 'pathMap', 'canvas' ];
+BpmnRenderer.$inject = [ 'eventBus', 'styles', 'pathMap', 'canvas', 'config' ];
 
 module.exports = BpmnRenderer;
 

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -235,6 +235,30 @@ describe('draw - bpmn renderer', function() {
         var markers = svg.querySelectorAll('marker');
 
         expect(markers).to.have.length(5);
+        expect(markers[0].id).to.equal('sequenceflow-end-white-black');
+        expect(markers[4].id).to.equal('messageflow-start-white-fuchsia');
+      })();
+
+      done();
+    });
+  });
+
+  it('markers should have correct unique IDs when viewerID option is specified', function(done) {
+    
+    var xml = require('../../fixtures/bpmn/draw/colors.bpmn');
+    bootstrapViewer(xml, { viewerId: 123 })(function(err) {
+
+      if (err) {
+        return done(err);
+      }
+
+      inject(function(canvas) {
+        var svg = canvas._svg;
+        var markers = svg.querySelectorAll('marker');
+
+        expect(markers).to.have.length(5);
+        expect(markers[0].id).to.equal('sequenceflow-end-white-black-123');
+        expect(markers[4].id).to.equal('messageflow-start-white-fuchsia-123');
       })();
 
       done();


### PR DESCRIPTION
This pull request should address issues https://github.com/bpmn-io/bpmn-js/issues/706 and https://github.com/bpmn-io/bpmn-js/issues/639.

If user need to create more than one instance of **bpmn-js**, he can assign a unique ID to each instance via `viewerId` option:

```js
var viewer = new BpmnJS({ container: '#canvas',  viewerId: id });
```

In this case all marker IDs wil contain this unique identifier appended at the end:
```js
  function generateMarkerId(type, fill, stroke) {
    if (viewerId) {
      return type + '-' + fill + '-' + stroke + '-' + viewerId;
    } else {
      return type + '-' + fill + '-' + stroke;
    }
  }
```