### PR TITLE
Task resizing

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -39,15 +39,17 @@ import {
 /**
  * BPMN specific modeling rule
  */
-export default function BpmnRules(eventBus) {
+export default function BpmnRules(eventBus, taskOptions) {
   RuleProvider.call(this, eventBus);
+  this.taskOptions=taskOptions || {};
 }
 
 inherits(BpmnRules, RuleProvider);
 
-BpmnRules.$inject = [ 'eventBus' ];
+BpmnRules.$inject = [ 'eventBus', 'config.taskOptions' ];
 
 BpmnRules.prototype.init = function() {
+  var me=this;
 
   this.addRule('connection.start', function(context) {
     var source = context.source;
@@ -113,7 +115,7 @@ BpmnRules.prototype.init = function() {
     var shape = context.shape,
         newBounds = context.newBounds;
 
-    return canResize(shape, newBounds);
+    return canResize.call(me, shape, newBounds);
   });
 
   this.addRule('elements.move', function(context) {
@@ -774,6 +776,11 @@ function canResize(shape, newBounds) {
   }
 
   if (isTextAnnotation(shape)) {
+    return true;
+  }
+
+  if (this.taskOptions.resizeEnabled && is(shape, 'bpmn:Task') && (
+        !newBounds || (newBounds.width >= 100 && newBounds.height >= 80))) {
     return true;
   }
 

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -779,8 +779,11 @@ function canResize(shape, newBounds) {
     return true;
   }
 
-  if (this.taskOptions.resizeEnabled && is(shape, 'bpmn:Task') && (
-        !newBounds || (newBounds.width >= 100 && newBounds.height >= 80))) {
+  if (this.taskOptions.resizeEnabled && is(shape, 'bpmn:Task')) {
+    if (newBounds) { 
+      newBounds.width=Math.max(100,newBounds.width);
+      newBounds.height=Math.max(80,newBounds.height);
+    }
     return true;
   }
 

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -780,7 +780,7 @@ function canResize(shape, newBounds) {
   }
 
   if (this.taskOptions.resizeEnabled && is(shape, 'bpmn:Task')) {
-    if (newBounds) { 
+    if (newBounds) {
       newBounds.width=Math.max(100,newBounds.width);
       newBounds.height=Math.max(80,newBounds.height);
     }


### PR DESCRIPTION
This PR wants to add the ability to resize tasks in the diagram.
The functionality is enabled through a special option:

`
var viewer = new BpmnJS({
  container: 'body', 
  taskOptions: {
    resizeEnabled: true
  }
});
`

This feature is essential if you consider that through the editor BPMN-JS you can also open diagrams written with other editors.
You may need to adjust the size of tasks altered by other editors.