### PR TITLE
WIP Basic group moving

### DIFF
--- a/lib/features/modeling/behavior/DropIntoGroupBehavior.js
+++ b/lib/features/modeling/behavior/DropIntoGroupBehavior.js
@@ -1,0 +1,52 @@
+import inherits from 'inherits';
+
+import {
+  is
+} from '../../../util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+
+export default function DropIntoGroupBehavior(eventBus) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this.preExecute('elements.move', function(context) {
+
+    var newParent = context.newParent;
+
+    // if the new parent is a group,
+    // change it to the new parent's parent
+    if (newParent && isGroup(newParent)) {
+      context.newParent = newParent.parent;
+    }
+
+  }, true);
+
+  this.preExecute('shape.create', function(context) {
+
+    var parent = context.parent;
+
+    // if the parent is a group,
+    // change it to the parent's parent
+    if (parent && isGroup(parent)) {
+      context.parent = parent.parent;
+    }
+
+  }, true);
+
+}
+
+inherits(DropIntoGroupBehavior, CommandInterceptor);
+
+DropIntoGroupBehavior.$inject = [
+  'eventBus'
+];
+
+
+// helpers /////////////////////
+
+function isGroup(element) {
+  return is(element, 'bpmn:Group');
+}
+

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -9,6 +9,7 @@ import DataInputAssociationBehavior from './DataInputAssociationBehavior';
 import DataStoreBehavior from './DataStoreBehavior';
 import DeleteLaneBehavior from './DeleteLaneBehavior';
 import DropOnFlowBehavior from './DropOnFlowBehavior';
+import DropIntoGroupBehavior from './DropIntoGroupBehavior';
 import ImportDockingFix from './ImportDockingFix';
 import IsHorizontalFix from './IsHorizontalFix';
 import LabelBehavior from './LabelBehavior';
