### PR TITLE
fix(draw): revert to Arial as default font

### DIFF
--- a/lib/draw/TextRenderer.js
+++ b/lib/draw/TextRenderer.js
@@ -11,7 +11,7 @@ var MIN_TEXT_ANNOTATION_HEIGHT = 30;
 export default function TextRenderer(config) {
 
   var defaultStyle = assign({
-    fontFamily: 'sans-serif',
+    fontFamily: 'Arial, sans-serif',
     fontSize: DEFAULT_FONT_SIZE,
     fontWeight: 'normal',
     lineHeight: LINE_HEIGHT_RATIO


### PR DESCRIPTION
This solves diagram export and rendering issues.

The font can still be easily overriden if integrators
wish to do so.

Closes #819