### PR TITLE
chore(contextPadProvider): adjust popupMenu method calls

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -329,14 +329,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     }
   }
 
-  var replaceMenu;
-
-  if (popupMenu._providers['bpmn-replace']) {
-    replaceMenu = popupMenu.create('bpmn-replace', element);
-  }
-
-  if (replaceMenu && !replaceMenu.isEmpty()) {
-
+  if (!popupMenu.isEmpty(element, 'bpmn-replace')) {
     // Replace menu entry
     assign(actions, {
       'replace': {
@@ -345,9 +338,12 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         title: translate('Change type'),
         action: {
           click: function(event, element) {
-            replaceMenu.open(assign(getReplaceMenuPosition(element), {
+
+            var position = assign(getReplaceMenuPosition(element), {
               cursor: { x: event.x, y: event.y }
-            }), element);
+            });
+
+            popupMenu.open(element, 'bpmn-replace', position);
           }
         }
       }

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -76,9 +76,9 @@ describe('features/popup-menu - replace menu provider', function() {
 
     getBpmnJS().invoke(function(popupMenu) {
 
-      popupMenu.create('bpmn-replace', element);
-
-      popupMenu.open({ x: element.x + offset, y: element.y + offset });
+      popupMenu.open(element, 'bpmn-replace', {
+        x: element.x + offset, y: element.y + offset
+      });
 
     });
   };


### PR DESCRIPTION
Since breaking changes were introduced in diagram-js
popupMenu methos calls need to be adjusted

* call popupMenu#open with element, id and position as params
* call popupMenu#isEmpty with element and providerId as params
* remove popupMenu#create call

<!--

Thanks for filing a pull request!

Make sure you've read through [our contributing guide](https://github.com/bpmn-io/bpmn-js/blob/master/CONTRIBUTING.md#creating-a-pull-request) before you continue.

-->


Related to bpmn-io/diagram-js#253