### PR TITLE
784 no boundary event after event based gateway

### DIFF
--- a/lib/features/modeling/behavior/ConnectEventBasedGatewayBehavior.js
+++ b/lib/features/modeling/behavior/ConnectEventBasedGatewayBehavior.js
@@ -1,0 +1,47 @@
+import inherits from 'inherits';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { is } from '../../../util/ModelUtil';
+
+import {
+  filter
+} from 'min-dash';
+
+
+/**
+ * Behavior for deleting boundaries from receive task after connecting them with event based gateway
+ */
+export default function ConnectEventBasedGatewayBehavior(eventBus, modeling) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  function extractBoundaryEvents(element) {
+    return filter(element.attachers, function(attacher) {
+      return is(attacher, 'bpmn:BoundaryEvent');
+    });
+  }
+
+  this.postExecute('connection.create', function(context) {
+    var source = context.context.source,
+        target = context.context.target,
+        boundaries = extractBoundaryEvents(target);
+
+    if (
+      is(source, 'bpmn:EventBasedGateway') &&
+      is(target, 'bpmn:ReceiveTask') &&
+      boundaries.length > 0
+    ) {
+      modeling.removeElements(boundaries);
+    }
+
+  });
+}
+
+ConnectEventBasedGatewayBehavior.$inject = [
+  'eventBus',
+  'modeling',
+  'bpmnRules'
+];
+
+inherits(ConnectEventBasedGatewayBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -1,5 +1,6 @@
 import AdaptiveLabelPositioningBehavior from './AdaptiveLabelPositioningBehavior';
 import AppendBehavior from './AppendBehavior';
+import ConnectEventBasedGatewayBehavior from './ConnectEventBasedGatewayBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
 import CreateBoundaryEventBehavior from './CreateBoundaryEventBehavior';
 import CreateDataObjectBehavior from './CreateDataObjectBehavior';
@@ -25,6 +26,7 @@ export default {
   __init__: [
     'adaptiveLabelPositioningBehavior',
     'appendBehavior',
+    'connectEventBasedGatewayBehavior',
     'copyPasteBehavior',
     'createBoundaryEventBehavior',
     'createDataObjectBehavior',
@@ -48,6 +50,7 @@ export default {
   ],
   adaptiveLabelPositioningBehavior: [ 'type', AdaptiveLabelPositioningBehavior ],
   appendBehavior: [ 'type', AppendBehavior ],
+  connectEventBasedGatewayBehavior: [ 'type', ConnectEventBasedGatewayBehavior ],
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],
   createBoundaryEventBehavior: [ 'type', CreateBoundaryEventBehavior ],
   createDataObjectBehavior: [ 'type', CreateDataObjectBehavior ],

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -555,6 +555,15 @@ function isBoundaryCandidate(element) {
         (is(element, 'bpmn:IntermediateThrowEvent') && !element.parent);
 }
 
+function isReceiveTaskAfterEventBasedGateway(element) {
+  return (
+    is(element, 'bpmn:ReceiveTask') &&
+    find(element.incoming, function(incoming) {
+      return is(incoming.source, 'bpmn:EventBasedGateway');
+    })
+  );
+}
+
 
 function canAttach(elements, target, source, position) {
 
@@ -601,6 +610,11 @@ function canAttach(elements, target, source, position) {
 
   // only attach to subprocess border
   if (position && !isBoundaryAttachment(position, target)) {
+    return false;
+  }
+
+  // do not attach on receive tasks after event based gateways
+  if (isReceiveTaskAfterEventBasedGateway(target)) {
     return false;
   }
 

--- a/test/spec/features/modeling/behavior/ConnectEventBasedGatewayBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/ConnectEventBasedGatewayBehavior.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1ipuizk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:eventBasedGateway id="EventBasedGateway_1" />
+    <bpmn:receiveTask id="ReceiveTask_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ReceiveTask_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="EventBasedGateway_1cu8t9h_di" bpmnElement="EventBasedGateway_1">
+        <dc:Bounds x="172" y="118" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReceiveTask_1vk05s6_di" bpmnElement="ReceiveTask_1">
+        <dc:Bounds x="300" y="103" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0xg8xmx_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="331" y="165" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/ConnectEventBasedGatewayBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/ConnectEventBasedGatewayBehaviorSpec.js
@@ -1,0 +1,36 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import coreModule from 'lib/core';
+
+
+describe('features/modeling/behavior - connect event based gateway to receive task with boundary', function() {
+
+  var testModules = [ coreModule, modelingModule ];
+
+  var diagramXML = require('./ConnectEventBasedGatewayBehavior.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+  it('should remove the boundary event from the receive task after connecting the task with an event based gateway',
+    inject(function(modeling, elementRegistry) {
+
+      // given
+      var eventBasedGateway = elementRegistry.get('EventBasedGateway_1'),
+          receiveTask = elementRegistry.get('ReceiveTask_1'),
+          boundaryEvent = elementRegistry.get('BoundaryEvent_1');
+
+      // when
+      modeling.connect(eventBasedGateway, receiveTask, {
+        type: 'bpmn:SequenceFlow'
+      });
+
+      // then
+      expect(elementRegistry.get(boundaryEvent.id)).to.be.undefined;
+    }));
+
+});

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1377,6 +1377,41 @@ describe('features/modeling/rules - BpmnRules', function() {
       }
     ));
 
+    it('not attach IntermediateEvent to ReceiveTask after EventBasedGateway', inject(
+      function(canvas, modeling, elementFactory, bpmnRules) {
+
+        // given
+        var rootElement = canvas.getRootElement(),
+            eventBasedGatewayShape = elementFactory.createShape({ type: 'bpmn:EventBasedGateway' }),
+            receiveTaskShape = elementFactory.createShape({ type: 'bpmn:ReceiveTask' }),
+            eventShape = elementFactory.createShape({
+              type: 'bpmn:IntermediateThrowEvent',
+              x: 0, y: 0
+            });
+
+        var boundaryPosition = {
+          x: 175,
+          y: 100 + receiveTaskShape.height
+        };
+
+        // when
+        modeling.createShape(eventBasedGatewayShape, { x: 100, y: 100 }, rootElement);
+        modeling.createShape(receiveTaskShape, { x : 150, y: 100 }, rootElement);
+        modeling.connect(eventBasedGatewayShape, receiveTaskShape, {
+          type: 'bpmn:SequenceFlow'
+        });
+
+        var canAttach = bpmnRules.canAttach(
+          [ eventShape ],
+          receiveTaskShape,
+          null,
+          boundaryPosition
+        );
+
+        // then
+        expect(canAttach).to.be.false;
+      }
+    ));
 
     it('create IntermediateEvent in SubProcess body', inject(
       function(elementFactory, elementRegistry, bpmnRules) {


### PR DESCRIPTION
Implemented a Bpmn rule that it shouldn't be possible to attach a BoundaryEvent on a ReceiveTask following a  EventBasedGateway in two different ways:

- It isn't possible to attach a BoundaryEvent on a ReceiveTask which is already connected after a EventBasedGateway (BpmnRule)
- Deletion of attached BoundaryEvent after connecting a EventBasedGateway to a ReceiveTask (Behavior)

Closes https://github.com/camunda/camunda-modeler/issues/784