### PR TITLE
Add auto-placement on context menu click

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -185,6 +185,7 @@ Modeler.prototype._modelingModules = [
   require('diagram-js/lib/features/move'),
   require('diagram-js/lib/features/resize'),
   require('./features/auto-resize'),
+  require('./features/auto-place'),
   require('./features/editor-actions'),
   require('./features/context-pad'),
   require('./features/keyboard'),

--- a/lib/features/auto-place/AutoPlace.js
+++ b/lib/features/auto-place/AutoPlace.js
@@ -1,0 +1,284 @@
+'use strict';
+
+var is = require('../../util/ModelUtil').is;
+var isAny = require('../modeling/util/ModelingUtil').isAny;
+
+var getMid = require('diagram-js/lib/layout/LayoutUtil').getMid,
+    asTRBL = require('diagram-js/lib/layout/LayoutUtil').asTRBL,
+    getOrientation = require('diagram-js/lib/layout/LayoutUtil').getOrientation;
+
+var find = require('lodash/collection/find'),
+    reduce = require('lodash/collection/reduce'),
+    filter = require('lodash/collection/filter');
+
+var DEFAULT_HORIZONTAL_DISTANCE = 50;
+
+var MAX_HORIZONTAL_DISTANCE = 250;
+
+// padding to detect element placement
+var PLACEMENT_DETECTION_PAD = 10;
+
+function AutoPlace(eventBus, modeling) {
+
+  this.append = function(source, shape) {
+    var position = getNewShapePosition(source, shape);
+
+    var newShape = modeling.appendShape(source, shape, position, source.parent);
+
+    // notify interested parties on new shape placed
+    eventBus.fire('autoPlace.end', {
+      shape: newShape
+    });
+
+    return newShape;
+  };
+
+}
+
+AutoPlace.$inject = [
+  'eventBus',
+  'modeling'
+];
+
+module.exports = AutoPlace;
+
+
+/////////// helpers /////////////////////////////////////
+
+function getNewShapePosition(source, element) {
+
+  if (is(element, 'bpmn:TextAnnotation')) {
+    return getTextAnnotationPosition(source, element);
+  }
+
+  if (isAny(element, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {
+    return getDataElementPosition(source, element);
+  }
+
+  if (is(element, 'bpmn:FlowNode')) {
+    return getFlowNodePosition(source, element);
+  }
+
+  return getDefaultPosition(source, element);
+}
+
+/**
+ * Always try to place element right of source;
+ * compute actual distance from previous nodes in flow.
+ */
+function getFlowNodePosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+  var sourceMid = getMid(source);
+
+  var horizontalDistance = getFlowNodeDistance(source);
+
+  var position = {
+    x: sourceTrbl.right + horizontalDistance + element.width / 2,
+    y: sourceMid.y
+  };
+
+  var existingTarget;
+
+  // make sure we don't place targets a
+  while ((existingTarget = getTargetAtPosition(source, position, element))) {
+
+    position = {
+      x: position.x,
+      y: Math.max(
+        existingTarget.y + existingTarget.height + 30 + element.height / 2,
+        position.y + 80
+      )
+    };
+  }
+
+  return position;
+}
+
+function isSequenceFlow(c) {
+  return is(c, 'bpmn:SequenceFlow');
+}
+
+
+/**
+ * Compute best distance between source and target,
+ * based on existing connections to and from source.
+ *
+ * @param {djs.model.Shape} source
+ *
+ * @return {Number} distance
+ */
+function getFlowNodeDistance(source) {
+
+  var sourceTrbl = asTRBL(source);
+
+  var nodes = [ ].concat(
+    filter(source.outgoing, isSequenceFlow).map(function(c) {
+      return {
+        shape: c.target,
+        weight: 5,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return shapeTrbl.left - sourceTrbl.right;
+        }
+      };
+    }),
+    filter(source.incoming, isSequenceFlow).map(function(c) {
+      return {
+        shape: c.source,
+        weight: 1,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return sourceTrbl.left - shapeTrbl.right;
+        }
+      };
+    })
+  );
+
+
+  // compute distances between source and incoming nodes;
+  // group at the same time by distance and expose the
+  // favourite distance as { fav: { count, value } }.
+  var distancesGrouped = reduce(nodes, function(result, node) {
+
+    var shape = node.shape,
+        weight = node.weight,
+        distanceTo = node.distanceTo;
+
+    var fav = result.fav,
+        currentDistance,
+        currentDistanceCount,
+        currentDistanceEntry;
+
+    currentDistance = distanceTo(shape);
+
+    // ignore too far away peers
+    // or non-left to right modeled nodes
+    if (currentDistance < 0 || currentDistance > MAX_HORIZONTAL_DISTANCE) {
+      return result;
+    }
+
+    currentDistanceEntry = result[String(currentDistance)] =
+      result[String(currentDistance)] || {
+        value: currentDistance,
+        count: 0
+      };
+
+    // inc diff count
+    currentDistanceCount = currentDistanceEntry.count += 1 * weight;
+
+    if (!fav || fav.count < currentDistanceCount) {
+      result.fav = currentDistanceEntry;
+    }
+
+    return result;
+  }, { });
+
+
+  if (distancesGrouped.fav) {
+    return distancesGrouped.fav.value;
+  } else {
+    return DEFAULT_HORIZONTAL_DISTANCE;
+  }
+}
+
+
+/**
+ * Always try to place text annotations top right of source.
+ */
+function getTextAnnotationPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  // todo: adaptive
+  var position = {
+    x: sourceTrbl.right + 30 + element.width / 2,
+    y: sourceTrbl.top - 50 - element.height / 2
+  };
+
+  var existingTarget;
+
+  while ((existingTarget = getTargetAtPosition(source, position, element))) {
+
+    // escape to top
+    position = {
+      x: position.x,
+      y: Math.min(
+        existingTarget.y - 30 - element.height / 2,
+        position.y - 30
+      )
+    };
+  }
+
+  return position;
+}
+
+/**
+ * Always put element bottom right of source.
+ */
+function getDataElementPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  var position = {
+    x: sourceTrbl.right + 50 + element.width / 2,
+    y: sourceTrbl.bottom + 40 + element.width / 2
+  };
+
+  var existingTarget;
+
+  while ((existingTarget = getTargetAtPosition(source, position, element))) {
+
+    // escape to right
+    position = {
+      x: Math.min(
+        existingTarget.x + existingTarget.width + 30 + element.width / 2,
+        position.x + 80
+      ),
+      y: position.y
+    };
+  }
+
+  return position;
+}
+
+/**
+ * Always put element right of source per default.
+ */
+function getDefaultPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  var sourceMid = getMid(source);
+
+  // simply put element right next to source
+  return {
+    x: sourceTrbl.right + DEFAULT_HORIZONTAL_DISTANCE + element.width / 2,
+    y: sourceMid.y
+  };
+}
+
+/**
+ * Return target at given position, if defined.
+ */
+function getTargetAtPosition(source, position, element) {
+
+  var bounds = {
+    x: position.x - (element.width / 2),
+    y: position.y - (element.height / 2),
+    width: element.width,
+    height: element.height
+  };
+
+  var targets = source.outgoing.map(function(c) {
+    return c.target;
+  });
+
+  return find(targets, function(target) {
+    var orientation = getOrientation(target, bounds, PLACEMENT_DETECTION_PAD);
+
+    return orientation === 'intersect';
+  });
+}

--- a/lib/features/auto-place/AutoPlace.js
+++ b/lib/features/auto-place/AutoPlace.js
@@ -3,30 +3,49 @@
 var is = require('../../util/ModelUtil').is;
 var isAny = require('../modeling/util/ModelingUtil').isAny;
 
-var getMid = require('diagram-js/lib/layout/LayoutUtil').getMid,
-    asTRBL = require('diagram-js/lib/layout/LayoutUtil').asTRBL,
-    getOrientation = require('diagram-js/lib/layout/LayoutUtil').getOrientation;
+var getTextAnnotationPosition = require('./AutoPlaceUtil').getTextAnnotationPosition,
+    getDataElementPosition = require('./AutoPlaceUtil').getDataElementPosition,
+    getFlowNodePosition = require('./AutoPlaceUtil').getFlowNodePosition,
+    getDefaultPosition = require('./AutoPlaceUtil').getDefaultPosition;
 
