### PR TITLE
fix(Modeler): use correct copy-paste-module

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -17,7 +17,7 @@ import AutoResizeModule from './features/auto-resize';
 import AutoScrollModule from 'diagram-js/lib/features/auto-scroll';
 import BendpointsModule from 'diagram-js/lib/features/bendpoints';
 import ContextPadModule from './features/context-pad';
-import CopyPasteModule from 'diagram-js/lib/features/copy-paste';
+import CopyPasteModule from './features/copy-paste';
 import DistributeElementsModule from './features/distribute-elements';
 import EditorActionsModule from './features/editor-actions';
 import KeyboardModule from './features/keyboard';

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -463,6 +463,41 @@ describe('Modeler', function() {
 
     });
 
+    it('should inject mandatory modules', function(done) {
+
+      // given
+      var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      // when
+      createModeler(xml, function(err, warnings, modeler) {
+
+        // then
+        expect(modeler.get('alignElements')).to.exist;
+        expect(modeler.get('autoPlace')).to.exist;
+        expect(modeler.get('bpmnAutoResize')).to.exist;
+        expect(modeler.get('autoScroll')).to.exist;
+        expect(modeler.get('bendpoints')).to.exist;
+        expect(modeler.get('bpmnCopyPaste')).to.exist;
+        expect(modeler.get('bpmnSearch')).to.exist;
+        expect(modeler.get('contextPad')).to.exist;
+        expect(modeler.get('copyPaste')).to.exist;
+        expect(modeler.get('alignElements')).to.exist;
+        expect(modeler.get('distributeElements')).to.exist;
+        expect(modeler.get('editorActions')).to.exist;
+        expect(modeler.get('keyboard')).to.exist;
+        expect(modeler.get('keyboardMoveSelection')).to.exist;
+        expect(modeler.get('labelEditingProvider')).to.exist;
+        expect(modeler.get('modeling')).to.exist;
+        expect(modeler.get('move')).to.exist;
+        expect(modeler.get('paletteProvider')).to.exist;
+        expect(modeler.get('resize')).to.exist;
+        expect(modeler.get('snapping')).to.exist;
+
+        done(err);
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
This fixes the missing paste-functionality by adding the correct `BpmnCopyPaste` module.

Also adds a regression test for this kind of bug.

Fixes #900 