### PR TITLE
fix(chore): fix main file location, ensure compatibility with nodejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-export {
-  default
-} from './lib/Viewer';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bpmn-js",
   "version": "2.4.1",
   "description": "A bpmn 2.0 toolkit and web modeler",
+  "main": "dist/bpmn-viewer.production.min.js",
   "scripts": {
     "all": "run-s lint test distro test:distro",
     "lint": "eslint .",

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -2,8 +2,6 @@ import TestContainer from 'mocha-test-container-support';
 
 import Diagram from 'diagram-js/lib/Diagram';
 
-import ViewerDefaultExport from '../../';
-
 import Viewer from 'lib/Viewer';
 
 import inherits from 'inherits';
@@ -1062,11 +1060,6 @@ describe('Viewer', function() {
       });
     });
 
-  });
-
-
-  it('default export', function() {
-    expect(ViewerDefaultExport).to.equal(Viewer);
   });
 
 });


### PR DESCRIPTION
The current setup uses implicit default main file `index.js` which uses es6 native module `import` syntax, and directly loads from source file (`lib` folder) which uses native module `import` syntax too.

The whole setup bypasses `dist` file prepared by rollup.

The reason that this setup still works in webpack, is webpack supports es6 native module `import` syntax. We don't have the luck if we use the main file in nodejs or browser environments directly (both currently do not support `import` syntax by default).