-var find = require('lodash/collection/find'),
-    reduce = require('lodash/collection/reduce'),
-    filter = require('lodash/collection/filter');
-
-var DEFAULT_HORIZONTAL_DISTANCE = 50;
-
-var MAX_HORIZONTAL_DISTANCE = 250;
-
-// padding to detect element placement
-var PLACEMENT_DETECTION_PAD = 10;
-
+/**
+ * A service that places elements connected to existing ones
+ * to an appropriate position in an _automated_ fashion.
+ *
+ * @param {EventBus} eventBus
+ * @param {Modeling} modeling
+ */
 function AutoPlace(eventBus, modeling) {
 
+  function emit(event, payload) {
+    return eventBus.fire(event, payload);
+  }
+
+
+  /**
+   * Append shape to source at appropriate position.
+   *
+   * @param {djs.model.Shape} source
+   * @param {djs.model.Shape} shape
+   *
+   * @return {djs.model.Shape} appended shape
+   */
   this.append = function(source, shape) {
-    var position = getNewShapePosition(source, shape);
+
+    // allow others to provide the position
+    var position = emit('autoPlace', {
+      source: source,
+      shape: shape
+    });
+
+    if (!position) {
+      position = getNewShapePosition(source, shape);
+    }
 
     var newShape = modeling.appendShape(source, shape, position, source.parent);
 
     // notify interested parties on new shape placed
-    eventBus.fire('autoPlace.end', {
+    emit('autoPlace.end', {
       shape: newShape
     });
 
@@ -45,6 +64,15 @@ module.exports = AutoPlace;
 
 /////////// helpers /////////////////////////////////////
 
+/**
+ * Find the new position for the target element to
+ * connect to source.
+ *
+ * @param  {djs.model.Shape} source
+ * @param  {djs.model.Shape} element
+ *
+ * @return {Point}
+ */
 function getNewShapePosition(source, element) {
 
   if (is(element, 'bpmn:TextAnnotation')) {
@@ -60,225 +88,4 @@ function getNewShapePosition(source, element) {
   }
 
   return getDefaultPosition(source, element);
-}
-
-/**
- * Always try to place element right of source;
- * compute actual distance from previous nodes in flow.
- */
-function getFlowNodePosition(source, element) {
-
-  var sourceTrbl = asTRBL(source);
-  var sourceMid = getMid(source);
-
-  var horizontalDistance = getFlowNodeDistance(source);
-
-  var position = {
-    x: sourceTrbl.right + horizontalDistance + element.width / 2,
-    y: sourceMid.y
-  };
-
-  var existingTarget;
-
-  // make sure we don't place targets a
-  while ((existingTarget = getTargetAtPosition(source, position, element))) {
-
-    position = {
-      x: position.x,
-      y: Math.max(
-        existingTarget.y + existingTarget.height + 30 + element.height / 2,
-        position.y + 80
-      )
-    };
-  }
-
-  return position;
-}
-
-function isSequenceFlow(c) {
-  return is(c, 'bpmn:SequenceFlow');
-}
-
-
-/**
- * Compute best distance between source and target,
- * based on existing connections to and from source.
- *
- * @param {djs.model.Shape} source
- *
- * @return {Number} distance
- */
-function getFlowNodeDistance(source) {
-
-  var sourceTrbl = asTRBL(source);
-
-  var nodes = [ ].concat(
-    filter(source.outgoing, isSequenceFlow).map(function(c) {
-      return {
-        shape: c.target,
-        weight: 5,
-        distanceTo: function(shape) {
-          var shapeTrbl = asTRBL(shape);
-
-          return shapeTrbl.left - sourceTrbl.right;
-        }
-      };
-    }),
-    filter(source.incoming, isSequenceFlow).map(function(c) {
-      return {
-        shape: c.source,
-        weight: 1,
-        distanceTo: function(shape) {
-          var shapeTrbl = asTRBL(shape);
-
-          return sourceTrbl.left - shapeTrbl.right;
-        }
-      };
-    })
-  );
-
-
-  // compute distances between source and incoming nodes;
-  // group at the same time by distance and expose the
-  // favourite distance as { fav: { count, value } }.
-  var distancesGrouped = reduce(nodes, function(result, node) {
-
-    var shape = node.shape,
-        weight = node.weight,
-        distanceTo = node.distanceTo;
-
-    var fav = result.fav,
-        currentDistance,
-        currentDistanceCount,
-        currentDistanceEntry;
-
-    currentDistance = distanceTo(shape);
-
-    // ignore too far away peers
-    // or non-left to right modeled nodes
-    if (currentDistance < 0 || currentDistance > MAX_HORIZONTAL_DISTANCE) {
-      return result;
-    }
-
-    currentDistanceEntry = result[String(currentDistance)] =
-      result[String(currentDistance)] || {
-        value: currentDistance,
-        count: 0
-      };
-
-    // inc diff count
-    currentDistanceCount = currentDistanceEntry.count += 1 * weight;
-
-    if (!fav || fav.count < currentDistanceCount) {
-      result.fav = currentDistanceEntry;
-    }
-
-    return result;
-  }, { });
-
-
-  if (distancesGrouped.fav) {
-    return distancesGrouped.fav.value;
-  } else {
-    return DEFAULT_HORIZONTAL_DISTANCE;
-  }
-}
-
-
-/**
- * Always try to place text annotations top right of source.
- */
-function getTextAnnotationPosition(source, element) {
-
-  var sourceTrbl = asTRBL(source);
-
-  // todo: adaptive
-  var position = {
-    x: sourceTrbl.right + 30 + element.width / 2,
-    y: sourceTrbl.top - 50 - element.height / 2
-  };
-
-  var existingTarget;
-
-  while ((existingTarget = getTargetAtPosition(source, position, element))) {
-
-    // escape to top
-    position = {
-      x: position.x,
-      y: Math.min(
-        existingTarget.y - 30 - element.height / 2,
-        position.y - 30
-      )
-    };
-  }
-
-  return position;
-}
-
-/**
- * Always put element bottom right of source.
- */
-function getDataElementPosition(source, element) {
-
-  var sourceTrbl = asTRBL(source);
-
-  var position = {
-    x: sourceTrbl.right + 50 + element.width / 2,
-    y: sourceTrbl.bottom + 40 + element.width / 2
-  };
-
-  var existingTarget;
-
-  while ((existingTarget = getTargetAtPosition(source, position, element))) {
-
-    // escape to right
-    position = {
-      x: Math.min(
-        existingTarget.x + existingTarget.width + 30 + element.width / 2,
-        position.x + 80
-      ),
-      y: position.y
-    };
-  }
-
-  return position;
-}
-
-/**
- * Always put element right of source per default.
- */
-function getDefaultPosition(source, element) {
-
-  var sourceTrbl = asTRBL(source);
-
-  var sourceMid = getMid(source);
-
-  // simply put element right next to source
-  return {
-    x: sourceTrbl.right + DEFAULT_HORIZONTAL_DISTANCE + element.width / 2,
-    y: sourceMid.y
-  };
-}
-
-/**
- * Return target at given position, if defined.
- */
-function getTargetAtPosition(source, position, element) {
-
-  var bounds = {
-    x: position.x - (element.width / 2),
-    y: position.y - (element.height / 2),
-    width: element.width,
-    height: element.height
-  };
-
-  var targets = source.outgoing.map(function(c) {
-    return c.target;
-  });
-
-  return find(targets, function(target) {
-    var orientation = getOrientation(target, bounds, PLACEMENT_DETECTION_PAD);
-
-    return orientation === 'intersect';
-  });
 }

--- a/lib/features/auto-place/AutoPlaceSelectionBehavior.js
+++ b/lib/features/auto-place/AutoPlaceSelectionBehavior.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Select element after auto placement.
+ *
+ * @param {EventBus} eventBus
+ * @param {Selection} selection
+ */
+function AutoPlaceSelectionBehavior(eventBus, selection) {
+
+  eventBus.on('autoPlace.end', 500, function(e) {
+    selection.select(e.shape);
+  });
+
+}
+
+AutoPlaceSelectionBehavior.$inject = [
+  'eventBus',
+  'selection'
+];
+
+module.exports = AutoPlaceSelectionBehavior;

--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -34,21 +34,14 @@ function getFlowNodePosition(source, element) {
     y: sourceMid.y
   };
 
-  var existingTarget;
+  var escapeDirection = {
+    y: {
+      margin: 30,
+      rowSize: 80
+    }
+  };
 
-  // make sure we don't place targets a
-  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
-
-    position = {
-      x: position.x,
-      y: Math.max(
-        existingTarget.y + existingTarget.height + 30 + element.height / 2,
-        position.y + 80
-      )
-    };
-  }
-
-  return position;
+  return deconflictPosition(source, element, position, escapeDirection);
 }
 
 module.exports.getFlowNodePosition = getFlowNodePosition;
@@ -153,27 +146,19 @@ function getTextAnnotationPosition(source, element) {
 
   var sourceTrbl = asTRBL(source);
 
-  // todo: adaptive
   var position = {
     x: sourceTrbl.right + 30 + element.width / 2,
     y: sourceTrbl.top - 50 - element.height / 2
   };
 
-  var existingTarget;
+  var escapeDirection = {
+    y: {
+      margin: -30,
+      rowSize: 30
+    }
+  };
 
-  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
-
-    // escape to top
-    position = {
-      x: position.x,
-      y: Math.min(
-        existingTarget.y - 30 - element.height / 2,
-        position.y - 30
-      )
-    };
-  }
-
-  return position;
+  return deconflictPosition(source, element, position, escapeDirection);
 }
 
 module.exports.getTextAnnotationPosition = getTextAnnotationPosition;
@@ -191,21 +176,14 @@ function getDataElementPosition(source, element) {
     y: sourceTrbl.bottom + 40 + element.width / 2
   };
 
-  var existingTarget;
+  var escapeDirection = {
+    x: {
+      margin: 30,
+      rowSize: 80
+    }
+  };
 
-  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
-
-    // escape to right
-    position = {
-      x: Math.min(
-        existingTarget.x + existingTarget.width + 30 + element.width / 2,
-        position.x + 80
-      ),
-      y: position.y
-    };
-  }
-
-  return position;
+  return deconflictPosition(source, element, position, escapeDirection);
 }
 
 module.exports.getDataElementPosition = getDataElementPosition;
