### PR TITLE
feat: Autoresizing labels based on its content size

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -471,8 +471,8 @@ export default function BpmnRenderer(
   function renderExternalLabel(parentGfx, element) {
     var semantic = getSemantic(element);
     var box = {
-      width: 90,
-      height: 30,
+      width: !element.width ? 90 : element.width,
+      height: !element.height ? 30 : element.height,
       x: element.width / 2 + element.x,
       y: element.height / 2 + element.y
     };

--- a/lib/draw/TextRenderer.js
+++ b/lib/draw/TextRenderer.js
@@ -40,8 +40,8 @@ export default function TextRenderer(config) {
 
     var layoutedDimensions = textUtil.getDimensions(text, {
       box: {
-        width: 90,
-        height: 30,
+        width: !bounds.width ? 90 : bounds.width,
+        height: !bounds.height ? 30 : bounds.height,
         x: bounds.width / 2 + bounds.x,
         y: bounds.height / 2 + bounds.y
       },


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Closes #

This is actually coming from this forum post: https://forum.bpmn.io/t/name-of-textannotation-resize-eventhandler/2646/4 because Niklas_Kiefer suggested to create a PR.
The implementation is not mine as you can see in the forum so all credit goes to jclaxton. I am just doing this pull request bec. I also need this feature.

However I ran npm test and see that 4 tests are failing after these modifications.
These:
should expand width
should reduce height
should remain the same
should keep label position

If you ask me I would delete those test cases from now on, but I am open to any other proposal how to fix the tests.