### PR TITLE
376 add keyboard shortcuts to move elements

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -9,6 +9,7 @@ import NavigatedViewer from './NavigatedViewer';
 import MoveCanvasModule from 'diagram-js/lib/navigation/movecanvas';
 import TouchModule from 'diagram-js/lib/navigation/touch';
 import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
+import KeyboardNavigationModule from 'diagram-js/lib/features/keyboard-navigation';
 
 import AutoScrollModule from 'diagram-js/lib/features/auto-scroll';
 import BendpointsModule from 'diagram-js/lib/features/bendpoints';
@@ -187,6 +188,7 @@ Modeler.prototype._collectIds = function(definitions, context) {
 
 Modeler.prototype._interactionModules = [
   // non-modeling components
+  KeyboardNavigationModule,
   MoveCanvasModule,
   TouchModule,
   ZoomScrollModule
@@ -203,6 +205,7 @@ Modeler.prototype._modelingModules = [
   EditorActionsModule,
   ContextPadModule,
   KeyboardModule,
+  KeyboardNavigationModule,
   LabelEditingModule,
   ModelingModule,
   PaletteModule,

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -14,6 +14,7 @@ import KeyboardNavigationModule from 'diagram-js/lib/features/keyboard-navigatio
 import AutoScrollModule from 'diagram-js/lib/features/auto-scroll';
 import BendpointsModule from 'diagram-js/lib/features/bendpoints';
 import MoveModule from 'diagram-js/lib/features/move';
+import MoveSelectionModule from 'diagram-js/lib/features/move-selection';
 import ResizeModule from 'diagram-js/lib/features/resize';
 import AutoResizeModule from './features/auto-resize';
 import AutoPlaceModule from './features/auto-place';
@@ -199,6 +200,7 @@ Modeler.prototype._modelingModules = [
   AutoScrollModule,
   BendpointsModule,
   MoveModule,
+  MoveSelectionModule,
   ResizeModule,
   AutoResizeModule,
   AutoPlaceModule,

--- a/lib/features/keyboard/BpmnKeyBindings.js
+++ b/lib/features/keyboard/BpmnKeyBindings.js
@@ -11,7 +11,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
 
     var event = context.event;
 
-    if (event.keyCode === 65 && keyboard.isCmd(event)) {
+    if (keyboard.isKey(['a', 'A'], event) && keyboard.isCmd(event)) {
       editorActions.trigger('selectElements');
 
       return true;
@@ -23,7 +23,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
 
     var event = context.event;
 
-    if (event.keyCode === 70 && keyboard.isCmd(event)) {
+    if (keyboard.isKey(['f', 'F'], event) && keyboard.isCmd(event)) {
       editorActions.trigger('find');
 
       return true;
@@ -39,7 +39,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
       return;
     }
 
-    if (event.keyCode === 83) {
+    if (keyboard.isKey(['s', 'S'], event)) {
       editorActions.trigger('spaceTool');
 
       return true;
@@ -55,7 +55,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
       return;
     }
 
-    if (event.keyCode === 76) {
+    if (keyboard.isKey(['l', 'L'], event)) {
       editorActions.trigger('lassoTool');
 
       return true;
@@ -72,7 +72,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
       return;
     }
 
-    if (event.keyCode === 72) {
+    if (keyboard.isKey(['h', 'H'], event)) {
       editorActions.trigger('handTool');
 
       return true;
@@ -88,7 +88,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
       return;
     }
 
-    if (event.keyCode === 67) {
+    if (keyboard.isKey(['c', 'C'], event)) {
       editorActions.trigger('globalConnectTool');
 
       return true;
@@ -104,7 +104,7 @@ export default function BpmnKeyBindings(keyboard, editorActions) {
       return;
     }
 
-    if (event.keyCode === 69) {
+    if (keyboard.isKey(['e', 'E'], event)) {
       editorActions.trigger('directEditing');
 
       return true;

--- a/lib/features/keyboard/BpmnKeyBindings.js
+++ b/lib/features/keyboard/BpmnKeyBindings.js
@@ -6,61 +6,119 @@
  */
 export default function BpmnKeyBindings(keyboard, editorActions) {
 
-  keyboard.addListener(function(key, modifiers) {
+  // ctrl + a -> select all elements
+  function selectAll(context) {
 
-    // ctrl + a -> select all elements
-    if (key === 65 && keyboard.isCmd(modifiers)) {
+    var event = context.event;
+
+    if (event.keyCode === 65 && keyboard.isCmd(event)) {
       editorActions.trigger('selectElements');
 
       return true;
     }
+  }
 
-    // ctrl + f -> search labels
-    if (key === 70 && keyboard.isCmd(modifiers)) {
+  // ctrl + f -> search labels
+  function find(context) {
+
+    var event = context.event;
+
+    if (event.keyCode === 70 && keyboard.isCmd(event)) {
       editorActions.trigger('find');
 
       return true;
     }
+  }
 
-    if (keyboard.hasModifier(modifiers)) {
+  // s -> activate space tool
+  function spaceTool(context) {
+
+    var event = context.event;
+
+    if (keyboard.hasModifier(event)) {
       return;
     }
 
-    // s -> activate space tool
-    if (key === 83) {
+    if (event.keyCode === 83) {
       editorActions.trigger('spaceTool');
 
       return true;
     }
+  }
 
-    // l -> activate lasso tool
-    if (key === 76) {
+  // l -> activate lasso tool
+  function lassoTool(context) {
+
+    var event = context.event;
+
+    if (keyboard.hasModifier(event)) {
+      return;
+    }
+
+    if (event.keyCode === 76) {
       editorActions.trigger('lassoTool');
 
       return true;
     }
+  }
 
-    // h -> activate hand tool
-    if (key === 72) {
+
+  // h -> activate hand tool
+  function handTool(context) {
+
+    var event = context.event;
+
+    if (keyboard.hasModifier(event)) {
+      return;
+    }
+
+    if (event.keyCode === 72) {
       editorActions.trigger('handTool');
 
       return true;
     }
+  }
 
-    // c -> activate global connect tool
-    if (key === 67) {
+  // c -> activate global connect tool
+  function globalConnectTool(context) {
+
+    var event = context.event;
+
+    if (keyboard.hasModifier(event)) {
+      return;
+    }
+
+    if (event.keyCode === 67) {
       editorActions.trigger('globalConnectTool');
 
       return true;
     }
+  }
 
-    // e -> activate direct editing
-    if (key === 69) {
+  // e -> activate direct editing
+  function directEditing(context) {
+
+    var event = context.event;
+
+    if (keyboard.hasModifier(event)) {
+      return;
+    }
+
+    if (event.keyCode === 69) {
       editorActions.trigger('directEditing');
 
       return true;
     }
-  });
+  }
+
+
+  keyboard.addListener(selectAll);
+  keyboard.addListener(find);
+  keyboard.addListener(spaceTool);
+  keyboard.addListener(lassoTool);
+  keyboard.addListener(handTool);
+  keyboard.addListener(globalConnectTool);
+  keyboard.addListener(directEditing);
 }
 
 BpmnKeyBindings.$inject = [

--- a/test/spec/features/keyboard/BpmnKeyBindingsSpec.js
+++ b/test/spec/features/keyboard/BpmnKeyBindingsSpec.js
@@ -7,6 +7,8 @@ import {
 
 import TestContainer from 'mocha-test-container-support';
 
+import { forEach } from 'min-dash';
+
 import coreModule from 'lib/core';
 import editorActionsModule from 'lib/features/editor-actions';
 import keyboardModule from 'lib/features/keyboard';
@@ -43,102 +45,128 @@ describe('features - keyboard', function() {
     }));
 
 
-    it('should trigger lasso tool', inject(function(keyboard, globalConnect) {
+    forEach(['c', 'C'], function(key) {
 
-      sinon.spy(globalConnect, 'toggle');
+      it('should global connect tool for key ' + key, inject(function(keyboard, globalConnect) {
 
-      // given
-      var e = createKeyEvent(container, 67, false);
+        sinon.spy(globalConnect, 'toggle');
 
-      // when
-      keyboard._keyHandler(e);
+        // given
+        var e = createKeyEvent(container, key, false);
 
-      // then
-      expect(globalConnect.toggle.calledOnce).to.be.true;
-    }));
+        // when
+        keyboard._keyHandler(e);
 
+        // then
+        expect(globalConnect.toggle.calledOnce).to.be.true;
+      }));
 
-    it('should trigger lasso tool', inject(function(keyboard, lassoTool) {
-
-      sinon.spy(lassoTool, 'activateSelection');
-
-      // given
-      var e = createKeyEvent(container, 76, false);
-
-      // when
-      keyboard._keyHandler(e);
-
-      // then
-      expect(lassoTool.activateSelection.calledOnce).to.be.true;
-    }));
+    });
 
 
-    it('should trigger space tool', inject(function(keyboard, spaceTool) {
+    forEach(['l', 'L'], function(key) {
 
-      sinon.spy(spaceTool, 'activateSelection');
+      it('should trigger lasso tool for key ' + key, inject(function(keyboard, lassoTool) {
 
-      // given
-      var e = createKeyEvent(container, 83, false);
+        sinon.spy(lassoTool, 'activateSelection');
 
-      // when
-      keyboard._keyHandler(e);
+        // given
+        var e = createKeyEvent(container, key, false);
 
-      // then
-      expect(spaceTool.activateSelection.calledOnce).to.be.true;
-    }));
+        // when
+        keyboard._keyHandler(e);
 
+        // then
+        expect(lassoTool.activateSelection.calledOnce).to.be.true;
+      }));
 
-    it('should trigger direct editing', inject(function(keyboard, selection, elementRegistry, directEditing) {
-
-      sinon.spy(directEditing, 'activate');
-
-      // given
-      var task = elementRegistry.get('Task_1');
-
-      selection.select(task);
-
-      var e = createKeyEvent(container, 69, false);
-
-      // when
-      keyboard._keyHandler(e);
-
-      // then
-      expect(directEditing.activate.calledOnce).to.be.true;
-    }));
+    });
 
 
-    it('should select all elements', inject(function(canvas, keyboard, selection, elementRegistry) {
+    forEach(['s', 'S'], function(key) {
 
-      // given
-      var e = createKeyEvent(container, 65, true);
+      it('should trigger space tool', inject(function(keyboard, spaceTool) {
 
-      var allElements = elementRegistry.getAll(),
-          rootElement = canvas.getRootElement();
+        sinon.spy(spaceTool, 'activateSelection');
 
-      // when
-      keyboard._keyHandler(e);
+        // given
+        var e = createKeyEvent(container, key, false);
 
-      // then
-      var selectedElements = selection.get();
+        // when
+        keyboard._keyHandler(e);
 
-      expect(selectedElements).to.have.length(allElements.length - 1);
-      expect(selectedElements).not.to.contain(rootElement);
-    }));
+        // then
+        expect(spaceTool.activateSelection.calledOnce).to.be.true;
+      }));
+
+    });
 
 
-    it('should trigger search for labels', inject(function(canvas, keyboard, searchPad, elementRegistry) {
+    forEach(['e', 'E'], function(key) {
 
-      sinon.spy(searchPad, 'toggle');
+      it('should trigger direct editing', inject(function(keyboard, selection, elementRegistry, directEditing) {
 
-      // given
-      var e = createKeyEvent(container, 70, true);
+        sinon.spy(directEditing, 'activate');
 
-      // when
-      keyboard._keyHandler(e);
+        // given
+        var task = elementRegistry.get('Task_1');
 
-      // then
-      expect(searchPad.toggle).calledOnce;
-    }));
+        selection.select(task);
+
+        var e = createKeyEvent(container, key, false);
+
+        // when
+        keyboard._keyHandler(e);
+
+        // then
+        expect(directEditing.activate.calledOnce).to.be.true;
+      }));
+
+    });
+
+
+    forEach(['a', 'A'], function(key) {
+
+      it('should select all elements',
+        inject(function(canvas, keyboard, selection, elementRegistry) {
+
+          // given
+          var e = createKeyEvent(container, key, true);
+
+          var allElements = elementRegistry.getAll(),
+              rootElement = canvas.getRootElement();
+
+          // when
+          keyboard._keyHandler(e);
+
+          // then
+          var selectedElements = selection.get();
+
+          expect(selectedElements).to.have.length(allElements.length - 1);
+          expect(selectedElements).not.to.contain(rootElement);
+        })
+      );
+
+    });
+
+
+    forEach(['f', 'F'], function(key) {
+
+      it('should trigger search for labels', inject(function(keyboard, searchPad) {
+
+        sinon.spy(searchPad, 'toggle');
+
+        // given
+        var e = createKeyEvent(container, key, true);
+
+        // when
+        keyboard._keyHandler(e);
+
+        // then
+        expect(searchPad.toggle).calledOnce;
+      }));
+
+    });
 
   });
 

--- a/test/util/KeyEvents.js
+++ b/test/util/KeyEvents.js
@@ -1,8 +1,9 @@
-export function createKeyEvent(element, code, ctrlKey) {
+export function createKeyEvent(element, key, ctrlKey) {
   var e = document.createEvent('Events') || new document.defaultView.CustomEvent('keyEvent');
 
-  e.keyCode = code;
-  e.which = code;
+  e.key = key;
+  e.keyCode = key;
+  e.which = key;
   e.ctrlKey = ctrlKey;
 
   return e;


### PR DESCRIPTION
This PR activates `KeyboardNavigation` and `MoveSelection` features added in `diagram-js` per default.

Note to reviewer: 
Includes changes in https://github.com/bpmn-io/bpmn-js/pull/885. Review the linked PR first.

Closes #376 