### PR TITLE
feat(viewer): emit export events

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -199,6 +199,16 @@ Viewer.prototype.importXML = function(xml, done) {
  * Export the currently displayed BPMN 2.0 diagram as
  * a BPMN 2.0 XML document.
  *
+ * ## Life-Cycle Events
+ *
+ * During XML saving the viewer will fire life-cycle events:
+ *
+ *   * saveXML.start (before serialization)
+ *   * saveXML.serialized (after xml generation)
+ *   * saveXML.done (everything done)
+ *
+ * You can use these events to hook into the life-cycle.
+ *
  * @param {Object} [options] export options
  * @param {Boolean} [options.format=false] output formated XML
  * @param {Boolean} [options.preamble=true] output preamble
@@ -212,18 +222,51 @@ Viewer.prototype.saveXML = function(options, done) {
     options = {};
   }
 
+  var self = this;
+
   var definitions = this._definitions;
 
   if (!definitions) {
     return done(new Error('no definitions loaded'));
   }
 
-  this._moddle.toXML(definitions, options, done);
+  // allow to fiddle around with definitions
+  definitions = this._emit('saveXML.start', {
+    definitions: definitions
+  }) || definitions;
+
+  this._moddle.toXML(definitions, options, function(err, xml) {
+
+    try {
+      xml = self._emit('saveXML.serialized', {
+        error: err,
+        xml: xml
+      }) || xml;
+
+      self._emit('saveXML.done', {
+        error: err,
+        xml: xml
+      });
+    } catch (e) {
+      console.error('error in saveXML life-cycle listener', e);
+    }
+
+    done(err, xml);
+  });
 };
 
 /**
  * Export the currently displayed BPMN 2.0 diagram as
  * an SVG image.
+ *
+ * ## Life-Cycle Events
+ *
+ * During SVG saving the viewer will fire life-cycle events:
+ *
+ *   * saveSVG.start (before serialization)
+ *   * saveSVG.done (everything done)
+ *
+ * You can use these events to hook into the life-cycle.
  *
  * @param {Object} [options]
  * @param {Function} done invoked with (err, svgStr)
@@ -234,6 +277,8 @@ Viewer.prototype.saveSVG = function(options, done) {
     done = options;
     options = {};
   }
+
+  this._emit('saveSVG.start');
 
   var svg, err;
 
@@ -260,6 +305,11 @@ Viewer.prototype.saveSVG = function(options, done) {
   } catch (e) {
     err = e;
   }
+
+  this._emit('saveSVG.done', {
+    error: err,
+    svg: svg
+  });
 
   done(err, svg);
 };


### PR DESCRIPTION
This makes the viewer emit events during SVG and XML export.

These events allow others to hook in, i.e. to trigger additional _save_
actions.

Closes #811