### PR TITLE
fix(auto-place): fix infinite loop during auto-place

### DIFF
--- a/lib/features/auto-place/AutoPlaceUtil.js
+++ b/lib/features/auto-place/AutoPlaceUtil.js
@@ -42,16 +42,19 @@ export function getFlowNodePosition(source, element) {
     }
   }
 
-  var verticalDistances = {
-    left: 0,
-    right: 0,
-    top: -1 * rowSize,
-    bottom: rowSize
-  };
+  function getVerticalDistance(orient) {
+    if (orient.indexOf('top') != -1) {
+      return -1 * rowSize;
+    } else if (orient.indexOf('bottom') != -1) {
+      return rowSize;
+    } else {
+      return 0;
+    }
+  }
 
   var position = {
     x: sourceTrbl.right + horizontalDistance + element.width / 2,
-    y: sourceMid.y + verticalDistances[orientation]
+    y: sourceMid.y + getVerticalDistance(orientation)
   };
 
   var escapeDirection = {

--- a/test/spec/features/auto-place/AutoPlace.boundary-events.bpmn
+++ b/test/spec/features/auto-place/AutoPlace.boundary-events.bpmn
@@ -11,6 +11,7 @@
     <sequenceFlow id="SequenceFlow_0o6gp3o" sourceRef="TASK_1" targetRef="TASK_2" />
     <task id="TASK_3" name="TASK_3" />
     <boundaryEvent id="BOUNDARY_TOP" name="BOUNDARY_TOP" attachedToRef="TASK_1" />
+    <boundaryEvent id="BOUNDARY_TOP_RIGHT" name="BOUNDARY_TOP_RIGHT" attachedToRef="TASK_2" />
     <subProcess id="SUBPROCESS" name="SUBPROCESS" />
     <boundaryEvent id="BOUNDARY_SUBPROCESS_BOTTOM" name="BOUNDARY_SUBPROCESS_BOTTOM" attachedToRef="SUBPROCESS" />
     <boundaryEvent id="BOUNDARY_SUBPROCESS_TOP" name="BOUNDARY_SUBPROCESS_TOP" attachedToRef="SUBPROCESS" />
@@ -43,6 +44,12 @@
         <omgdc:Bounds x="156" y="75" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="78" y="52" width="86" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BOUNDARY_TOP_RIGHT_di" bpmnElement="BOUNDARY_TOP_RIGHT">
+        <omgdc:Bounds x="387" y="75" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="363" y="44" width="84" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SUBPROCESS_di" bpmnElement="SUBPROCESS" isExpanded="true">

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -216,6 +216,11 @@ describe('features/auto-place', function() {
       expectedBounds: { x: 242, y: -27, width: 100, height: 80 }
     }));
 
+    it('should place top right of BOUNDARY_TOP_RIGHT without infinite loop', autoPlace({
+      element: 'bpmn:Task',
+      behind: 'BOUNDARY_TOP_RIGHT',
+      expectedBounds: { x: 473, y: -27, width: 100, height: 80 }
+    }));
 
     it('should place top right of BOUNDARY_SUBPROCESS_TOP', autoPlace({
       element: 'bpmn:Task',


### PR DESCRIPTION
Fix NaN return while autoplace an element after a BoundaryEvent in a corner.

Fixes #788

### Proposed Changes
Replace dict by function that computes vertical distance of an element after a boundary placed in a corner.