### PR TITLE
feat(replace): Keep timer boundary config when just switching interrupt

### DIFF
--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -144,6 +144,30 @@ export default function BpmnReplace(
     // initialize custom BPMN extensions
     if (target.eventDefinitionType) {
       newElement.eventDefinitionType = target.eventDefinitionType;
+
+      // Keep timer event def config if switching between interrupting and non-interrupting
+      if (oldBusinessObject.eventDefinitions) {
+        var oldEventDef = oldBusinessObject.eventDefinitions[0];
+        if (oldEventDef &&
+            is(oldEventDef, 'bpmn:TimerEventDefinition') &&
+            target.eventDefinitionType === oldEventDef.$type) {
+
+          var eventDef = bpmnFactory.create('bpmn:TimerEventDefinition');
+          eventDef = helper.clone(oldEventDef, eventDef, {});
+          if (oldEventDef.timeDuration) {
+            eventDef.timeDuration = oldEventDef.timeDuration;
+          }
+          if (oldEventDef.timeDate) {
+            eventDef.timeDate = oldEventDef.timeDate;
+          }
+          if (oldEventDef.timeCycle) {
+            eventDef.timeCycle = oldEventDef.timeCycle;
+          }
+
+          newBusinessObject.eventDefinitions = [];
+          newBusinessObject.eventDefinitions.push(eventDef);
+        }
+      }
     }
 
     if (is(oldBusinessObject, 'bpmn:Activity')) {

--- a/test/fixtures/bpmn/features/replace/01_replace.bpmn
+++ b/test/fixtures/bpmn/features/replace/01_replace.bpmn
@@ -43,7 +43,9 @@
     <bpmn:adHocSubProcess id="AdHocSubProcessCollapsed" />
     <bpmn:adHocSubProcess id="AdHocSubProcessExpanded" />
     <bpmn:boundaryEvent id="BoundaryEvent_1" cancelActivity="false" attachedToRef="Task_1">
-      <bpmn:timerEventDefinition />
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration>P1D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:boundaryEvent id="BoundaryEvent_2" attachedToRef="Task_1">
       <bpmn:outgoing>SequenceFlow_7</bpmn:outgoing>

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -154,6 +154,27 @@ describe('features/replace - bpmn replace', function() {
       })
     );
 
+    it('non interrupting boundary event by interrupting boundary event both with timer',
+      inject(function(elementRegistry, modeling, bpmnReplace, canvas) {
+
+        // given
+        var boundaryEvent = elementRegistry.get('BoundaryEvent_1'),
+            newElementData = {
+              type: 'bpmn:BoundaryEvent',
+              eventDefinitionType: 'bpmn:TimerEventDefinition'
+            };
+
+        // when
+        var newElement = bpmnReplace.replaceElement(boundaryEvent, newElementData);
+
+        // then
+        expect(newElement).to.exist;
+        expect(is(newElement.businessObject, 'bpmn:BoundaryEvent')).to.be.true;
+        expect(newElement.businessObject.eventDefinitions[0].$type).to.equal('bpmn:TimerEventDefinition');
+        expect(newElement.businessObject.eventDefinitions[0].timeDuration).to.exist;
+        expect(newElement.businessObject.cancelActivity).to.be.true;
+      })
+    );
 
     it('interrupting boundary event by non interrupting boundary event',
       inject(function(elementRegistry, modeling, bpmnReplace, canvas) {


### PR DESCRIPTION
TimerEventDefinitions loose its configuration (which is a child element) when switching between interrupting and not interrupting.

Fixes #799

### Proposed Changes

* Copy timerEventDefinition child if switch appends between two timerBoundary