### PR TITLE
fix(Viewer): correctly export <defs> node on IE

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -233,7 +233,7 @@ Viewer.prototype.saveSVG = function(options, done) {
       defsNode = domQuery('defs', canvas._svg);
 
   var contents = innerSVG(contentNode),
-      defs = (defsNode && defsNode.outerHTML) || '';
+      defs = defsNode ? '<defs>' + innerSVG(defsNode) + '</defs>' : '';
 
   var bbox = contentNode.getBBox();
 


### PR DESCRIPTION
Changed the export of `<defs>` section as proposed in #710 so that it should work on IE 11, too.

Closes #710 