### PR TITLE
improvement: generate native javascript module distributions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7481,6 +7481,79 @@
         "rollup-pluginutils": "^2.0.1"
       }
     },
+    "rollup-plugin-terser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^1.6.1",
+        "terser": "^3.14.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "24.3.1",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.3.1.tgz",
+          "integrity": "sha512-ZCoAe/iGLzTJvWHrO8fyx3bmEQhpL16SILJmWHKe8joHhyF3z00psF1sCRT54DoHw5GJG0ZpUtGy+ylvwA4haA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^1.0.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+          "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "terser": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+          "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.19.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.10"
+          }
+        }
+      }
+    },
     "rollup-plugin-uglify": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "rollup-plugin-license": "^0.7.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-uglify": "^6.0.0",
     "sinon": "^7.1.0",
     "sinon-chai": "^3.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
 import license from 'rollup-plugin-license';
 import replace from 'rollup-plugin-replace';
+import { terser } from 'rollup-plugin-terser';
 
 import {
   readFileSync
@@ -57,6 +58,33 @@ const configs = distros.reduce(function(configs, distro) {
       plugins: pgl([
         banner(output, true),
         uglify({
+          output: {
+            comments: /license|@preserve/
+          }
+        })
+      ])
+    },
+    {
+      input: `./lib/${input}.js`,
+      output: {
+        name: 'BpmnJS',
+        file: `${outputDir}/${output}.esm.development.js`,
+        format: 'es'
+      },
+      plugins: pgl([
+        banner(output)
+      ])
+    },
+    {
+      input: `./lib/${input}.js`,
+      output: {
+        name: 'BpmnJS',
+        file: `${outputDir}/${output}.esm.production.min.js`,
+        format: 'es'
+      },
+      plugins: pgl([
+        banner(output, true),
+        terser({
           output: {
             comments: /license|@preserve/
           }

--- a/tasks/test-distro.js
+++ b/tasks/test-distro.js
@@ -3,6 +3,19 @@ var execSync = require('execa').sync;
 var failures = 0;
 
 function runTest(variant, env, isModule = false) {
+  // when running distro tests for JavaScript modules PhantomJS is not supported.
+  // If there is not at least one browser left then skip the test.
+  var browsers = (process.env.TEST_BROWSERS || 'PhantomJS')
+    .replace(/^\s+|\s+$/, '')
+    .split(/\s*,\s*/g)
+    .filter(browser => !isModule || (isModule && browser != 'PhantomJS'));
+
+  if (browsers.length === 0) {
+    console.log('[SKIPPED] ' + variant + '@' + env + ' :: No supported browser specified');
+    return;
+  }
+
+  process.env.TEST_BROWSERS = browsers.join(',');
 
   var NODE_ENV = process.env.NODE_ENV;
 

--- a/tasks/test-distro.js
+++ b/tasks/test-distro.js
@@ -2,12 +2,13 @@ var execSync = require('execa').sync;
 
 var failures = 0;
 
-function runTest(variant, env) {
+function runTest(variant, env, isModule = false) {
 
   var NODE_ENV = process.env.NODE_ENV;
 
   process.env.VARIANT = variant;
   process.env.NODE_ENV = env;
+  process.env.IS_MODULE = isModule;
 
   console.log('[TEST] ' + variant + '@' + env);
 
@@ -28,11 +29,20 @@ function test() {
   runTest('bpmn-modeler', 'development');
   runTest('bpmn-modeler', 'production');
 
+  runTest('bpmn-modeler.esm', 'development', true);
+  runTest('bpmn-modeler.esm', 'production', true);
+
   runTest('bpmn-navigated-viewer', 'development');
   runTest('bpmn-navigated-viewer', 'production');
 
+  runTest('bpmn-navigated-viewer.esm', 'development', true);
+  runTest('bpmn-navigated-viewer.esm', 'production', true);
+
   runTest('bpmn-viewer', 'development');
   runTest('bpmn-viewer', 'production');
+
+  runTest('bpmn-viewer.esm', 'development', true);
+  runTest('bpmn-viewer.esm', 'production', true);
 
   if (failures) {
     process.exit(1);

--- a/test/config/karma.distro.js
+++ b/test/config/karma.distro.js
@@ -24,6 +24,8 @@ var VARIANT = process.env.VARIANT;
 
 var NODE_ENV = process.env.NODE_ENV;
 
+var IS_MODULE = (process.env.IS_MODULE == 'true');
+
 module.exports = function(karma) {
   karma.set({
 
@@ -35,13 +37,13 @@ module.exports = function(karma) {
     ],
 
     files: [
-      'dist/' + VARIANT + '.' + (NODE_ENV === 'production' ? 'production.min' : 'development') + '.js',
+      { pattern: 'dist/' + VARIANT + '.' + (NODE_ENV === 'production' ? 'production.min' : 'development') + '.js', type: IS_MODULE ? 'module' : 'js' },
       'dist/assets/bpmn-font/css/bpmn.css',
       'dist/assets/diagram-js.css',
       { pattern: 'resources/initial.bpmn', included: false },
       { pattern: 'dist/assets/**/*', included: false },
       'test/distro/helper.js',
-      'test/distro/' + VARIANT + '.js'
+      { pattern: 'test/distro/' + VARIANT + (IS_MODULE ? '.' + (NODE_ENV === 'production' ? 'production.min' : 'development') : '') + '.js', type: IS_MODULE ? 'module' : 'js' }
     ],
 
     reporters: [ 'progress' ],

--- a/test/distro/bpmn-modeler.esm.development.js
+++ b/test/distro/bpmn-modeler.esm.development.js
@@ -1,0 +1,28 @@
+import BpmnJS from '/base/dist/bpmn-modeler.esm.development.js';
+
+describe('bpmn-modeler.esm', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should expose Viewer and NavigatedViewer', function() {
+    // then
+    expect(BpmnJS.NavigatedViewer).to.exist;
+    expect(new BpmnJS.NavigatedViewer()).to.exist;
+
+    expect(BpmnJS.Viewer).to.exist;
+    expect(new BpmnJS.Viewer()).to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});

--- a/test/distro/bpmn-modeler.esm.production.min.js
+++ b/test/distro/bpmn-modeler.esm.production.min.js
@@ -1,0 +1,28 @@
+import BpmnJS from '/base/dist/bpmn-modeler.esm.production.min.js';
+
+describe('bpmn-modeler.esm', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should expose Viewer and NavigatedViewer', function() {
+    // then
+    expect(BpmnJS.NavigatedViewer).to.exist;
+    expect(new BpmnJS.NavigatedViewer()).to.exist;
+
+    expect(BpmnJS.Viewer).to.exist;
+    expect(new BpmnJS.Viewer()).to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});

--- a/test/distro/bpmn-navigated-viewer.esm.development.js
+++ b/test/distro/bpmn-navigated-viewer.esm.development.js
@@ -1,0 +1,24 @@
+import BpmnJS from '/base/dist/bpmn-navigated-viewer.esm.development.js';
+
+describe('bpmn-navigated-viewer', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should expose Viewer', function() {
+    // then
+    expect(BpmnJS.Viewer).not.to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});

--- a/test/distro/bpmn-navigated-viewer.esm.production.min.js
+++ b/test/distro/bpmn-navigated-viewer.esm.production.min.js
@@ -1,0 +1,24 @@
+import BpmnJS from '/base/dist/bpmn-navigated-viewer.esm.production.min.js';
+
+describe('bpmn-navigated-viewer', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should expose Viewer', function() {
+    // then
+    expect(BpmnJS.Viewer).not.to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});

--- a/test/distro/bpmn-viewer.esm.development.js
+++ b/test/distro/bpmn-viewer.esm.development.js
@@ -1,0 +1,18 @@
+import BpmnJS from '/base/dist/bpmn-viewer.esm.development.js';
+
+describe('bpmn-navigated-viewer', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});

--- a/test/distro/bpmn-viewer.esm.production.min.js
+++ b/test/distro/bpmn-viewer.esm.production.min.js
@@ -1,0 +1,18 @@
+import BpmnJS from '/base/dist/bpmn-viewer.esm.production.min.js';
+
+describe('bpmn-navigated-viewer', function() {
+
+  it('should expose globals', function() {
+    // then
+    expect(BpmnJS).to.exist;
+    expect(new BpmnJS()).to.exist;
+  });
+
+
+  it('should import initial diagram', function(done) {
+    // then
+    /* global testImport */
+    testImport(BpmnJS, done);
+  });
+
+});


### PR DESCRIPTION
Hello, this pull request will generate native JavaScript module distributions that can be directly included using e.g. import BpmnJS from '/bpmn-modeler.esm.development.js';

My use case is to be able to use the distribution directly without requiring a separate bundler.