### PR TITLE
feat(contextPad): improve tooltip titles for IntermediateCatchEvents

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -266,21 +266,25 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         'append.message-intermediate-event': appendAction(
           'bpmn:IntermediateCatchEvent',
           'bpmn-icon-intermediate-event-catch-message',
+          'MessageIntermediateCatchEvent',
           { eventDefinitionType: 'bpmn:MessageEventDefinition' }
         ),
         'append.timer-intermediate-event': appendAction(
           'bpmn:IntermediateCatchEvent',
           'bpmn-icon-intermediate-event-catch-timer',
+          'TimerIntermediateCatchEvent',
           { eventDefinitionType: 'bpmn:TimerEventDefinition' }
         ),
         'append.condtion-intermediate-event': appendAction(
           'bpmn:IntermediateCatchEvent',
           'bpmn-icon-intermediate-event-catch-condition',
+          'ConditionIntermediateCatchEvent',
           { eventDefinitionType: 'bpmn:ConditionalEventDefinition' }
         ),
         'append.signal-intermediate-event': appendAction(
           'bpmn:IntermediateCatchEvent',
           'bpmn-icon-intermediate-event-catch-signal',
+          'SignalIntermediateCatchEvent',
           { eventDefinitionType: 'bpmn:SignalEventDefinition' }
         )
       });


### PR DESCRIPTION
Improves the tooltip titles for the different IntermediateCatchEvent types

Closes https://github.com/camunda/camunda-modeler/issues/917