@@ -36,6 +37,7 @@ export default {
     'dataInputAssociationBehavior',
     'deleteLaneBehavior',
     'dropOnFlowBehavior',
+    'dropIntoGroupBehavior',
     'importDockingFix',
     'isHorizontalFix',
     'labelBehavior',
@@ -61,6 +63,7 @@ export default {
   dataStoreBehavior: [ 'type', DataStoreBehavior ],
   deleteLaneBehavior: [ 'type', DeleteLaneBehavior ],
   dropOnFlowBehavior: [ 'type', DropOnFlowBehavior ],
+  dropIntoGroupBehavior: [ 'type', DropIntoGroupBehavior ],
   importDockingFix: [ 'type', ImportDockingFix ],
   isHorizontalFix: [ 'type', IsHorizontalFix ],
   labelBehavior: [ 'type', LabelBehavior ],

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -254,6 +254,10 @@ function isTextAnnotation(element) {
   return is(element, 'bpmn:TextAnnotation');
 }
 
+function isGroup(element) {
+  return is(element, 'bpmn:Group');
+}
+
 function isCompensationBoundary(element) {
   return is(element, 'bpmn:BoundaryEvent') &&
          hasEventDefinition(element, 'bpmn:CompensateEventDefinition');
@@ -449,13 +453,18 @@ function canDrop(element, target, position) {
     return true;
   }
 
+  // allow to create inside group
+  if (is(element, 'bpmn:FlowElement') && isGroup(target)) {
+    return true;
+  }
+
   // disallow to create elements on collapsed pools
   if (is(target, 'bpmn:Participant') && !isExpanded(target)) {
     return false;
   }
 
   // allow to create new participants on
-  // on existing collaboration and process diagrams
+  // existing collaboration and process diagrams
   if (is(element, 'bpmn:Participant')) {
     return is(target, 'bpmn:Process') || is(target, 'bpmn:Collaboration');
   }

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -786,6 +786,10 @@ function canResize(shape, newBounds) {
     return true;
   }
 
+  if (isGroup(shape)) {
+    return true;
+  }
+
   return false;
 }
 

--- a/test/spec/features/modeling/behavior/DropIntoGroupBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/DropIntoGroupBehavior.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:signavio="http://www.signavio.com" xmlns:tns="http://www.signavio.com/bpmn20" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:yaoqiang="http://bpmn.sourceforge.net" id="sid-0fcc2144-457b-4505-9e44-ff673663e3bc" name="" targetNamespace="http://www.signavio.com/bpmn20" exporter="Camunda Modeler" exporterVersion="3.0.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <category id="Category_1">
+    <categoryValue id="CategoryValue_1" value="group" />
+  </category>
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_1" />
+    <group id="Group_1" categoryValueRef="CategoryValue_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="Group_1">
+        <omgdc:Bounds x="189" y="62" width="400" height="254" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="276" y="98" width="58" height="18.96" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="125" y="116" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" />
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/modeling/behavior/DropIntoGroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/DropIntoGroupBehaviorSpec.js
@@ -1,0 +1,116 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import moveModule from 'diagram-js/lib/features/move';
+import modelingModule from 'lib/features/modeling';
+
+import {
+  createCanvasEvent as canvasEvent
+} from '../../../../util/MockEvents';
+
+
+describe('modeling/behavior - drop into group', function() {
+
+  var diagramXML = require('./DropIntoGroupBehavior.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      moveModule,
+      modelingModule,
+      coreModule
+    ]
+  }));
+
+
+  describe('execution', function() {
+
+    describe('create', function() {
+
+      it('should drop shape into group', inject(
+        function(modeling, elementRegistry, elementFactory) {
+
+          // given
+          var intermediateThrowEvent = elementFactory.createShape({
+            type: 'bpmn:IntermediateThrowEvent'
+          });
+
+          var group = elementRegistry.get('Group_1');
+
+          var dropPosition = { x: 300, y: 100 };
+
+          // when
+          var newShape = modeling.createShape(
+            intermediateThrowEvent,
+            dropPosition,
+            group
+          );
+
+          // then
+          expect(newShape).to.exist;
+          expect(isPointInsideBBox(group, newShape));
+          expect(newShape.parent).to.not.eql(group);
+          expect(newShape.parent).to.eql(group.parent);
+        }
+      ));
+
+    });
+
+
+    describe('move', function() {
+
+      beforeEach(inject(function(dragging) {
+        dragging.setOptions({ manual: true });
+      }));
+
+      it('should drop shape into group', inject(
+        function(dragging, move, elementRegistry, selection) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_1');
+
+          var group = elementRegistry.get('Group_1'),
+              groupGfx = elementRegistry.getGraphics(group);
+
+          // when
+
+          selection.select(startEvent);
+
+          move.start(canvasEvent({ x: 0, y: 0 }), startEvent);
+
+          dragging.hover({
+            element: group,
+            gfx: groupGfx
+          });
+
+          dragging.move(canvasEvent({ x: 100, y: 0 }));
+          dragging.end();
+
+          // then
+          // todo(pinussilvestrus): expect to be inside group bounds
+          expect(isPointInsideBBox(group, startEvent));
+          expect(startEvent.parent).to.not.eql(group);
+          expect(startEvent.parent).to.eql(group.parent);
+        }
+      ));
+
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////
+
+function isPointInsideBBox(bbox, point) {
+  var x = point.x,
+      y = point.y;
+
+  return x >= bbox.x &&
+      x <= bbox.x + bbox.width &&
+      y >= bbox.y &&
+      y <= bbox.y + bbox.height;
+}

--- a/test/spec/features/rules/BpmnRules.groups.bpmn
+++ b/test/spec/features/rules/BpmnRules.groups.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:signavio="http://www.signavio.com" xmlns:tns="http://www.signavio.com/bpmn20" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:yaoqiang="http://bpmn.sourceforge.net" id="sid-0fcc2144-457b-4505-9e44-ff673663e3bc" name="" targetNamespace="http://www.signavio.com/bpmn20" exporter="Camunda Modeler" exporterVersion="3.0.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <category id="Category_1">
+    <categoryValue id="CategoryValue_1" value="group" />
+  </category>
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_1" />
+    <task id="Task_1" />
+    <subProcess id="SubProcess_1" />
+    <group id="Group_1" categoryValueRef="CategoryValue_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="Group_1">
+        <omgdc:Bounds x="189" y="62" width="400" height="254" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="276" y="98" width="58" height="18.96" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="296" y="379" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_3" bpmnElement="Task_1">
+        <omgdc:Bounds x="370" y="357" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_4" bpmnElement="SubProcess_1" isExpanded="false">
+        <omgdc:Bounds x="501" y="357" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SubProcess_1" />
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1575,6 +1575,23 @@ describe('features/modeling/rules - BpmnRules', function() {
     });
 
 
+    describe('should resize', function() {
+
+      it('Group', inject(function(bpmnRules, elementRegistry) {
+
+        // given
+        var groupElement = elementRegistry.get('Group_1');
+
+        // when
+        var canResize = bpmnRules.canResize(groupElement);
+
+        // then
+        expect(canResize).to.be.true;
+      }));
+
+    });
+
+
     describe('should allow drop', function() {
 
       it('[any Element] -> Group', inject(function(elementRegistry, bpmnRules) {

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1532,6 +1532,73 @@ describe('features/modeling/rules - BpmnRules', function() {
   });
 
 
+  describe('groups', function() {
+
+    var testXML = require('./BpmnRules.groups.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+
+    describe('should allow add', function() {
+
+      it('[any Element] -> Group', inject(function(elementFactory, elementRegistry, bpmnRules) {
+
+        // given
+        var groupElement = elementRegistry.get('Group_1');
+
+        var shapes = [
+          elementFactory.createShape({
+            type: 'bpmn:StartEvent',
+            x: 0, y: 0
+          }),
+          elementFactory.createShape({
+            type: 'bpmn:SubProcess',
+            x: 200, y: 200
+          }),
+          elementFactory.createShape({
+            type: 'bpmn:Task',
+            x: 100, y: 100
+          })
+        ];
+
+        shapes.forEach(function(s) {
+
+          // when
+          var canCreate = bpmnRules.canCreate(s, groupElement);
+
+          // then
+          expect(canCreate).to.be.true;
+        });
+
+      }));
+
+    });
+
+
+    describe('should allow drop', function() {
+
+      it('[any Element] -> Group', inject(function(elementRegistry, bpmnRules) {
+
+        // given
+        var startEventElement = elementRegistry.get('StartEvent_1'),
+            subProcessElement = elementRegistry.get('SubProcess_1'),
+            taskElement = elementRegistry.get('Task_1'),
+            groupElement = elementRegistry.get('Group_1');
+
+        // when
+        var canMove = bpmnRules.canMove([
+          startEventElement,
+          subProcessElement,
+          taskElement
+        ], groupElement);
+
+        // then
+        expect(canMove).to.be.true;
+      }));
+    });
+  });
+
+
   describe('lanes', function() {
 
     var testXML = require('./BpmnRules.collaboration-lanes.bpmn');


### PR DESCRIPTION
This pull request starts the general implementation of `bpmn:Group` support. Therefore it fixes the following issues:

- Closes #959 
- Closes #956 

![Apr-03-2019 08-49-28](https://user-images.githubusercontent.com/9433996/55458499-6f094780-55ed-11e9-8a9a-6517285be044.gif)

**Note:** The changes come with several modeling trade-offs regarding group elements for now, e.g.

![Apr-03-2019 08-55-21](https://user-images.githubusercontent.com/9433996/55458823-50f01700-55ee-11e9-8114-f299066c27f2.gif)

One approach would be to simply increase the order of a group element (e.g. in this [example branch](https://github.com/bpmn-io/bpmn-js/commits/group-experiments)). But, since group elements have always to act in the background and they have to be rendered on top otherwise, will we need to implement a completely new type of shapes, which are only draggable in the background and are kind of empty inside (cf. #960, #957). This will follow in another pull request, which needs the current changes as its base.



