### PR TITLE
Fix adaptive label positioning

### DIFF
--- a/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
+++ b/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
@@ -48,6 +48,13 @@ export default function AdaptiveLabelPositioningBehavior(eventBus, modeling) {
   });
 
 
+  this.postExecuted([
+    'label.create'
+  ], function(event) {
+    checkLabelAdjustment(event.context.shape.labelTarget);
+  });
+
+
   function checkLabelAdjustment(element) {
 
     // skip non-existing labels

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bpmn-font": "^0.8.0",
     "bpmn-moddle": "^5.1.5",
     "css.escape": "^1.5.1",
-    "diagram-js": "^2.4.0",
+    "diagram-js": "^2.4.1",
     "diagram-js-direct-editing": "^1.3.0",
     "ids": "^0.2.0",
     "inherits": "^2.0.1",

--- a/test/spec/features/modeling/MoveShapeSpec.js
+++ b/test/spec/features/modeling/MoveShapeSpec.js
@@ -195,7 +195,7 @@ describe('features/modeling - move shape', function() {
   });
 
 
-  describe('label suport', function() {
+  describe('label support', function() {
 
     it('should move label with shape', inject(function(elementRegistry, modeling) {
 
@@ -210,12 +210,12 @@ describe('features/modeling - move shape', function() {
       };
 
       // when
-      modeling.moveElements([ startEventElement ], { x: 40, y: -80 });
+      modeling.moveElements([ startEventElement ], { x: 40, y: 80 });
 
       // then
       expect(label).to.have.position({
         x: labelPosition.x + 40,
-        y: labelPosition.y - 80
+        y: labelPosition.y + 80
       });
     }));
 
@@ -305,7 +305,7 @@ describe('features/modeling - move shape', function() {
           y: label.y
         };
 
-        modeling.moveElements([ startEventElement ], { x: 40, y: -80 });
+        modeling.moveElements([ startEventElement ], { x: 40, y: 80 });
         commandStack.undo();
 
         // when
@@ -314,7 +314,7 @@ describe('features/modeling - move shape', function() {
         // then
         expect(label).to.have.position({
           x: labelPosition.x + 40,
-          y: labelPosition.y - 80
+          y: labelPosition.y + 80
         });
       }));
 

--- a/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehavior.bpmn
@@ -31,6 +31,13 @@
     <sequenceFlow id="SequenceFlow_1qmllcx" sourceRef="Task" targetRef="LabelImpossible" />
     <sequenceFlow id="SequenceFlow_0s993e4" sourceRef="Task" targetRef="LabelImpossible" />
     <sequenceFlow id="SequenceFlow_022at7e" sourceRef="Task" targetRef="LabelImpossible" />
+    <exclusiveGateway id="NoLabel">
+      <outgoing>SequenceFlow_0isa70k</outgoing>
+    </exclusiveGateway>
+    <exclusiveGateway id="ExclusiveGateway_02fomt2">
+      <incoming>SequenceFlow_0isa70k</incoming>
+    </exclusiveGateway>
+    <sequenceFlow id="SequenceFlow_0isa70k" sourceRef="NoLabel" targetRef="ExclusiveGateway_02fomt2" />
   </process>
   <bpmndi:BPMNDiagram id="BpmnDiagram_1">
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
@@ -77,15 +84,15 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
-        <omgdi:waypoint xsi:type="omgdc:Point" x="334" y="275" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="334" y="370" />
+        <omgdi:waypoint x="334" y="275" />
+        <omgdi:waypoint x="334" y="370" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="346" y="317" width="7" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
-        <omgdi:waypoint xsi:type="omgdc:Point" x="131" y="275" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="131" y="370" />
+        <omgdi:waypoint x="131" y="275" />
+        <omgdi:waypoint x="131" y="370" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="142" y="317" width="8" height="12" />
         </bpmndi:BPMNLabel>
@@ -100,32 +107,47 @@
         <omgdc:Bounds x="776" y="293" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1qmllcx_di" bpmnElement="SequenceFlow_1qmllcx">
-        <omgdi:waypoint xsi:type="omgdc:Point" x="826" y="293" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="826" y="202" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="658" y="202" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="658" y="308" />
+        <omgdi:waypoint x="826" y="293" />
+        <omgdi:waypoint x="826" y="202" />
+        <omgdi:waypoint x="658" y="202" />
+        <omgdi:waypoint x="658" y="308" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="742" y="181" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0s993e4_di" bpmnElement="SequenceFlow_0s993e4">
-        <omgdi:waypoint xsi:type="omgdc:Point" x="826" y="373" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="826" y="424" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="658" y="424" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="658" y="358" />
+        <omgdi:waypoint x="826" y="373" />
+        <omgdi:waypoint x="826" y="424" />
+        <omgdi:waypoint x="658" y="424" />
+        <omgdi:waypoint x="658" y="358" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="742" y="403" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_022at7e_di" bpmnElement="SequenceFlow_022at7e">
-        <omgdi:waypoint xsi:type="omgdc:Point" x="845" y="373" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="845" y="453" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="594" y="453" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="594" y="333" />
-        <omgdi:waypoint xsi:type="omgdc:Point" x="633" y="333" />
+        <omgdi:waypoint x="845" y="373" />
+        <omgdi:waypoint x="845" y="453" />
+        <omgdi:waypoint x="594" y="453" />
+        <omgdi:waypoint x="594" y="333" />
+        <omgdi:waypoint x="633" y="333" />
         <bpmndi:BPMNLabel>
           <omgdc:Bounds x="719.5" y="432" width="0" height="12" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="NoLabel_di" bpmnElement="NoLabel" isMarkerVisible="true">
+        <omgdc:Bounds x="633" y="82" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="120" y="570" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_02fomt2_di" bpmnElement="ExclusiveGateway_02fomt2" isMarkerVisible="true">
+        <omgdc:Bounds x="836" y="82" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0isa70k_di" bpmnElement="SequenceFlow_0isa70k">
+        <omgdi:waypoint x="658" y="132" />
+        <omgdi:waypoint x="658" y="159" />
+        <omgdi:waypoint x="861" y="159" />
+        <omgdi:waypoint x="861" y="132" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
@@ -200,6 +200,27 @@ describe('modeling/behavior - AdaptiveLabelPositioningBehavior', function() {
   });
 
 
+  describe('on source move / layout', function() {
+
+    it('should move label from BOTTOM to TOP', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var source = elementRegistry.get('LabelTop'),
+            target = elementRegistry.get('LabelBottom_3');
+
+        // when
+        modeling.moveElements([ target ], { x: 20, y: -300 });
+
+        // then
+        expectLabelOrientation(source, 'bottom');
+        expectLabelOrientation(target, 'top');
+      }
+    ));
+
+  });
+
+
   describe('on waypoints update', function() {
 
     it('should move label from RIGHT to TOP', inject(function(elementRegistry, modeling) {

--- a/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
@@ -260,4 +260,21 @@ describe('modeling/behavior - AdaptiveLabelPositioningBehavior', function() {
   });
 
 
+  describe('on label creation', function() {
+
+    it('should create label at TOP', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var element = elementRegistry.get('NoLabel');
+
+        // when
+        modeling.updateProperties(element, { name: 'FOO BAR' });
+
+        // then
+        expectLabelOrientation(element, 'top');
+      }
+    ));
+  });
+
 });


### PR DESCRIPTION
This brings back adaptive label position on label creation.

Closes #825

Depends on https://github.com/bpmn-io/diagram-js/pull/268 for an [additional fix](https://github.com/bpmn-io/bpmn-js/commit/15596ef97cb6a2ba71817197bf1c11ce4800eaab).