### PR TITLE
style(Viewer): fix a typo in the imported name

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -32,7 +32,7 @@ import {
 import CoreModule from './core';
 import TranslateModule from 'diagram-js/lib/i18n/translate';
 import SelectionModule from 'diagram-js/lib/features/selection';
-import OveraysModule from 'diagram-js/lib/features/overlays';
+import OverlaysModule from 'diagram-js/lib/features/overlays';
 
 
 function checkValidationError(err) {
@@ -520,7 +520,7 @@ Viewer.prototype._modules = [
   CoreModule,
   TranslateModule,
   SelectionModule,
-  OveraysModule
+  OverlaysModule
 ];
 
 // default moddle extensions the viewer is composed of


### PR DESCRIPTION
Fixes a minor typo OveraysModule → OverlaysModule.