### PR TITLE
chore(renderer): exposed _drawPath in constructor

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -342,6 +342,7 @@ function BpmnRenderer(eventBus, styles, pathMap, canvas, priority) {
 
     return path;
   }
+  this._drawPath = drawPath;
 
   function drawMarker(type, parentGfx, path, attrs) {
     return drawPath(parentGfx, path, assign({ 'data-marker': type }, attrs));


### PR DESCRIPTION
### Proposed Changes

* The renderer now has the function `drawPath` exposed as `renderer._drawPath` which allows for implementing custom paths and rendering them.

I did decide to not add additional test cases as I don't have the expertise required to check for correctness by using the `tiny-svg` library.