@@ -260,3 +238,70 @@ function getConnectedAtPosition(source, position, element) {
 }
 
 module.exports.getConnectedAtPosition = getConnectedAtPosition;
+
+
+/**
+ * Returns a new, position for the given element
+ * based on the given element that is not occupied
+ * by any element connected to source.
+ *
+ * Take into account the escapeDirection (where to move
+ * on positining clashes) in the computation.
+ *
+ * @param {djs.model.Shape} source
+ * @param {djs.model.Shape} element
+ * @param {Point} position
+ * @param {Object} escapeDelta
+ *
+ * @return {Point}
+ */
+function deconflictPosition(source, element, position, escapeDelta) {
+
+  function nextPosition(existingElement) {
+
+    var newPosition = {
+      x: position.x,
+      y: position.y
+    };
+
+    [ 'x', 'y' ].forEach(function(axis) {
+
+      var axisDelta = escapeDelta[axis];
+
+      if (!axisDelta) {
+        return;
+      }
+
+      var dimension = axis === 'x' ? 'width' : 'height';
+
+      var margin = axisDelta.margin,
+          rowSize = axisDelta.rowSize;
+
+      if (margin < 0) {
+        newPosition[axis] = Math.min(
+          existingElement[axis] + margin - element[dimension] / 2,
+          position[axis] - rowSize + margin
+        );
+      } else {
+        newPosition[axis] = Math.max(
+          existingTarget[axis] + existingTarget[dimension] + margin + element[dimension] / 2,
+          position[axis] + rowSize + margin
+        );
+      }
+    });
+
+    return newPosition;
+  }
+
+  var existingTarget;
+
+
+  // deconflict position until free slot is found
+  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
+    position = nextPosition(existingTarget);
+  }
+
+  return position;
+}
+
+module.exports.deconflictPosition = deconflictPosition;

--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -65,7 +65,13 @@ function getFlowNodeDistance(source, element) {
     return is(c, 'bpmn:SequenceFlow');
   };
 
-  var nodes = [].concat(
+  // we create a list of nodes to take into consideration
+  // for calculating the optimal flow node distance
+  //
+  //   * weight existing target nodes higher than source nodes
+  //   * only take into account individual nodes once
+  //
+  var nodes = reduce([].concat(
     filter(source.outgoing, isReference).map(function(c) {
       return {
         shape: c.target,
@@ -88,7 +94,12 @@ function getFlowNodeDistance(source, element) {
         }
       };
     })
-  );
+  ), function(nodes, node) {
+    // filter out shapes connected twice via source or target
+    nodes[node.shape.id + '__weight_' + node.weight] = node;
+
+    return nodes;
+  }, {});
 
   // compute distances between source and incoming nodes;
   // group at the same time by distance and expose the

--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -7,8 +7,7 @@ var getMid = require('diagram-js/lib/layout/LayoutUtil').getMid,
     getOrientation = require('diagram-js/lib/layout/LayoutUtil').getOrientation;
 
 var find = require('lodash/collection/find'),
-    reduce = require('lodash/collection/reduce'),
-    filter = require('lodash/collection/filter');
+    reduce = require('lodash/collection/reduce');
 
 var DEFAULT_HORIZONTAL_DISTANCE = 50;
 
@@ -29,15 +28,34 @@ function getFlowNodePosition(source, element) {
 
   var horizontalDistance = getFlowNodeDistance(source, element);
 
+  var orientation = 'left',
+      rowSize = 80,
+      margin = 30;
+
+  if (is(source, 'bpmn:BoundaryEvent')) {
+    orientation = getOrientation(source, source.host, -25);
+
+    if (orientation === 'top') {
+      margin *= -1;
+    }
+  }
+
+  var verticalDistances = {
+    left: 0,
+    right: 0,
+    top: -1 * rowSize,
+    bottom: rowSize
+  };
+
   var position = {
     x: sourceTrbl.right + horizontalDistance + element.width / 2,
-    y: sourceMid.y
+    y: sourceMid.y + verticalDistances[orientation]
   };
 
   var escapeDirection = {
     y: {
-      margin: 30,
-      rowSize: 80
+      margin: margin,
+      rowSize: rowSize
     }
   };
 
@@ -61,9 +79,38 @@ function getFlowNodeDistance(source, element) {
   var sourceTrbl = asTRBL(source);
 
   // is connection a reference to consider?
-  var isReference = function(c) {
+  function isReference(c) {
     return is(c, 'bpmn:SequenceFlow');
-  };
+  }
+
+  function toTargetNode(weight) {
+
+    return function(shape) {
+      return {
+        shape: shape,
+        weight: weight,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return shapeTrbl.left - sourceTrbl.right;
+        }
+      };
+    };
+  }
+
+  function toSourceNode(weight) {
+    return function(shape) {
+      return {
+        shape: shape,
+        weight: weight,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return sourceTrbl.left - shapeTrbl.right;
+        }
+      };
+    };
+  }
 
   // we create a list of nodes to take into consideration
   // for calculating the optimal flow node distance
