### PR TITLE
fix: error date in license

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -122,7 +122,7 @@ function today() {
   return [
     d.getFullYear(),
     pad(d.getMonth() + 1),
-    pad(d.getDay())
+    pad(d.getDate())
   ].join('-');
 }
 


### PR DESCRIPTION
I found the date in license is error, because of Date.prototype.getDay() method returns the day of the week, and Date.prototype.getDate() method returns the day of the month which is right here.