### PR TITLE
Only update datastore parents in collaboration

### DIFF
--- a/lib/features/modeling/behavior/DataStoreBehavior.js
+++ b/lib/features/modeling/behavior/DataStoreBehavior.js
@@ -132,15 +132,14 @@ export default function DataStoreBehavior(
   });
 
 
-  // update data store parents on participant deleted
+  // update data store parents on participant or subprocess deleted
   this.postExecute('shape.delete', function(event) {
     var context = event.context,
         shape = context.shape,
-        rootElement;
+        rootElement = canvas.getRootElement();
 
-    if (isAny(shape, [ 'bpmn:Participant', 'bpmn:SubProcess' ])) {
-      rootElement = canvas.getRootElement();
-
+    if (isAny(shape, [ 'bpmn:Participant', 'bpmn:SubProcess' ])
+        && is(rootElement, 'bpmn:Collaboration')) {
       getDataStores(rootElement)
         .filter(function(dataStore) {
           return isDescendant(dataStore, shape);

--- a/test/spec/features/modeling/behavior/DataStoreBehavior.process.bpmn
+++ b/test/spec/features/modeling/behavior/DataStoreBehavior.process.bpmn
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1pdhhel" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.0-dev">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1pdhhel" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:dataStoreReference id="DataStoreReference" />
+    <bpmn:subProcess id="SubProcess" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -10,6 +11,9 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="25" y="54" width="0" height="12" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_18wikk9_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="0" y="100" width="350" height="200" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/DataStoreBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/DataStoreBehaviorSpec.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import {
   bootstrapModeler,
   inject
@@ -308,6 +310,32 @@ describe('features/modeling/behavior - data store', function() {
       }));
 
     });
+
+  });
+
+
+  describe('process', function() {
+    var processDiagramXML = require('./DataStoreBehavior.process.bpmn');
+
+    beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+    it('should not update parent on subprocess delete', inject(
+      function(elementRegistry, eventBus, modeling) {
+
+        // given
+        var spy = sinon.spy();
+
+        eventBus.on('commandStack.dataStore.updateContainment.execute', spy);
+
+        var subProcessElement = elementRegistry.get('SubProcess');
+
+        // when
+        modeling.removeShape(subProcessElement);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      }
+    ));
 
   });
 


### PR DESCRIPTION
Updating parents of datastores in the root is only necessary when deleting a subprocess in a collaboration.