@@ -72,28 +119,8 @@ function getFlowNodeDistance(source, element) {
   //   * only take into account individual nodes once
   //
   var nodes = reduce([].concat(
-    filter(source.outgoing, isReference).map(function(c) {
-      return {
-        shape: c.target,
-        weight: 5,
-        distanceTo: function(shape) {
-          var shapeTrbl = asTRBL(shape);
-
-          return shapeTrbl.left - sourceTrbl.right;
-        }
-      };
-    }),
-    filter(source.incoming, isReference).map(function(c) {
-      return {
-        shape: c.source,
-        weight: 1,
-        distanceTo: function(shape) {
-          var shapeTrbl = asTRBL(shape);
-
-          return sourceTrbl.left - shapeTrbl.right;
-        }
-      };
-    })
+    getTargets(source, isReference).map(toTargetNode(5)),
+    getSources(source, isReference).map(toSourceNode(1))
   ), function(nodes, node) {
     // filter out shapes connected twice via source or target
     nodes[node.shape.id + '__weight_' + node.weight] = node;
@@ -220,7 +247,41 @@ module.exports.getDefaultPosition = getDefaultPosition;
 
 
 /**
+ * Returns all connected elements around the given source.
+ *
+ * This includes:
+ *
+ *   - connected elements
+ *   - host connected elements
+ *   - attachers connected elements
+ *
+ * @param  {djs.model.Shape} source
+ * @param  {djs.model.Shape} element
+ *
+ * @return {Array<djs.model.Shape>}
+ */
+function getAutoPlaceClosure(source, element) {
+
+  var allConnected = getConnected(source);
+
+  if (source.host) {
+    allConnected = allConnected.concat(getConnected(source.host));
+  }
+
+  if (source.attachers) {
+    allConnected = allConnected.concat(source.attachers.reduce(function(shapes, attacher) {
+      return shapes.concat(getConnected(attacher));
+    }, []));
+  }
+
+  return allConnected;
+}
+
+/**
  * Return target at given position, if defined.
+ *
+ * This takes connected elements from host and attachers
+ * into account, too.
  */
 function getConnectedAtPosition(source, position, element) {
 
@@ -231,17 +292,14 @@ function getConnectedAtPosition(source, position, element) {
     height: element.height
   };
 
-  var targets = source.outgoing.map(function(c) {
-    return c.target;
-  });
+  var closure = getAutoPlaceClosure(source, element);
 
-  var sources = source.incoming.map(function(c) {
-    return c.source;
-  });
+  return find(closure, function(target) {
 
-  var allConnected = [].concat(targets, sources);
+    if (target === element) {
+      return false;
+    }
 
-  return find(allConnected, function(target) {
     var orientation = getOrientation(target, bounds, PLACEMENT_DETECTION_PAD);
 
     return orientation === 'intersect';
@@ -306,7 +364,6 @@ function deconflictPosition(source, element, position, escapeDelta) {
 
   var existingTarget;
 
-
   // deconflict position until free slot is found
   while ((existingTarget = getConnectedAtPosition(source, position, element))) {
     position = nextPosition(existingTarget);
@@ -316,3 +373,41 @@ function deconflictPosition(source, element, position, escapeDelta) {
 }
 
 module.exports.deconflictPosition = deconflictPosition;
+
+
+
+
+///////// helpers /////////////////////
+
+function noneFilter() {
+  return true;
+}
+
+function getConnected(element, connectionFilter) {
+  return [].concat(
+    getTargets(element, connectionFilter),
+    getSources(element, connectionFilter)
+  );
+}
+
+function getSources(shape, connectionFilter) {
+
+  if (!connectionFilter) {
+    connectionFilter = noneFilter;
+  }
+
+  return shape.incoming.filter(connectionFilter).map(function(c) {
+    return c.source;
+  });
+}
+
+function getTargets(shape, connectionFilter) {
+
+  if (!connectionFilter) {
+    connectionFilter = noneFilter;
+  }
+
+  return shape.outgoing.filter(connectionFilter).map(function(c) {
+    return c.target;
+  });
+}

--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -1,0 +1,262 @@
+'use strict';
+
+var is = require('../../util/ModelUtil').is;
+
+var getMid = require('diagram-js/lib/layout/LayoutUtil').getMid,
+    asTRBL = require('diagram-js/lib/layout/LayoutUtil').asTRBL,
+    getOrientation = require('diagram-js/lib/layout/LayoutUtil').getOrientation;
+
+var find = require('lodash/collection/find'),
+    reduce = require('lodash/collection/reduce'),
+    filter = require('lodash/collection/filter');
+
+var DEFAULT_HORIZONTAL_DISTANCE = 50;
+
+var MAX_HORIZONTAL_DISTANCE = 250;
+
+// padding to detect element placement
+var PLACEMENT_DETECTION_PAD = 10;
+
+
+/**
+ * Always try to place element right of source;
+ * compute actual distance from previous nodes in flow.
+ */
+function getFlowNodePosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+  var sourceMid = getMid(source);
+
+  var horizontalDistance = getFlowNodeDistance(source, element);
+
+  var position = {
+    x: sourceTrbl.right + horizontalDistance + element.width / 2,
+    y: sourceMid.y
+  };
+
+  var existingTarget;
+
+  // make sure we don't place targets a
+  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
+
+    position = {
+      x: position.x,
+      y: Math.max(
+        existingTarget.y + existingTarget.height + 30 + element.height / 2,
+        position.y + 80
+      )
+    };
+  }
+
+  return position;
+}
+
+module.exports.getFlowNodePosition = getFlowNodePosition;
+
+
+/**
+ * Compute best distance between source and target,
+ * based on existing connections to and from source.
+ *
+ * @param {djs.model.Shape} source
+ * @param {djs.model.Shape} element
+ *
+ * @return {Number} distance
+ */
+function getFlowNodeDistance(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  // is connection a reference to consider?
+  var isReference = function(c) {
+    return is(c, 'bpmn:SequenceFlow');
+  };
+
+  var nodes = [].concat(
+    filter(source.outgoing, isReference).map(function(c) {
+      return {
+        shape: c.target,
+        weight: 5,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return shapeTrbl.left - sourceTrbl.right;
+        }
+      };
+    }),
+    filter(source.incoming, isReference).map(function(c) {
+      return {
+        shape: c.source,
+        weight: 1,
+        distanceTo: function(shape) {
+          var shapeTrbl = asTRBL(shape);
+
+          return sourceTrbl.left - shapeTrbl.right;
+        }
+      };
+    })
+  );
+
+  // compute distances between source and incoming nodes;
+  // group at the same time by distance and expose the
+  // favourite distance as { fav: { count, value } }.
+  var distancesGrouped = reduce(nodes, function(result, node) {
+
+    var shape = node.shape,
+        weight = node.weight,
+        distanceTo = node.distanceTo;
+
+    var fav = result.fav,
+        currentDistance,
+        currentDistanceCount,
+        currentDistanceEntry;
+
+    currentDistance = distanceTo(shape);
+
+    // ignore too far away peers
+    // or non-left to right modeled nodes
+    if (currentDistance < 0 || currentDistance > MAX_HORIZONTAL_DISTANCE) {
+      return result;
+    }
+
+    currentDistanceEntry = result[String(currentDistance)] =
+      result[String(currentDistance)] || {
+        value: currentDistance,
+        count: 0
+      };
+
+    // inc diff count
+    currentDistanceCount = currentDistanceEntry.count += 1 * weight;
+
+    if (!fav || fav.count < currentDistanceCount) {
+      result.fav = currentDistanceEntry;
+    }
+
+    return result;
+  }, { });
+
+
+  if (distancesGrouped.fav) {
+    return distancesGrouped.fav.value;
+  } else {
+    return DEFAULT_HORIZONTAL_DISTANCE;
+  }
+}
+
+module.exports.getFlowNodeDistance = getFlowNodeDistance;
+
+
+/**
+ * Always try to place text annotations top right of source.
+ */
+function getTextAnnotationPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  // todo: adaptive
+  var position = {
+    x: sourceTrbl.right + 30 + element.width / 2,
+    y: sourceTrbl.top - 50 - element.height / 2
+  };
+
+  var existingTarget;
+
+  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
+
+    // escape to top
+    position = {
+      x: position.x,
+      y: Math.min(
+        existingTarget.y - 30 - element.height / 2,
+        position.y - 30
+      )
+    };
+  }
+
+  return position;
+}
+
+module.exports.getTextAnnotationPosition = getTextAnnotationPosition;
+
+
+/**
+ * Always put element bottom right of source.
+ */
+function getDataElementPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  var position = {
+    x: sourceTrbl.right + 50 + element.width / 2,
+    y: sourceTrbl.bottom + 40 + element.width / 2
+  };
+
+  var existingTarget;
+
+  while ((existingTarget = getConnectedAtPosition(source, position, element))) {
+
+    // escape to right
+    position = {
+      x: Math.min(
+        existingTarget.x + existingTarget.width + 30 + element.width / 2,
+        position.x + 80
+      ),
+      y: position.y
+    };
+  }
+
+  return position;
+}
+
+module.exports.getDataElementPosition = getDataElementPosition;
+
+
+/**
+ * Always put element right of source per default.
+ */
+function getDefaultPosition(source, element) {
+
+  var sourceTrbl = asTRBL(source);
+
+  var sourceMid = getMid(source);
+
+  // simply put element right next to source
+  return {
+    x: sourceTrbl.right + DEFAULT_HORIZONTAL_DISTANCE + element.width / 2,
+    y: sourceMid.y
+  };
+}
+
+module.exports.getDefaultPosition = getDefaultPosition;
+
+
+/**
+ * Return target at given position, if defined.
+ */
+function getConnectedAtPosition(source, position, element) {
+
+  var bounds = {
+    x: position.x - (element.width / 2),
+    y: position.y - (element.height / 2),
+    width: element.width,
+    height: element.height
+  };
+
+  var targets = source.outgoing.map(function(c) {
+    return c.target;
+  });
+
+  var sources = source.incoming.map(function(c) {
+    return c.source;
+  });
+
+  var allConnected = [].concat(targets, sources);
+
+  return find(allConnected, function(target) {
+    var orientation = getOrientation(target, bounds, PLACEMENT_DETECTION_PAD);
+
+    return orientation === 'intersect';
+  });
+}
+
+module.exports.getConnectedAtPosition = getConnectedAtPosition;

--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -158,14 +158,14 @@ function getTextAnnotationPosition(source, element) {
   var sourceTrbl = asTRBL(source);
 
   var position = {
-    x: sourceTrbl.right + 30 + element.width / 2,
+    x: sourceTrbl.right + element.width / 2,
     y: sourceTrbl.top - 50 - element.height / 2
   };
 
   var escapeDirection = {
     y: {
       margin: -30,
-      rowSize: 30
+      rowSize: 20
     }
   };
 
@@ -183,14 +183,14 @@ function getDataElementPosition(source, element) {
   var sourceTrbl = asTRBL(source);
 
   var position = {
-    x: sourceTrbl.right + 50 + element.width / 2,
+    x: sourceTrbl.right - 10 + element.width / 2,
     y: sourceTrbl.bottom + 40 + element.width / 2
   };
 
   var escapeDirection = {
     x: {
       margin: 30,
-      rowSize: 80
+      rowSize: 30
     }
   };
 

--- a/lib/features/auto-place/index.js
+++ b/lib/features/auto-place/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  __init__: [ 'autoPlaceSelectionBehavior' ],
+  autoPlace: [ 'type', require('./AutoPlace') ],
+  autoPlaceSelectionBehavior: [ 'type', require('./AutoPlaceSelectionBehavior') ]
+};

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -14,9 +14,11 @@ var assign = require('lodash/object/assign'),
 /**
  * A provider for BPMN 2.0 elements context pad
  */
-function ContextPadProvider(injector, eventBus, contextPad, modeling,
+function ContextPadProvider(config, injector, eventBus, contextPad, modeling,
                             elementFactory, connect, create, popupMenu,
                             canvas, rules, translate) {
+
+  config = config || {};
 
   contextPad.registerProvider(this);
 
@@ -31,7 +33,10 @@ function ContextPadProvider(injector, eventBus, contextPad, modeling,
   this._canvas  = canvas;
   this._rules = rules;
   this._translate = translate;
-  this._autoPlace = injector.get('autoPlace', false);
+
+  if (config.autoPlace !== false) {
+    this._autoPlace = injector.get('autoPlace', false);
+  }
 
   eventBus.on('create.end', 250, function(event) {
     var shape = event.context.shape;
@@ -49,6 +54,7 @@ function ContextPadProvider(injector, eventBus, contextPad, modeling,
 }
 
 ContextPadProvider.$inject = [
+  'config.contextPad',
   'injector',
   'eventBus',
   'contextPad',

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -14,8 +14,8 @@ var assign = require('lodash/object/assign'),
 /**
  * A provider for BPMN 2.0 elements context pad
  */
-function ContextPadProvider(eventBus, contextPad, modeling, elementFactory,
-                            connect, create, popupMenu,
+function ContextPadProvider(injector, eventBus, contextPad, modeling,
+                            elementFactory, connect, create, popupMenu,
                             canvas, rules, translate) {
 
   contextPad.registerProvider(this);
@@ -31,7 +31,7 @@ function ContextPadProvider(eventBus, contextPad, modeling, elementFactory,
   this._canvas  = canvas;
   this._rules = rules;
   this._translate = translate;
-
+  this._autoPlace = injector.get('autoPlace', false);
 
   eventBus.on('create.end', 250, function(event) {
     var shape = event.context.shape;
@@ -49,6 +49,7 @@ function ContextPadProvider(eventBus, contextPad, modeling, elementFactory,
 }
 
 ContextPadProvider.$inject = [
+  'injector',
   'eventBus',
   'contextPad',
   'modeling',
@@ -75,7 +76,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       popupMenu = this._popupMenu,
       canvas = this._canvas,
       rules = this._rules,
-
+      autoPlace = this._autoPlace,
       translate = this._translate;
 
   var actions = {};
@@ -137,19 +138,27 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       title = translate('Append {type}', { type: type.replace(/^bpmn\:/, '') });
     }
 
-    function appendListener(event, element) {
+    function appendStart(event, element) {
 
       var shape = elementFactory.createShape(assign({ type: type }, options));
       create.start(event, shape, element);
     }
+
+
+    var append = autoPlace ? function(event, element) {
+      var shape = elementFactory.createShape(assign({ type: type }, options));
+
+      autoPlace.append(element, shape);
+    } : appendStart;
+
 
     return {
       group: 'model',
       className: className,
       title: title,
       action: {
-        dragstart: appendListener,
-        click: appendListener
+        dragstart: appendStart,
+        click: append
       }
     };
   }

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -67,6 +67,10 @@ function LabelEditingProvider(eventBus, canvas, directEditing, commandStack, res
     activateDirectEdit(element);
   });
 
+  eventBus.on('autoPlace.end', 500, function(event) {
+    activateDirectEdit(event.shape);
+  });
+
 
   function activateDirectEdit(element, force) {
     if (force ||

--- a/test/spec/features/auto-place/AutoPlace.boundary-events.bpmn
+++ b/test/spec/features/auto-place/AutoPlace.boundary-events.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="http://bpmn.io" exporterVersion="0.10.1">
+  <process id="Process_1" isExecutable="false">
+    <task id="TASK_1" name="TASK_1">
+      <outgoing>SequenceFlow_0o6gp3o</outgoing>
+    </task>
+    <boundaryEvent id="BOUNDARY_BOTTOM" name="BOUNDARY_BOTTOM" attachedToRef="TASK_1" />
+    <task id="TASK_2" name="TASK_2">
+      <incoming>SequenceFlow_0o6gp3o</incoming>
+    </task>
+    <sequenceFlow id="SequenceFlow_0o6gp3o" sourceRef="TASK_1" targetRef="TASK_2" />
+    <task id="TASK_3" name="TASK_3" />
+    <boundaryEvent id="BOUNDARY_TOP" name="BOUNDARY_TOP" attachedToRef="TASK_1" />
+    <subProcess id="SUBPROCESS" name="SUBPROCESS" />
+    <boundaryEvent id="BOUNDARY_SUBPROCESS_BOTTOM" name="BOUNDARY_SUBPROCESS_BOTTOM" attachedToRef="SUBPROCESS" />
+    <boundaryEvent id="BOUNDARY_SUBPROCESS_TOP" name="BOUNDARY_SUBPROCESS_TOP" attachedToRef="SUBPROCESS" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="TASK_1_di" bpmnElement="TASK_1">
+        <omgdc:Bounds x="121" y="93" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BOUNDARY_BOTTOM_di" bpmnElement="BOUNDARY_BOTTOM">
+        <omgdc:Bounds x="155" y="155" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="72" y="188" width="87" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_2_di" bpmnElement="TASK_2">
+        <omgdc:Bounds x="305" y="93" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0o6gp3o_di" bpmnElement="TASK_1">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="221" y="133" />
+        <omgdi:waypoint xsi:type="omgdc:Point" x="305" y="133" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="263" y="112" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_3_di" bpmnElement="TASK_3">
+        <omgdc:Bounds x="305" y="203" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BOUNDARY_TOP_di" bpmnElement="BOUNDARY_TOP">
+        <omgdc:Bounds x="156" y="75" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="78" y="52" width="86" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SUBPROCESS_di" bpmnElement="SUBPROCESS" isExpanded="true">
+        <omgdc:Bounds x="142" y="314" width="258" height="141" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BOUNDARY_SUBPROCESS_BOTTOM_di" bpmnElement="BOUNDARY_SUBPROCESS_BOTTOM">
+        <omgdc:Bounds x="192" y="437" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="110" y="473" width="86" height="36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BOUNDARY_SUBPROCESS_TOP_di" bpmnElement="BOUNDARY_SUBPROCESS_TOP">
+        <omgdc:Bounds x="189" y="296" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="98" y="259" width="86" height="36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/auto-place/AutoPlace.bpmn
+++ b/test/spec/features/auto-place/AutoPlace.bpmn
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_16tlpj7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="TASK_0" name="TASK_0">
+      <bpmn:incoming>SequenceFlow_16tlpj7</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_19p2kv6</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_16tlpj7" sourceRef="StartEvent_1" targetRef="TASK_0" />
+    <bpmn:task id="TASK_1" name="TASK_1">
+      <bpmn:incoming>SequenceFlow_0s1mty3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0b5s2a7</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="StartEvent_0f2fdfi">
+      <bpmn:outgoing>SequenceFlow_0s1mty3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0s1mty3" sourceRef="StartEvent_0f2fdfi" targetRef="TASK_1" />
+    <bpmn:task id="TASK_2" name="TASK_2">
+      <bpmn:incoming>SequenceFlow_0b5s2a7</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_0b5s2a7" sourceRef="TASK_1" targetRef="TASK_2" />
+    <bpmn:task id="TASK_3" name="TASK_3">
+      <bpmn:outgoing>SequenceFlow_18dnq8n</bpmn:outgoing>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_16lcc1g">
+        <bpmn:targetRef>DataStoreReference_0r0lie7</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+    </bpmn:task>
+    <bpmn:task id="TASK_4" name="TASK_4">
+      <bpmn:incoming>SequenceFlow_18dnq8n</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_18dnq8n" sourceRef="TASK_3" targetRef="TASK_4" />
+    <bpmn:task id="TASK_5" name="TASK_5">
+      <bpmn:incoming>SequenceFlow_0n4l6q7</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_10nwqsy</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_13ubee5</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:startEvent id="StartEvent_0wxeenz">
+      <bpmn:outgoing>SequenceFlow_0n4l6q7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_1m0lwft">
+      <bpmn:outgoing>SequenceFlow_10nwqsy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_06jwo6i">
+      <bpmn:outgoing>SequenceFlow_13ubee5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0n4l6q7" sourceRef="StartEvent_0wxeenz" targetRef="TASK_5" />
+    <bpmn:sequenceFlow id="SequenceFlow_10nwqsy" sourceRef="StartEvent_1m0lwft" targetRef="TASK_5" />
+    <bpmn:sequenceFlow id="SequenceFlow_13ubee5" sourceRef="StartEvent_06jwo6i" targetRef="TASK_5" />
+    <bpmn:startEvent id="START_EVENT_1" name="START_EVENT_1" />
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_0yy98gf">
+      <bpmn:outgoing>SequenceFlow_19p2kv6</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_19p2kv6" sourceRef="IntermediateThrowEvent_0yy98gf" targetRef="TASK_0" />
+    <bpmn:dataStoreReference id="DataStoreReference_0r0lie7" />
+    <bpmn:subProcess id="SUBPROCESS_1" name="SUBPROCESS_1" />
+    <bpmn:textAnnotation id="TextAnnotation_0czqc1j" />
+    <bpmn:association id="Association_1ebqqnb" sourceRef="TASK_3" targetRef="TextAnnotation_0czqc1j" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="44" y="76" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="112" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_0_di" bpmnElement="TASK_0">
+        <dc:Bounds x="121" y="54" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_16tlpj7_di" bpmnElement="SequenceFlow_16tlpj7">
+        <di:waypoint xsi:type="dc:Point" x="80" y="94" />
+        <di:waypoint xsi:type="dc:Point" x="121" y="94" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="100.5" y="73" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_1_di" bpmnElement="TASK_1">
+        <dc:Bounds x="121" y="183" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0f2fdfi_di" bpmnElement="StartEvent_0f2fdfi">
+        <dc:Bounds x="44" y="205" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="241" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0s1mty3_di" bpmnElement="SequenceFlow_0s1mty3">
+        <di:waypoint xsi:type="dc:Point" x="80" y="223" />
+        <di:waypoint xsi:type="dc:Point" x="121" y="223" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="100.5" y="202" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_2_di" bpmnElement="TASK_2">
+        <dc:Bounds x="279" y="183" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0b5s2a7_di" bpmnElement="SequenceFlow_0b5s2a7">
+        <di:waypoint xsi:type="dc:Point" x="221" y="223" />
+        <di:waypoint xsi:type="dc:Point" x="279" y="223" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="250" y="202" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_3_di" bpmnElement="TASK_3">
+        <dc:Bounds x="596" y="127" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0czqc1j_di" bpmnElement="TextAnnotation_0czqc1j">
+        <dc:Bounds x="698" y="56" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1ebqqnb_di" bpmnElement="Association_1ebqqnb">
+        <di:waypoint xsi:type="dc:Point" x="687" y="128" />
+        <di:waypoint xsi:type="dc:Point" x="732" y="86" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_4_di" bpmnElement="TASK_4">
+        <dc:Bounds x="1030" y="127" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_18dnq8n_di" bpmnElement="SequenceFlow_18dnq8n">
+        <di:waypoint xsi:type="dc:Point" x="696" y="167" />
+        <di:waypoint xsi:type="dc:Point" x="1030" y="167" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="818" y="146" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_5_di" bpmnElement="TASK_5">
+        <dc:Bounds x="121" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0wxeenz_di" bpmnElement="StartEvent_0wxeenz">
+        <dc:Bounds x="10" y="353" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-17" y="393" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1m0lwft_di" bpmnElement="StartEvent_1m0lwft">
+        <dc:Bounds x="44" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="452" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_06jwo6i_di" bpmnElement="StartEvent_06jwo6i">
+        <dc:Bounds x="10" y="479" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-17" y="519" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0n4l6q7_di" bpmnElement="SequenceFlow_0n4l6q7">
+        <di:waypoint xsi:type="dc:Point" x="46" y="371" />
+        <di:waypoint xsi:type="dc:Point" x="84" y="371" />
+        <di:waypoint xsi:type="dc:Point" x="84" y="408" />
+        <di:waypoint xsi:type="dc:Point" x="121" y="408" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54" y="384" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10nwqsy_di" bpmnElement="SequenceFlow_10nwqsy">
+        <di:waypoint xsi:type="dc:Point" x="80" y="430" />
+        <di:waypoint xsi:type="dc:Point" x="121" y="430" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="56" y="409" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_13ubee5_di" bpmnElement="SequenceFlow_13ubee5">
+        <di:waypoint xsi:type="dc:Point" x="46" y="497" />
+        <di:waypoint xsi:type="dc:Point" x="84" y="497" />
+        <di:waypoint xsi:type="dc:Point" x="84" y="449" />
+        <di:waypoint xsi:type="dc:Point" x="121" y="449" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54" y="467" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="START_EVENT_1_di" bpmnElement="START_EVENT_1">
+        <dc:Bounds x="966" y="246" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="941" y="286" width="87" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_0yy98gf_di" bpmnElement="IntermediateThrowEvent_0yy98gf">
+        <dc:Bounds x="219" y="5" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="192" y="45" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_19p2kv6_di" bpmnElement="SequenceFlow_19p2kv6">
+        <di:waypoint xsi:type="dc:Point" x="219" y="23" />
+        <di:waypoint xsi:type="dc:Point" x="171" y="23" />
+        <di:waypoint xsi:type="dc:Point" x="171" y="54" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="150" y="2" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="DataStoreReference_0r0lie7_di" bpmnElement="DataStoreReference_0r0lie7">
+        <dc:Bounds x="689" y="245" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="669" y="299" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_16lcc1g_di" bpmnElement="DataOutputAssociation_16lcc1g">
+        <di:waypoint xsi:type="dc:Point" x="671" y="207" />
+        <di:waypoint xsi:type="dc:Point" x="695" y="245" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SUBPROCESS_1_di" bpmnElement="SUBPROCESS_1" isExpanded="true">
+        <dc:Bounds x="525" y="308" width="350" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/auto-place/AutoPlace.multi-connection.bpmn
+++ b/test/spec/features/auto-place/AutoPlace.multi-connection.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="TASK_1" name="TASK_1">
+      <bpmn:outgoing>SequenceFlow_0uj471x</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0sys8ww</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1q8yl3p</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dh9p3h</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="TASK_2" name="TASK_2">
+      <bpmn:incoming>SequenceFlow_0uj471x</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1dh9p3h</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_0uj471x" sourceRef="TASK_1" targetRef="TASK_2" />
+    <bpmn:task id="TASK_3" name="TASK_3">
+      <bpmn:incoming>SequenceFlow_0sys8ww</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_0sys8ww" sourceRef="TASK_1" targetRef="TASK_3" />
+    <bpmn:task id="TASK_4" name="TASK_4">
+      <bpmn:incoming>SequenceFlow_1q8yl3p</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1q8yl3p" sourceRef="TASK_1" targetRef="TASK_4" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dh9p3h" sourceRef="TASK_1" targetRef="TASK_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="TASK_1_di" bpmnElement="TASK_1">
+        <dc:Bounds x="66.87482219061161" y="115.89615931721193" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_2_di" bpmnElement="TASK_2">
+        <dc:Bounds x="361.8748221906116" y="116" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uj471x_di" bpmnElement="SequenceFlow_0uj471x">
+        <di:waypoint xsi:type="dc:Point" x="167" y="156" />
+        <di:waypoint xsi:type="dc:Point" x="362" y="156" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="264.5" y="135" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_3_di" bpmnElement="TASK_3">
+        <dc:Bounds x="206.8748221906116" y="247.89615931721193" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sys8ww_di" bpmnElement="SequenceFlow_0sys8ww">
+        <di:waypoint xsi:type="dc:Point" x="117" y="196" />
+        <di:waypoint xsi:type="dc:Point" x="117" y="288" />
+        <di:waypoint xsi:type="dc:Point" x="207" y="288" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="236" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TASK_4_di" bpmnElement="TASK_4">
+        <dc:Bounds x="206.8748221906116" y="358.8961593172119" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q8yl3p_di" bpmnElement="SequenceFlow_1q8yl3p">
+        <di:waypoint xsi:type="dc:Point" x="117" y="196" />
+        <di:waypoint xsi:type="dc:Point" x="117" y="399" />
+        <di:waypoint xsi:type="dc:Point" x="207" y="399" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="291.5" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dh9p3h_di" bpmnElement="SequenceFlow_1dh9p3h">
+        <di:waypoint xsi:type="dc:Point" x="117" y="116" />
+        <di:waypoint xsi:type="dc:Point" x="117" y="50" />
+        <di:waypoint xsi:type="dc:Point" x="412" y="50" />
+        <di:waypoint xsi:type="dc:Point" x="412" y="116" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="264.5" y="29" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -27,34 +27,6 @@ describe('features/auto-place', function() {
     }));
 
 
-    function autoPlace(cfg) {
-
-      var element = cfg.element,
-          behind = cfg.behind,
-          expectedBounds = cfg.expectedBounds;
-
-      return inject(function(autoPlace, elementRegistry, elementFactory) {
-
-        var sourceEl = elementRegistry.get(behind);
-
-        // assume
-        expect(sourceEl).to.exist;
-
-        if (typeof element === 'string') {
-          element = { type: element };
-        }
-
-        var shape = elementFactory.createShape(element);
-
-        // when
-        var placedShape = autoPlace.append(sourceEl, shape);
-
-        // then
-        expect(placedShape).to.have.bounds(expectedBounds);
-      });
-    }
-
-
     describe('should place bpmn:FlowNode', function() {
 
       it('at default distance after START_EVENT_1', autoPlace({
@@ -209,4 +181,80 @@ describe('features/auto-place', function() {
 
   });
 
+
+  describe('boundary event connection handling', function() {
+
+    var diagramXML = require('./AutoPlace.boundary-events.bpmn');
+
+    before(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        modelingModule,
+        autoPlaceModule,
+        selectionModule
+      ]
+    }));
+
+
+    it('should place bottom right of BOUNDARY_BOTTOM', autoPlace({
+      element: 'bpmn:Task',
+      behind: 'BOUNDARY_BOTTOM',
+      expectedBounds: { x: 241, y: 213, width: 100, height: 80 }
+    }));
+
+
+    it('should place bottom right of BOUNDARY_SUBPROCESS_BOTTOM', autoPlace({
+      element: 'bpmn:Task',
+      behind: 'BOUNDARY_SUBPROCESS_BOTTOM',
+      expectedBounds: { x: 278, y: 495, width: 100, height: 80 }
+    }));
+
+
+    it('should place top right of BOUNDARY_TOP', autoPlace({
+      element: 'bpmn:Task',
+      behind: 'BOUNDARY_TOP',
+      expectedBounds: { x: 242, y: -27, width: 100, height: 80 }
+    }));
+
+
+    it('should place top right of BOUNDARY_SUBPROCESS_TOP', autoPlace({
+      element: 'bpmn:Task',
+      behind: 'BOUNDARY_SUBPROCESS_TOP',
+      expectedBounds: { x: 275, y: 194, width: 100, height: 80 }
+    }));
+
+  });
+
 });
+
+
+
+
+////////// helpers /////////////////////////////////////////
+
+function autoPlace(cfg) {
+
+  var element = cfg.element,
+      behind = cfg.behind,
+      expectedBounds = cfg.expectedBounds;
+
+  return inject(function(autoPlace, elementRegistry, elementFactory) {
+
+    var sourceEl = elementRegistry.get(behind);
+
+    // assume
+    expect(sourceEl).to.exist;
+
+    if (typeof element === 'string') {
+      element = { type: element };
+    }
+
+    var shape = elementFactory.createShape(element);
+
+    // when
+    var placedShape = autoPlace.append(sourceEl, shape);
+
+    // then
+    expect(placedShape).to.have.bounds(expectedBounds);
+  });
+}

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -1,0 +1,170 @@
+'use strict';
+
+require('../../../TestHelper');
+
+/* global bootstrapModeler, inject */
+
+var autoPlaceModule = require('../../../../lib/features/auto-place'),
+    modelingModule = require('../../../../lib/features/modeling'),
+    selectionModule = require('diagram-js/lib/features/selection'),
+    labelEditingModule = require('../../../../lib/features/label-editing'),
+    coreModule = require('../../../../lib/core');
+
+
+describe('features/auto-place', function() {
+
+  var diagramXML = require('./AutoPlace.bpmn');
+
+
+  describe('element placement', function() {
+
+    before(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        modelingModule,
+        autoPlaceModule,
+        selectionModule
+      ]
+    }));
+
+
+    function autoPlace(cfg) {
+
+      var element = cfg.element,
+          behind = cfg.behind,
+          expectedBounds = cfg.expectedBounds;
+
+      return inject(function(autoPlace, elementRegistry, elementFactory) {
+
+        var sourceEl = elementRegistry.get(behind);
+
+        // assume
+        expect(sourceEl).to.exist;
+
+        if (typeof element === 'string') {
+          element = { type: element };
+        }
+
+        var shape = elementFactory.createShape(element);
+
+        // when
+        var placedShape = autoPlace.append(sourceEl, shape);
+
+        // then
+        expect(placedShape).to.have.bounds(expectedBounds);
+      });
+    }
+
+
+    describe('should place bpmn:FlowNode', function() {
+
+      it('at default distance after START_EVENT_1', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'START_EVENT_1',
+        expectedBounds: { x: 1052, y: 224, width: 100, height: 80 }
+      }));
+
+
+      it('at incoming distance after TASK_0', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'TASK_0',
+        expectedBounds: { x: 262, y: 54, width: 100, height: 80 }
+      }));
+
+
+      it('at incoming distance / quorum after TASK_5', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'TASK_5',
+        expectedBounds: { x: 296, y: 390, width: 100, height: 80 }
+      }));
+
+
+      it('at existing outgoing / below TASK_2', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'TASK_1',
+        expectedBounds: { x: 279, y: 293, width: 100, height: 80 }
+      }));
+
+
+      it('ignoring existing, far away outgoing of TASK_3', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'TASK_3',
+        expectedBounds: { x: 746, y: 127, width: 100, height: 80 }
+      }));
+
+
+      it('behind bpmn:SubProcess', autoPlace({
+        element: 'bpmn:Task',
+        behind: 'SUBPROCESS_1',
+        expectedBounds: { x: 925, y: 368, width: 100, height: 80 }
+      }));
+
+    });
+
+
+    describe('should place bpmn:DataStoreReference', function() {
+
+      it('bottom right of source', autoPlace({
+        element: 'bpmn:DataStoreReference',
+        behind: 'TASK_3',
+        expectedBounds: { x: 769, y: 247, width: 50, height: 50 }
+      }));
+
+    });
+
+
+    describe('should place bpmn:TextAnnotation', function() {
+
+      it('top right of source', autoPlace({
+        element: 'bpmn:TextAnnotation',
+        behind: 'TASK_2',
+        expectedBounds: { x: 409, y: 103, width: 100, height: 30 }
+      }));
+
+
+      it('above existing', autoPlace({
+        element: 'bpmn:TextAnnotation',
+        behind: 'TASK_3',
+        expectedBounds: { x: 726, y: -4, width: 100, height: 30 }
+      }));
+
+    });
+
+  });
+
+
+  describe('modeling flow', function() {
+
+    before(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        modelingModule,
+        autoPlaceModule,
+        selectionModule,
+        labelEditingModule
+      ]
+    }));
+
+
+    it('should select + direct edit on autoPlace', inject(
+      function(autoPlace, elementRegistry, elementFactory, selection, directEditing) {
+
+        // given
+        var el = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_2');
+
+        // when
+        var newShape = autoPlace.append(source, el);
+
+        // then
+        expect(selection.get()).to.eql([ newShape ]);
+
+        expect(directEditing.isActive()).to.be.true;
+        expect(directEditing._active.element).to.equal(newShape);
+      }
+    ));
+
+  });
+
+});

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -13,10 +13,9 @@ var autoPlaceModule = require('../../../../lib/features/auto-place'),
 
 describe('features/auto-place', function() {
 
-  var diagramXML = require('./AutoPlace.bpmn');
-
-
   describe('element placement', function() {
+
+    var diagramXML = require('./AutoPlace.bpmn');
 
     before(bootstrapModeler(diagramXML, {
       modules: [
@@ -135,6 +134,8 @@ describe('features/auto-place', function() {
 
   describe('modeling flow', function() {
 
+    var diagramXML = require('./AutoPlace.bpmn');
+
     before(bootstrapModeler(diagramXML, {
       modules: [
         coreModule,
@@ -162,6 +163,40 @@ describe('features/auto-place', function() {
 
         expect(directEditing.isActive()).to.be.true;
         expect(directEditing._active.element).to.equal(newShape);
+      }
+    ));
+
+  });
+
+
+  describe('multi connection handling', function() {
+
+    var diagramXML = require('./AutoPlace.multi-connection.bpmn');
+
+    before(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        modelingModule,
+        autoPlaceModule,
+        selectionModule
+      ]
+    }));
+
+
+    it('should ignore multiple source -> target connections', inject(
+      function(autoPlace, elementRegistry, elementFactory, selection, directEditing) {
+
+        // given
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_1');
+        var alignedElement = elementRegistry.get('TASK_3');
+
+        // when
+        var newShape = autoPlace.append(source, element);
+
+        // then
+        expect(newShape.x).to.eql(alignedElement.x);
       }
     ));
 

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -105,6 +105,13 @@ describe('features/auto-place', function() {
 
       it('bottom right of source', autoPlace({
         element: 'bpmn:DataStoreReference',
+        behind: 'TASK_2',
+        expectedBounds: { x: 369, y: 303, width: 50, height: 50 }
+      }));
+
+
+      it('next to existing', autoPlace({
+        element: 'bpmn:DataStoreReference',
         behind: 'TASK_3',
         expectedBounds: { x: 769, y: 247, width: 50, height: 50 }
       }));
@@ -117,14 +124,14 @@ describe('features/auto-place', function() {
       it('top right of source', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'TASK_2',
-        expectedBounds: { x: 409, y: 103, width: 100, height: 30 }
+        expectedBounds: { x: 379, y: 103, width: 100, height: 30 }
       }));
 
 
       it('above existing', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'TASK_3',
-        expectedBounds: { x: 726, y: -4, width: 100, height: 30 }
+        expectedBounds: { x: 696, y: -4, width: 100, height: 30 }
       }));
 
     });

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -19,7 +19,8 @@ var contextPadModule = require('../../../../lib/features/context-pad'),
     modelingModule = require('../../../../lib/features/modeling'),
     replaceMenuModule = require('../../../../lib/features/popup-menu'),
     createModule = require('diagram-js/lib/features/create'),
-    customRulesModule = require('../../../util/custom-rules');
+    customRulesModule = require('../../../util/custom-rules'),
+    autoPlaceModule = require('../../../../lib/features/auto-place');
 
 
 describe('features - context-pad', function() {
@@ -429,6 +430,89 @@ describe('features - context-pad', function() {
         // then
         expect(replaceMenu).to.not.exist;
       }));
+
+  });
+
+
+  describe('auto place', function() {
+
+    var diagramXML = require('../../../fixtures/bpmn/simple.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules.concat(autoPlaceModule)
+    }));
+
+    var container;
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+
+    it('should trigger', inject(function(elementRegistry, contextPad) {
+
+      // given
+      var element = elementRegistry.get('Task_1');
+
+      contextPad.open(element);
+
+      // mock event
+      var event = {
+        clientX: 100,
+        clientY: 100,
+        target: padEntry(container, 'append.gateway'),
+        preventDefault: function() {}
+      };
+
+      // when
+      contextPad.trigger('click', event);
+
+      // then
+      expect(element.outgoing).to.have.length(1);
+    }));
+
+  });
+
+
+  describe('disabled auto-place', function() {
+
+    var diagramXML = require('../../../fixtures/bpmn/simple.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules.concat(autoPlaceModule),
+      contextPad: {
+        autoPlace: false
+      }
+    }));
+
+    var container;
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+
+    it('should default to drag start', inject(function(elementRegistry, contextPad, dragging) {
+
+      // given
+      var element = elementRegistry.get('Task_1');
+
+      contextPad.open(element);
+
+      // mock event
+      var event = {
+        clientX: 100,
+        clientY: 100,
+        target: padEntry(container, 'append.gateway'),
+        preventDefault: function() {}
+      };
+
+      // when
+      contextPad.trigger('click', event);
+
+      // then
+      expect(dragging.context()).to.exist;
+    }));
 
   });
 


### PR DESCRIPTION
Right now, clicking the context menu starts a drag operation. 

This pull request changes the behavior to perform an automatic placement of the element based on certain semi-smart behaviors:

* text annotation top right of shape
* data element bottom right of shape
* flow element right of shape
* don't stack elements
* compute flow element distances based on existing elements connecting with source shape

The new behavior enables a much simpler modeling experience (drawing a process in seconds rather than minutes, no more fiddling around with positioning). At the same time, the advanced behavior to drag an element anywhere is still there when dragging out from the context menu.

Check out #563 for screencasts demoing the behavior.

Would be interesting to get some feedback on the approach taken and whether it makes sense to continue / merge this as an improvement.

Closes #563 
