### PR TITLE
Added support to different diagrams per XML file

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -6,6 +6,8 @@
  */
 import {
   assign,
+  find,
+  isFunction,
   isNumber,
   omit
 } from 'min-dash';
@@ -64,6 +66,26 @@ var DEFAULT_OPTIONS = {
  */
 function ensureUnit(val) {
   return val + (isNumber(val) ? 'px' : '');
+}
+
+
+/**
+ *
+ * Find BPMNDiagram in definitions by ID
+ *
+ * @param {ModdleElement} definitions
+ * @param {String} diagramId
+ *
+ * @return {Diagram|undefined}
+ */
+function findDiagram(definitions, diagramId) {
+  if (!diagramId) {
+    return;
+  }
+
+  return find(definitions.diagrams, function(element) {
+    return element.id === diagramId;
+  });
 }
 
 /**
@@ -152,9 +174,15 @@ inherits(Viewer, Diagram);
  * You can use these events to hook into the life-cycle.
  *
  * @param {String} xml the BPMN 2.0 xml
+ * @param {String} [diagramId] id of the diagram to render (if not provided, the first one will be rendered)
  * @param {Function} [done] invoked with (err, warnings=[])
  */
-Viewer.prototype.importXML = function(xml, done) {
+Viewer.prototype.importXML = function(xml, diagramId, done) {
+
+  if (isFunction(diagramId)) {
+    done = diagramId;
+    diagramId = null;
+  }
 
   // done is optional
   done = done || function() {};
@@ -175,7 +203,8 @@ Viewer.prototype.importXML = function(xml, done) {
       context: context
     }) || definitions;
 
-    var parseWarnings = context.warnings;
+    var parseWarnings = context.warnings,
+        diagram;
 
     if (err) {
       err = checkValidationError(err);
@@ -185,7 +214,17 @@ Viewer.prototype.importXML = function(xml, done) {
       return done(err, parseWarnings);
     }
 
-    self.importDefinitions(definitions, function(err, importWarnings) {
+    diagram = findDiagram(definitions, diagramId);
+
+    if (diagramId && !diagram) {
+      err = new Error('BPMNDiagram not found');
+
+      self._emit('import.done', { error: err, warnings: parseWarnings || [] });
+
+      return done(err);
+    }
+
+    self.importDefinitions(definitions, diagram, function(err, importWarnings) {
       var allWarnings = [].concat(parseWarnings, importWarnings || []);
 
       self._emit('import.done', { error: err, warnings: allWarnings });
@@ -354,7 +393,12 @@ Viewer.prototype.saveSVG = function(options, done) {
  * @method Viewer#clear
  */
 
-Viewer.prototype.importDefinitions = function(definitions, done) {
+Viewer.prototype.importDefinitions = function(definitions, diagram, done) {
+
+  if (isFunction(diagram)) {
+    done = diagram;
+    diagram = null;
+  }
 
   // catch synchronous exceptions during #clear()
   try {
@@ -370,7 +414,7 @@ Viewer.prototype.importDefinitions = function(definitions, done) {
   }
 
   // perform graphical import
-  return importBpmnDiagram(this, definitions, done);
+  return importBpmnDiagram(this, definitions, diagram, done);
 };
 
 Viewer.prototype.getModules = function() {

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -76,16 +76,16 @@ function ensureUnit(val) {
  * @param {ModdleElement} definitions
  * @param {String} diagramId
  *
- * @return {Diagram|undefined}
+ * @return {Diagram|null}
  */
 function findDiagram(definitions, diagramId) {
   if (!diagramId) {
-    return;
+    return null;
   }
 
   return find(definitions.diagrams, function(element) {
     return element.id === diagramId;
-  });
+  }) || null;
 }
 
 /**
@@ -203,8 +203,7 @@ Viewer.prototype.importXML = function(xml, diagramId, done) {
       context: context
     }) || definitions;
 
-    var parseWarnings = context.warnings,
-        diagram;
+    var parseWarnings = context.warnings;
 
     if (err) {
       err = checkValidationError(err);
@@ -214,17 +213,9 @@ Viewer.prototype.importXML = function(xml, diagramId, done) {
       return done(err, parseWarnings);
     }
 
-    diagram = findDiagram(definitions, diagramId);
+    self._setDefinitions(definitions);
 
-    if (diagramId && !diagram) {
-      err = new Error('BPMNDiagram not found');
-
-      self._emit('import.done', { error: err, warnings: parseWarnings || [] });
-
-      return done(err);
-    }
-
-    self.importDefinitions(definitions, diagram, function(err, importWarnings) {
+    self.open(diagramId, function(err, importWarnings) {
       var allWarnings = [].concat(parseWarnings, importWarnings || []);
 
       self._emit('import.done', { error: err, warnings: allWarnings });
@@ -232,6 +223,60 @@ Viewer.prototype.importXML = function(xml, diagramId, done) {
       done(err, allWarnings);
     });
   });
+};
+
+/**
+ * Open diagram of previously imported XML.
+ *
+ * Once finished the viewer reports back the result to the
+ * provided callback function with (err, warnings).
+ *
+ * ## Life-Cycle Events
+ *
+ * During switch the viewer will fire life-cycle events:
+ *
+ *   * import.render.start (graphical import start)
+ *   * import.render.complete (graphical import finished)
+ *
+ * You can use these events to hook into the life-cycle.
+ *
+ * @param {String|Diagram} [diagram] id or the diagram to open
+ * @param {Function} [done] invoked with (err, warnings=[])
+ */
+Viewer.prototype.open = function(diagram, done) {
+
+  if (isFunction(diagram)) {
+    done = diagram;
+    diagram = null;
+  }
+
+  var definitions = this._definitions;
+
+  // done is optional
+  done = done || function() {};
+
+  if (!definitions) {
+    return done(new Error('no XML imported'));
+  }
+
+  if (typeof diagram === 'string') {
+    diagram = findDiagram(definitions, diagram);
+
+    if (!diagram) {
+      return done(new Error('no diagram to display'));
+    }
+  }
+
+  // catch synchronous exceptions during #clear()
+  try {
+    // clear existing rendered diagram
+    this.clear();
+  } catch (error) {
+    return done(error);
+  }
+
+  // perform graphical import
+  return importBpmnDiagram(this, definitions, diagram, done);
 };
 
 /**
@@ -393,28 +438,8 @@ Viewer.prototype.saveSVG = function(options, done) {
  * @method Viewer#clear
  */
 
-Viewer.prototype.importDefinitions = function(definitions, diagram, done) {
-
-  if (isFunction(diagram)) {
-    done = diagram;
-    diagram = null;
-  }
-
-  // catch synchronous exceptions during #clear()
-  try {
-    if (this._definitions) {
-      // clear existing rendered diagram
-      this.clear();
-    }
-
-    // update definitions
-    this._definitions = definitions;
-  } catch (e) {
-    return done(e);
-  }
-
-  // perform graphical import
-  return importBpmnDiagram(this, definitions, diagram, done);
+Viewer.prototype._setDefinitions = function(definitions) {
+  this._definitions = definitions;
 };
 
 Viewer.prototype.getModules = function() {

--- a/lib/import/Importer.js
+++ b/lib/import/Importer.js
@@ -1,5 +1,8 @@
 import BpmnTreeWalker from './BpmnTreeWalker';
 
+import {
+  isFunction
+} from 'min-dash';
 
 /**
  * Import the definitions into a diagram.
@@ -8,9 +11,16 @@ import BpmnTreeWalker from './BpmnTreeWalker';
  *
  * @param  {Diagram} diagram
  * @param  {ModdleElement} definitions
+ * @param  {ModdleElement} [selectedDiagram] the BPMNDiagram element selected to be rendered
+ * (if not provided, the first one will be rendered)
  * @param  {Function} done the callback, invoked with (err, [ warning ]) once the import is done
  */
-export function importBpmnDiagram(diagram, definitions, done) {
+export function importBpmnDiagram(diagram, definitions, selectedDiagram, done) {
+
+  if (isFunction(selectedDiagram)) {
+    done = selectedDiagram;
+    selectedDiagram = null;
+  }
 
   var importer,
       eventBus,
@@ -24,8 +34,9 @@ export function importBpmnDiagram(diagram, definitions, done) {
    * all elements you encounter.
    *
    * @param {ModdleElement} definitions
+   * @param {ModdleElement} selectedDiagram
    */
-  function render(definitions) {
+  function render(definitions, selectedDiagram) {
 
     var visitor = {
 
@@ -46,7 +57,7 @@ export function importBpmnDiagram(diagram, definitions, done) {
 
     // traverse BPMN 2.0 document model,
     // starting at definitions
-    walker.handleDefinitions(definitions);
+    walker.handleDefinitions(definitions, selectedDiagram);
   }
 
   try {
@@ -56,7 +67,7 @@ export function importBpmnDiagram(diagram, definitions, done) {
 
     eventBus.fire('import.render.start', { definitions: definitions });
 
-    render(definitions);
+    render(definitions, selectedDiagram);
 
     eventBus.fire('import.render.complete', {
       error: error,

--- a/test/fixtures/bpmn/import/multiple-diagrams.bpmn
+++ b/test/fixtures/bpmn/import/multiple-diagrams.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j4810n" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.1">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:userTask id="Task_1">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn:userTask id="Task_2">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="Task_2" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:process id="Process_2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_2" />
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="StartEvent_2" targetRef="IntermediateThrowEvent_1" />
+    <bpmn:endEvent id="EndEvent_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_5" sourceRef="IntermediateThrowEvent_1" targetRef="EndEvent_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_2" bpmnElement="Process_2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_2">
+        <dc:Bounds x="156" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_1" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="234" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_2">
+        <dc:Bounds x="328" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="192" y="99" />
+        <di:waypoint x="234" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5">
+        <di:waypoint x="270" y="99" />
+        <di:waypoint x="328" y="99" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_Task_1" bpmnElement="Task_1">
+        <dc:Bounds x="242" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_Task_2" bpmnElement="Task_2">
+        <dc:Bounds x="392" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds x="542" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="242" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="342" y="121" />
+        <di:waypoint x="392" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="492" y="121" />
+        <di:waypoint x="542" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/bpmn/multiple-diagrams.bpmn
+++ b/test/fixtures/bpmn/multiple-diagrams.bpmn
@@ -1,0 +1,5976 @@
+<?xml version="1.0" encoding="UTF-8"?><semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:trisofeed="http://trisotech.com/feed" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:ns6421="http://www.boc-group.com" xmlns:rss="http://purl.org/rss/2.0/" xmlns:w4graph="http://www.w4.eu/spec/BPMN/20110930/GRAPH" xmlns:w4="http://www.w4.eu/spec/BPMN/20110701/MODEL" xmlns="http://www.trisotech.com/definitions/_ec02e706-bc3a-499d-87f2-642c48b0d45b" id="_ec02e706-bc3a-499d-87f2-642c48b0d45b" exporter="BPMN Modeler" exporterVersion="5.2.0.201706151320" trisobpmn:logoChoice="None" name="EmployeeOnboarding" targetNamespace="http://www.trisotech.com/definitions/_ec02e706-bc3a-499d-87f2-642c48b0d45b" expressionLanguage="http://www.w3.org/1999/XPath" typeLanguage="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd" w4:version="1.0">
+    <semantic:message itemRef="itemDefAck" name="msgFacilites" id="Bpmn_Message_Usik0AQtEeev4LOvjrydZw"/>
+    <semantic:message itemRef="itemDefAck" name="msgIT" id="Bpmn_Message_m0uSMAQtEeev4LOvjrydZw"/>
+    <semantic:message itemRef="itemDefAck" name="msgPayroll" id="Bpmn_Message_oiVqkAQtEeev4LOvjrydZw"/>
+    <semantic:dataStore isUnlimited="true" itemSubjectRef="itemDefUserManagement" name="User Management" id="_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859"/>
+    <semantic:dataStore isUnlimited="true" itemSubjectRef="itemDefPayrollSystem" name="Payroll system" id="_88bbd82d-e83a-41c9-82c7-4f12e87faa9c"/>
+    <semantic:dataStore isUnlimited="true" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details" id="Bpmn_DataStore_q6Az8AQqEeev4LOvjrydZw"/>
+    <semantic:signal name="Employee_hired_Dept_X" structureRef="itemDefEmployeeDetails" id="signal_584c4307-b03c-4df7-ad30-d606bee9b472"/>
+    <semantic:itemDefinition isCollection="false" itemKind="Information" structureRef="semantic:string" id="itemDefEmployeeDetails"/>
+    <semantic:itemDefinition isCollection="false" itemKind="Information" structureRef="semantic:string" id="itemDefUserManagement"/>
+    <semantic:itemDefinition isCollection="false" itemKind="Information" structureRef="semantic:string" id="itemDefPayrollSystem"/>
+    <semantic:itemDefinition isCollection="false" itemKind="Information" structureRef="semantic:boolean" id="itemDefAck"/>
+    <semantic:collaboration isClosed="true" name="Onboarding employee" id="Collaboration_35ab9b1f-354a-48cb-9b99-f4e448f7b04c">
+        <semantic:extensionElements>
+            <ns6421:modelattributes>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_COMPLIANCE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_PROCESS_MANAGEMENT_MATURITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_MONITORING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_COMPLEXITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_CYCLE_TIME" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="PROCESS_TYPE" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_PREDICTABILITY" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_COST_EFFICIENCY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="MFB_RWF_STATE" lang-independent="v0">
+                    <ns6421:value>Draft</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_POTENTIAL_MATURITY_ANALYSIS_AS_IS_AVERAGE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_RISK_MANAGEMENT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_QUALITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_BUSINSS_VALUE" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" sourcelang="en" novalue="1" notebook="1" name="A_MFB_RWF_VALID_FROM_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="WIDTH">
+                    <ns6421:value>62220</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="GLOBAL_CHOREOGRAPHY_TASK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_CUSTOMER_SATISFACTION" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="KEY_PROCESS" lang-independent="v2">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_PROCESS_FREQUENCY" lang-independent="v5">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" sourcelang="en" novalue="1" notebook="1" name="A_MFB_RWF_RESUBMISSION_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" sourcelang="en" novalue="3" notebook="1" name="A_MFB_RWF_VALID_UNTIL_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="PROCESS_TYPE_ACCORDING_TO_ISO_9000" lang-independent="v4">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_AUDITING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="HEIGHT">
+                    <ns6421:value>15060</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="STRING" sourcelang="pl" novalue="0" notebook="1" name="MFB_RWF_VERSION">
+                    <ns6421:value>0.01</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="A_IT_SUPPORT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="DOUBLE" sourcelang="en" novalue="0" notebook="1" name="CREATION_DATE">
+                    <ns6421:value>1483612400369</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="EXTERNAL_PROCESS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="MFB_RWF_HISTORY"/>
+                <ns6421:record name="A_ATTACHMENT_LIST"/>
+                <ns6421:record name="CHANGE_HISTORY"/>
+                <ns6421:record name="PROCESS_INDICATORS"/>
+                <ns6421:record name="PROCESS_SUPPLIERS___REQUIREMENTS"/>
+                <ns6421:record name="TERMS_ABBREVIATIONS"/>
+                <ns6421:record name="PROCESS_CUSTOMERS___REQUIREMENTS"/>
+                <ns6421:record name="SUGGESTION_FOR_IMPROVEMENT"/>
+            </ns6421:modelattributes>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+                <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                <w4graph:root snapToGuide="true" snapToGrid="true" rulerVisible="true" rulerUnit="Pixels" gridVisible="true">
+                    <Grid spacing="15"/>
+                    <VerticalRuler/>
+                    <HorizontalRuler/>
+                </w4graph:root>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:participant id="_8356359b-4f38-4f3e-8a61-bf5ddbffdcb3" name="Money Bank" processRef="process_8356359b-4f38-4f3e-8a61-bf5ddbffdcb3">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:participant>
+    </semantic:collaboration>
+    <semantic:collaboration isClosed="true" name="IT" id="Collaboration_78d0e7ab-8452-45ec-8a47-6c48a6a32b90">
+        <semantic:extensionElements>
+            <ns6421:modelattributes>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLIANCE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_MANAGEMENT_MATURITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_MONITORING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLEXITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CYCLE_TIME" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PREDICTABILITY" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COST_EFFICIENCY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="MFB_RWF_STATE" lang-independent="v0">
+                    <ns6421:value>Draft</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_POTENTIAL_MATURITY_ANALYSIS_AS_IS_AVERAGE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_RISK_MANAGEMENT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_QUALITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_BUSINSS_VALUE" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_VALID_FROM_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="WIDTH">
+                    <ns6421:value>28050</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="GLOBAL_CHOREOGRAPHY_TASK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CUSTOMER_SATISFACTION" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="KEY_PROCESS" lang-independent="v2">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_FREQUENCY" lang-independent="v5">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_RESUBMISSION_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="3" notebook="1" name="A_MFB_RWF_VALID_UNTIL_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE_ACCORDING_TO_ISO_9000" lang-independent="v4">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_AUDITING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="HEIGHT">
+                    <ns6421:value>13605</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_IT_SUPPORT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="DOUBLE" sourcelang="en" novalue="0" notebook="1" name="CREATION_DATE">
+                    <ns6421:value>1484049748817</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="EXTERNAL_PROCESS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="MFB_RWF_HISTORY"/>
+                <ns6421:record name="A_ATTACHMENT_LIST"/>
+                <ns6421:record name="CHANGE_HISTORY"/>
+                <ns6421:record name="PROCESS_INDICATORS"/>
+                <ns6421:record name="PROCESS_SUPPLIERS___REQUIREMENTS"/>
+                <ns6421:record name="TERMS_ABBREVIATIONS"/>
+                <ns6421:record name="PROCESS_CUSTOMERS___REQUIREMENTS"/>
+                <ns6421:record name="SUGGESTION_FOR_IMPROVEMENT"/>
+            </ns6421:modelattributes>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+                <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                <w4graph:root snapToGuide="true" snapToGrid="true" rulerVisible="true" rulerUnit="Pixels" gridVisible="true">
+                    <Grid spacing="15"/>
+                    <VerticalRuler/>
+                    <HorizontalRuler/>
+                </w4graph:root>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:participant id="_4c3f552f-cd7a-41a7-a6d2-504a0aee7317" name="IT" processRef="process_4c3f552f-cd7a-41a7-a6d2-504a0aee7317">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:participant>
+    </semantic:collaboration>
+    <semantic:collaboration isClosed="true" name="Payroll" id="Collaboration_80fecfcd-0165-4c36-90b6-3ea384265fe7">
+        <semantic:extensionElements>
+            <ns6421:modelattributes>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLIANCE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_MANAGEMENT_MATURITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_MONITORING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLEXITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CYCLE_TIME" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PREDICTABILITY" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COST_EFFICIENCY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="MFB_RWF_STATE" lang-independent="v0">
+                    <ns6421:value>Draft</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_POTENTIAL_MATURITY_ANALYSIS_AS_IS_AVERAGE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_RISK_MANAGEMENT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_QUALITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_BUSINSS_VALUE" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_VALID_FROM_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="WIDTH">
+                    <ns6421:value>28050</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="GLOBAL_CHOREOGRAPHY_TASK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CUSTOMER_SATISFACTION" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="KEY_PROCESS" lang-independent="v2">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_FREQUENCY" lang-independent="v5">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_RESUBMISSION_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="3" notebook="1" name="A_MFB_RWF_VALID_UNTIL_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE_ACCORDING_TO_ISO_9000" lang-independent="v4">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_AUDITING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="HEIGHT">
+                    <ns6421:value>13605</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_IT_SUPPORT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="DOUBLE" sourcelang="en" novalue="0" notebook="1" name="CREATION_DATE">
+                    <ns6421:value>1484049756036</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="EXTERNAL_PROCESS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="MFB_RWF_HISTORY"/>
+                <ns6421:record name="A_ATTACHMENT_LIST"/>
+                <ns6421:record name="CHANGE_HISTORY"/>
+                <ns6421:record name="PROCESS_INDICATORS"/>
+                <ns6421:record name="PROCESS_SUPPLIERS___REQUIREMENTS"/>
+                <ns6421:record name="TERMS_ABBREVIATIONS"/>
+                <ns6421:record name="PROCESS_CUSTOMERS___REQUIREMENTS"/>
+                <ns6421:record name="SUGGESTION_FOR_IMPROVEMENT"/>
+            </ns6421:modelattributes>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+                <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                <w4graph:root snapToGuide="true" snapToGrid="true" rulerVisible="true" rulerUnit="Pixels" gridVisible="true">
+                    <Grid spacing="15"/>
+                    <VerticalRuler/>
+                    <HorizontalRuler/>
+                </w4graph:root>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:participant id="_227a38f2-af6e-4efa-b10a-be9c70d53c8f" name="Payroll" processRef="process_227a38f2-af6e-4efa-b10a-be9c70d53c8f">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:participant>
+    </semantic:collaboration>
+    <semantic:collaboration isClosed="true" name="Facilities" id="Collaboration_94435ba7-4027-4df9-ad3b-df1f6e068e5e">
+        <semantic:extensionElements>
+            <ns6421:modelattributes>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLIANCE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_MANAGEMENT_MATURITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_MONITORING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COMPLEXITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CYCLE_TIME" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PREDICTABILITY" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_COST_EFFICIENCY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="MFB_RWF_STATE" lang-independent="v0">
+                    <ns6421:value>Draft</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_POTENTIAL_MATURITY_ANALYSIS_AS_IS_AVERAGE" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_RISK_MANAGEMENT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_QUALITY" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_BUSINSS_VALUE" lang-independent="v3">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_VALID_FROM_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="WIDTH">
+                    <ns6421:value>28050</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="GLOBAL_CHOREOGRAPHY_TASK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_CUSTOMER_SATISFACTION" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="KEY_PROCESS" lang-independent="v2">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_PROCESS_FREQUENCY" lang-independent="v5">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="1" notebook="1" name="A_MFB_RWF_RESUBMISSION_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="UTC" novalue="3" notebook="1" name="A_MFB_RWF_VALID_UNTIL_DATE">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="PROCESS_TYPE_ACCORDING_TO_ISO_9000" lang-independent="v4">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_AUDITING_NCS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="HEIGHT">
+                    <ns6421:value>13605</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="A_IT_SUPPORT" lang-independent="v4">
+                    <ns6421:value>No entry</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="DOUBLE" sourcelang="en" novalue="0" notebook="1" name="CREATION_DATE">
+                    <ns6421:value>1484049765159</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="EXTERNAL_PROCESS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="MFB_RWF_HISTORY"/>
+                <ns6421:record name="A_ATTACHMENT_LIST"/>
+                <ns6421:record name="CHANGE_HISTORY"/>
+                <ns6421:record name="PROCESS_INDICATORS"/>
+                <ns6421:record name="PROCESS_SUPPLIERS___REQUIREMENTS"/>
+                <ns6421:record name="TERMS_ABBREVIATIONS"/>
+                <ns6421:record name="PROCESS_CUSTOMERS___REQUIREMENTS"/>
+                <ns6421:record name="SUGGESTION_FOR_IMPROVEMENT"/>
+            </ns6421:modelattributes>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+                <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                <w4graph:root snapToGuide="true" snapToGrid="true" rulerVisible="true" rulerUnit="Pixels" gridVisible="true">
+                    <Grid spacing="15"/>
+                    <VerticalRuler/>
+                    <HorizontalRuler/>
+                </w4graph:root>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:participant id="_6fd335df-160b-408c-9ce2-2aa5bba323fc" name="Facilities" processRef="process_6fd335df-160b-408c-9ce2-2aa5bba323fc">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:participant>
+    </semantic:collaboration>
+    <semantic:process isExecutable="false" processType="None" name="Onboarding employee - Money Bank - Process" triso:defaultName="true" id="process_8356359b-4f38-4f3e-8a61-bf5ddbffdcb3">
+        <semantic:extensionElements>
+            <ns6421:instance>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                    <ns6421:value>No change</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="BOUNDARY_VISIBLE">
+                    <ns6421:value>true</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                    <ns6421:value>true</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                    <ns6421:value>16777215</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MAX">
+                    <ns6421:value>1</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MIN">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_POOL" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                <ns6421:record name="OPEN_QUESTIONS"/>
+            </ns6421:instance>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:laneSet>
+            <semantic:lane id="_2901a455-018e-452a-95de-de74b46bff22" name="Responsible Department">
+                <semantic:extensionElements>
+                    <ns6421:instance>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                            <ns6421:value>No change</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                            <ns6421:value>true</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                            <ns6421:value>16777215</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                            <ns6421:value>0</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                        <ns6421:record name="OPEN_QUESTIONS"/>
+                    </ns6421:instance>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:flowNodeRef>Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_584c4307-b03c-4df7-ad30-d606bee9b472</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_73701b0e-a784-4e60-bddf-80bf629651b8</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_871c8a75-ffb3-46af-9850-0300e4d59ec6</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_8c0abe58-e74b-488b-840b-f02ccd6547cc</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_d67789fb-e055-47ac-9802-6efa6a7e4390</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="_d1ee7200-ca2b-485e-90e2-a8e6ac6b6dc8" name="HR Department">
+                <semantic:extensionElements>
+                    <ns6421:instance>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                            <ns6421:value>No change</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                            <ns6421:value>true</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                            <ns6421:value>16777215</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                            <ns6421:value>0</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                        <ns6421:record name="OPEN_QUESTIONS"/>
+                    </ns6421:instance>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:flowNodeRef>_4f16497f-746f-4193-894f-f452aab466cf</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_74c6a2e9-2b77-4a99-8f1c-25f441138582</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_3e9a1729-6121-4d60-84a1-eceff1073a48</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_86c24c30-155f-437b-877f-f66b2e8c9f48</semantic:flowNodeRef>
+                <semantic:flowNodeRef>Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:userTask id="Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ" name="Give employee welcome package" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>17</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_c33b796d-5b30-49ae-aa21-5c362c610d7f</semantic:incoming>
+            <semantic:outgoing>_14cd639b-5a75-4351-be98-9709f980859c</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_14cd639b-5a75-4351-be98-9709f980859c" triso:userConstraints="true" sourceRef="Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ" targetRef="_8c0abe58-e74b-488b-840b-f02ccd6547cc">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_c33b796d-5b30-49ae-aa21-5c362c610d7f" triso:userConstraints="true" sourceRef="Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ" name="Introduce new employee to the team" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>14</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_2bdba22a-0209-4e67-9be3-58bc2e618207</semantic:incoming>
+            <semantic:outgoing>_bfb20993-bbf5-4c91-853a-acad6690bf22</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_2bdba22a-0209-4e67-9be3-58bc2e618207" triso:userConstraints="false" sourceRef="_86c24c30-155f-437b-877f-f66b2e8c9f48" targetRef="Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_bfb20993-bbf5-4c91-853a-acad6690bf22" triso:userConstraints="true" sourceRef="Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:parallelGateway id="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw" name="Non-exclusive Gateway" gatewayDirection="Diverging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v2">
+                        <ns6421:value>do not show</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_CONVERGING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_8ce148f6-f444-4a02-8625-8c19fc8cb5fb</semantic:incoming>
+            <semantic:outgoing>_0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6</semantic:outgoing>
+            <semantic:outgoing>_d9ba759c-0465-43cb-86a2-7e6fb7e6eee6</semantic:outgoing>
+            <semantic:outgoing>_fe33bf0a-fb09-44dd-8b07-01b795945ab2</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:sequenceFlow id="_0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6" triso:userConstraints="false" sourceRef="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw" targetRef="_73701b0e-a784-4e60-bddf-80bf629651b8">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_8ce148f6-f444-4a02-8625-8c19fc8cb5fb" triso:userConstraints="true" sourceRef="Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ" targetRef="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_d9ba759c-0465-43cb-86a2-7e6fb7e6eee6" triso:userConstraints="false" sourceRef="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw" targetRef="_871c8a75-ffb3-46af-9850-0300e4d59ec6">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_fe33bf0a-fb09-44dd-8b07-01b795945ab2" triso:userConstraints="false" sourceRef="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw" targetRef="_d67789fb-e055-47ac-9802-6efa6a7e4390">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:intermediateThrowEvent id="_584c4307-b03c-4df7-ad30-d606bee9b472" name="New employee in department X">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>09</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_VISUALISE_REFERENCED_OBJECTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_3a3a19fc-0c56-4305-b1e2-d7c63aa0c546</semantic:incoming>
+            <semantic:outgoing>_7be50ce1-4794-43f3-8afc-b0f4ae141389</semantic:outgoing>
+            <semantic:dataInput id="Bpmn_DataInput_3-A1wQQqEeev4LOvjrydZw" isCollection="false" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details"/>
+            <semantic:dataInputAssociation id="Bpmn_DataInputAssociation_3-A1wAQqEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataObject_kTDHAQQqEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataInput_3-A1wQQqEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:inputSet id="Bpmn_InputSet_3-A1wgQqEeev4LOvjrydZw" name="default input set">
+                <semantic:dataInputRefs>Bpmn_DataInput_3-A1wQQqEeev4LOvjrydZw</semantic:dataInputRefs>
+            </semantic:inputSet>
+            <semantic:signalEventDefinition signalRef="signal_584c4307-b03c-4df7-ad30-d606bee9b472" id="signalEventDefinition_584c4307-b03c-4df7-ad30-d606bee9b472"/>
+        </semantic:intermediateThrowEvent>
+        <semantic:sequenceFlow id="_7be50ce1-4794-43f3-8afc-b0f4ae141389" triso:userConstraints="false" sourceRef="_584c4307-b03c-4df7-ad30-d606bee9b472" targetRef="_86c24c30-155f-437b-877f-f66b2e8c9f48">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_3a3a19fc-0c56-4305-b1e2-d7c63aa0c546" triso:userConstraints="true" sourceRef="Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ" targetRef="_584c4307-b03c-4df7-ad30-d606bee9b472">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:intermediateCatchEvent id="_73701b0e-a784-4e60-bddf-80bf629651b8" name="Input from IT ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_VISUALISE_REFERENCED_OBJECTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6</semantic:incoming>
+            <semantic:outgoing>_64fa4026-30d5-4b19-ad56-00d3bae7c818</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_m0uSMAQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_tPogIAQtEeev4LOvjrydZw"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:sequenceFlow id="_64fa4026-30d5-4b19-ad56-00d3bae7c818" triso:userConstraints="false" sourceRef="_73701b0e-a784-4e60-bddf-80bf629651b8" targetRef="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:intermediateCatchEvent id="_871c8a75-ffb3-46af-9850-0300e4d59ec6" name="Input from Payroll ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_VISUALISE_REFERENCED_OBJECTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_d9ba759c-0465-43cb-86a2-7e6fb7e6eee6</semantic:incoming>
+            <semantic:outgoing>_4c451dd2-6ba3-4709-94ab-c964cdb527fb</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_oiVqkAQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_rHPQQAQtEeev4LOvjrydZw"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:sequenceFlow id="_4c451dd2-6ba3-4709-94ab-c964cdb527fb" triso:userConstraints="false" sourceRef="_871c8a75-ffb3-46af-9850-0300e4d59ec6" targetRef="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:endEvent id="_8c0abe58-e74b-488b-840b-f02ccd6547cc" name="End Event">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="TYPE_END" lang-independent="v0">
+                        <ns6421:value>local</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>18</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_14cd639b-5a75-4351-be98-9709f980859c</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:userTask id="Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ" name="Perform training for position" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>15</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_bfb20993-bbf5-4c91-853a-acad6690bf22</semantic:incoming>
+            <semantic:outgoing>_8ce148f6-f444-4a02-8625-8c19fc8cb5fb</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ" name="Request preparations for a new employee" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>08</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_804ed46a-48d6-4c00-a57d-95fb43f9e431</semantic:incoming>
+            <semantic:outgoing>_3a3a19fc-0c56-4305-b1e2-d7c63aa0c546</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_804ed46a-48d6-4c00-a57d-95fb43f9e431" triso:userConstraints="false" sourceRef="_4f16497f-746f-4193-894f-f452aab466cf" targetRef="Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ" name="Compile welcome package" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:documentation>Inputs from:
+IT
+Payroll
+Facilities</semantic:documentation>
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>16</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_0bd61b86-7bbc-466a-a877-ea7f991d7e6e</semantic:incoming>
+            <semantic:outgoing>_c33b796d-5b30-49ae-aa21-5c362c610d7f</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_0bd61b86-7bbc-466a-a877-ea7f991d7e6e" triso:userConstraints="false" sourceRef="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw" targetRef="Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:intermediateCatchEvent id="_d67789fb-e055-47ac-9802-6efa6a7e4390" name="Input from Facilities ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_VISUALISE_REFERENCED_OBJECTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_fe33bf0a-fb09-44dd-8b07-01b795945ab2</semantic:incoming>
+            <semantic:outgoing>_fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_Usik0AQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_ko-zYAQtEeev4LOvjrydZw"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:sequenceFlow id="_fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43" triso:userConstraints="false" sourceRef="_d67789fb-e055-47ac-9802-6efa6a7e4390" targetRef="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:parallelGateway id="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw" name="Non-exclusive Gateway" gatewayDirection="Converging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v2">
+                        <ns6421:value>do not show</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" novalue="0" notebook="1" name="A_CONVERGING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_64fa4026-30d5-4b19-ad56-00d3bae7c818</semantic:incoming>
+            <semantic:incoming>_4c451dd2-6ba3-4709-94ab-c964cdb527fb</semantic:incoming>
+            <semantic:incoming>_fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43</semantic:incoming>
+            <semantic:outgoing>_0bd61b86-7bbc-466a-a877-ea7f991d7e6e</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:parallelGateway id="_4f16497f-746f-4193-894f-f452aab466cf" name="Non-exclusive Gateway" gatewayDirection="Diverging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v2">
+                        <ns6421:value>do not show</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>06</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_CONVERGING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_c0325c1b-c662-4a6b-a40d-d1c8650465db</semantic:incoming>
+            <semantic:outgoing>_022a5543-01bf-4ad7-a7e9-b310cdbf14f7</semantic:outgoing>
+            <semantic:outgoing>_804ed46a-48d6-4c00-a57d-95fb43f9e431</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:sequenceFlow id="_c0325c1b-c662-4a6b-a40d-d1c8650465db" triso:userConstraints="false" sourceRef="Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ" targetRef="_4f16497f-746f-4193-894f-f452aab466cf">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_022a5543-01bf-4ad7-a7e9-b310cdbf14f7" triso:userConstraints="false" sourceRef="_4f16497f-746f-4193-894f-f452aab466cf" targetRef="Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ" name="Inform employee of company policies" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>07</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_022a5543-01bf-4ad7-a7e9-b310cdbf14f7</semantic:incoming>
+            <semantic:outgoing>_fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f" triso:userConstraints="true" sourceRef="Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ" name="Register for medical insurance " startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>Bpmn_SequenceFlow_dRgtQCqSEee9dOUnH0MpZQ</semantic:incoming>
+            <semantic:outgoing>_680a535d-10e1-43bd-b0fb-ff16afb75c99</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_680a535d-10e1-43bd-b0fb-ff16afb75c99" triso:userConstraints="false" sourceRef="Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ" targetRef="_86c24c30-155f-437b-877f-f66b2e8c9f48">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="Bpmn_SequenceFlow_dRgtQCqSEee9dOUnH0MpZQ" isImmediate="true" triso:userConstraints="true" sourceRef="Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ" name="Send candidate Contract" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>02</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_77882ac9-e101-4d8d-bb2e-ce57f0b81a4f</semantic:incoming>
+            <semantic:incoming>_c310fe18-3c8f-4f7d-b4b9-db17e41ce02a</semantic:incoming>
+            <semantic:outgoing>_79166e63-e378-4424-95ee-a30c7c42a55a</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_77882ac9-e101-4d8d-bb2e-ce57f0b81a4f" triso:userConstraints="true" sourceRef="Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_c310fe18-3c8f-4f7d-b4b9-db17e41ce02a" triso:userConstraints="true" sourceRef="_3e9a1729-6121-4d60-84a1-eceff1073a48" targetRef="Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_79166e63-e378-4424-95ee-a30c7c42a55a" triso:userConstraints="false" sourceRef="Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ" targetRef="_74c6a2e9-2b77-4a99-8f1c-25f441138582">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:exclusiveGateway id="_74c6a2e9-2b77-4a99-8f1c-25f441138582" name="Contract terms accepted?" gatewayDirection="Diverging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v1">
+                        <ns6421:value>below</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>04</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_79166e63-e378-4424-95ee-a30c7c42a55a</semantic:incoming>
+            <semantic:outgoing>_8d55b014-266e-436c-bdb9-05e0c747d350</semantic:outgoing>
+            <semantic:outgoing>_294d1aa2-1fdf-4d35-837c-204fc4a4b67b</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow id="_8d55b014-266e-436c-bdb9-05e0c747d350" name="Yes" triso:userConstraints="false" sourceRef="_74c6a2e9-2b77-4a99-8f1c-25f441138582" targetRef="Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="STRING" sourcelang="en" novalue="0" notebook="1" name="DENOMINATION">
+                        <ns6421:value>Yes</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_294d1aa2-1fdf-4d35-837c-204fc4a4b67b" name="No" triso:userConstraints="false" sourceRef="_74c6a2e9-2b77-4a99-8f1c-25f441138582" targetRef="Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="STRING" sourcelang="en" novalue="0" notebook="1" name="DENOMINATION">
+                        <ns6421:value>No</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ" name="Perform training for time reports, sick leave and holidays" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>11</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_63974b42-2159-4908-b54c-797466ceeb08</semantic:incoming>
+            <semantic:outgoing>Bpmn_SequenceFlow_dRgtQCqSEee9dOUnH0MpZQ</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_63974b42-2159-4908-b54c-797466ceeb08" triso:userConstraints="true" sourceRef="Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ" targetRef="Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ" name="Review terms of Contract" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>03</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_294d1aa2-1fdf-4d35-837c-204fc4a4b67b</semantic:incoming>
+            <semantic:outgoing>_77882ac9-e101-4d8d-bb2e-ce57f0b81a4f</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:startEvent id="_3e9a1729-6121-4d60-84a1-eceff1073a48" name="Candidate accepted offer">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>01</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:outgoing>_c310fe18-3c8f-4f7d-b4b9-db17e41ce02a</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:userTask id="Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ" name="Get signature on contract and notify responsible department" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>05</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_8d55b014-266e-436c-bdb9-05e0c747d350</semantic:incoming>
+            <semantic:outgoing>_c0325c1b-c662-4a6b-a40d-d1c8650465db</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_kbn0MAQqEeev4LOvjrydZw">
+                <semantic:dataOutput id="Bpmn_DataOutput_kbobQAQqEeev4LOvjrydZw" isCollection="false" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details">
+                    <semantic:extensionElements>
+                        <w4graph:graphStyle>
+                            <w4graph:basic collapsed="false" autoResize="false"/>
+                        </w4graph:graphStyle>
+                    </semantic:extensionElements>
+                </semantic:dataOutput>
+                <semantic:inputSet id="Bpmn_InputSet_kbn0MgQqEeev4LOvjrydZw" name="default input set">
+                    <semantic:outputSetRefs>Bpmn_OutputSet_kbn0MQQqEeev4LOvjrydZw</semantic:outputSetRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="Bpmn_OutputSet_kbn0MQQqEeev4LOvjrydZw" name="default output set">
+                    <semantic:dataOutputRefs>Bpmn_DataOutput_kbobQAQqEeev4LOvjrydZw</semantic:dataOutputRefs>
+                    <semantic:inputSetRefs>Bpmn_InputSet_kbn0MgQqEeev4LOvjrydZw</semantic:inputSetRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="Bpmn_DataOutputAssociation_kbiUoAQqEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataOutput_kbobQAQqEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataObject_kTDHAQQqEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_86c24c30-155f-437b-877f-f66b2e8c9f48" name="Non-exclusive Gateway" gatewayDirection="Converging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v2">
+                        <ns6421:value>do not show</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>13</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_CONVERGING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_7be50ce1-4794-43f3-8afc-b0f4ae141389</semantic:incoming>
+            <semantic:incoming>_680a535d-10e1-43bd-b0fb-ff16afb75c99</semantic:incoming>
+            <semantic:outgoing>_2bdba22a-0209-4e67-9be3-58bc2e618207</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:userTask id="Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ" name="Introduce employee to company Mission, Vision and Values" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="SHORTSTRING" sourcelang="en" novalue="0" notebook="1" name="A_ORDER">
+                        <ns6421:value>10</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f</semantic:incoming>
+            <semantic:outgoing>_63974b42-2159-4908-b54c-797466ceeb08</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:dataStoreReference id="Bpmn_DataObject_kTDHAQQqEeev4LOvjrydZw" name="Employee Details" dataStoreRef="Bpmn_DataStore_q6Az8AQqEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+    </semantic:process>
+    <semantic:process isExecutable="false" processType="None" name="IT - IT - Process" triso:defaultName="true" id="process_4c3f552f-cd7a-41a7-a6d2-504a0aee7317">
+        <semantic:extensionElements>
+            <ns6421:instance>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                    <ns6421:value>No change</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="BOUNDARY_VISIBLE">
+                    <ns6421:value>true</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                    <ns6421:value>16777215</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MAX">
+                    <ns6421:value>1</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MIN">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_POOL" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                <ns6421:record name="OPEN_QUESTIONS"/>
+            </ns6421:instance>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:endEvent id="_b80dfc69-cd3b-40fc-b271-a1eee0bdb993" name="Workstation and permissions ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="TYPE_END" lang-independent="v0">
+                        <ns6421:value>local</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_f423b6da-adea-44cf-b2df-b5f3b1021e6a</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_m0uSMAQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_GcRa4CqSEee9dOUnH0MpZQ"/>
+        </semantic:endEvent>
+        <semantic:sequenceFlow id="_f423b6da-adea-44cf-b2df-b5f3b1021e6a" triso:userConstraints="true" sourceRef="_415821a5-acad-45b0-bf63-1024828e034f" targetRef="_b80dfc69-cd3b-40fc-b271-a1eee0bdb993">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:startEvent id="_93800974-affe-4326-ab78-71f6e095d061" name="New employee hired" isInterrupting="true">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:outgoing>_9bd2bec1-4e16-4796-9116-973580864a83</semantic:outgoing>
+            <semantic:dataOutput isCollection="false" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details" id="Bpmn_DataOutput_0F2mgAQsEeev4LOvjrydZw"/>
+            <semantic:dataOutputAssociation id="Bpmn_DataOutputAssociation_0F1_cgQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataOutput_0F2mgAQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataStoreReference_xkakgAQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="Bpmn_OutputSet_0F2mgQQsEeev4LOvjrydZw" name="default output set">
+                <semantic:dataOutputRefs>Bpmn_DataOutput_0F2mgAQsEeev4LOvjrydZw</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition signalRef="signal_584c4307-b03c-4df7-ad30-d606bee9b472" id="Bpmn_SignalEventDefinition_Cwnx0AQtEeev4LOvjrydZw"/>
+        </semantic:startEvent>
+        <semantic:sequenceFlow id="_9bd2bec1-4e16-4796-9116-973580864a83" triso:userConstraints="true" sourceRef="_93800974-affe-4326-ab78-71f6e095d061" targetRef="_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="_415821a5-acad-45b0-bf63-1024828e034f" name="Prepare IT part of welcome package" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_425a3093-06b7-490e-9d8e-dd7056fb0095</semantic:incoming>
+            <semantic:outgoing>_f423b6da-adea-44cf-b2df-b5f3b1021e6a</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_425a3093-06b7-490e-9d8e-dd7056fb0095" triso:userConstraints="true" sourceRef="_e645bdae-1905-40cb-b0bd-2edcaaa351f9" targetRef="_415821a5-acad-45b0-bf63-1024828e034f">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:dataStoreReference id="dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859" name="User Management" dataStoreRef="_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="UNLIMITED">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="CAPACITY">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+        <semantic:manualTask id="_e02e2802-09de-4ffd-a7f9-850ce33f4e9d" name="Prepare workstation" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_4b3d40cd-bcf5-4296-b244-b6ca7a458f78</semantic:incoming>
+            <semantic:outgoing>_544ce9a6-a3da-418f-9f29-9244fbf8f5bc</semantic:outgoing>
+        </semantic:manualTask>
+        <semantic:sequenceFlow id="_4b3d40cd-bcf5-4296-b244-b6ca7a458f78" triso:userConstraints="true" sourceRef="_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f" targetRef="_e02e2802-09de-4ffd-a7f9-850ce33f4e9d">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_544ce9a6-a3da-418f-9f29-9244fbf8f5bc" triso:userConstraints="true" sourceRef="_e02e2802-09de-4ffd-a7f9-850ce33f4e9d" targetRef="_2639c0ab-4f3b-400b-be49-4761ddfed6ff">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="_2639c0ab-4f3b-400b-be49-4761ddfed6ff" name="Assign required applications and permissions" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_544ce9a6-a3da-418f-9f29-9244fbf8f5bc</semantic:incoming>
+            <semantic:outgoing>_1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_4BRQAAQoEeev4LOvjrydZw">
+                <semantic:dataOutput id="dataOutput_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0" isCollection="false" itemSubjectRef="itemDefUserManagement"/>
+                <semantic:inputSet id="Bpmn_InputSet_4BRQAQQoEeev4LOvjrydZw"/>
+                <semantic:outputSet id="Bpmn_OutputSet_4BRQAgQoEeev4LOvjrydZw">
+                    <semantic:dataOutputRefs>dataOutput_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <ns6421:connector>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_DENOMNIATION">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                            <ns6421:value>automatic</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                    </ns6421:connector>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>dataOutput_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0</semantic:sourceRef>
+                <semantic:targetRef>dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4" triso:userConstraints="true" sourceRef="_2639c0ab-4f3b-400b-be49-4761ddfed6ff" targetRef="_e645bdae-1905-40cb-b0bd-2edcaaa351f9">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:serviceTask id="_e645bdae-1905-40cb-b0bd-2edcaaa351f9" name="Configure workstation" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4</semantic:incoming>
+            <semantic:outgoing>_425a3093-06b7-490e-9d8e-dd7056fb0095</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_4BTFMAQoEeev4LOvjrydZw">
+                <semantic:dataInput id="dataInput_a7686b51-3e57-4c5c-bfd3-582d75e85ef2" isCollection="false" itemSubjectRef="itemDefUserManagement"/>
+                <semantic:inputSet id="Bpmn_InputSet_4BTFMQQoEeev4LOvjrydZw">
+                    <semantic:dataInputRefs>dataInput_a7686b51-3e57-4c5c-bfd3-582d75e85ef2</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="Bpmn_OutputSet_4BTFMgQoEeev4LOvjrydZw"/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_a7686b51-3e57-4c5c-bfd3-582d75e85ef2" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <ns6421:connector>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_DENOMNIATION">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                            <ns6421:value>automatic</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                    </ns6421:connector>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859</semantic:sourceRef>
+                <semantic:targetRef>dataInput_a7686b51-3e57-4c5c-bfd3-582d75e85ef2</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:serviceTask>
+        <semantic:userTask id="_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f" name="Create domain account" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_9bd2bec1-4e16-4796-9116-973580864a83</semantic:incoming>
+            <semantic:outgoing>_4b3d40cd-bcf5-4296-b244-b6ca7a458f78</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_4BVhcAQoEeev4LOvjrydZw">
+                <semantic:dataInput id="Bpmn_DataInput_zKPS0QQsEeev4LOvjrydZw" isCollection="false" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details">
+                    <semantic:extensionElements>
+                        <w4graph:graphStyle>
+                            <w4graph:basic collapsed="false" autoResize="false"/>
+                        </w4graph:graphStyle>
+                    </semantic:extensionElements>
+                </semantic:dataInput>
+                <semantic:dataOutput id="dataOutput_40f59712-22d7-4a8a-8fdb-ef1461b2d8be" isCollection="false" itemSubjectRef="itemDefUserManagement"/>
+                <semantic:inputSet id="Bpmn_InputSet_4BVhcQQoEeev4LOvjrydZw">
+                    <semantic:dataInputRefs>Bpmn_DataInput_zKPS0QQsEeev4LOvjrydZw</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="Bpmn_OutputSet_4BVhcgQoEeev4LOvjrydZw">
+                    <semantic:dataOutputRefs>dataOutput_40f59712-22d7-4a8a-8fdb-ef1461b2d8be</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="Bpmn_DataInputAssociation_zKPS0AQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataStoreReference_xkakgAQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataInput_zKPS0QQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_40f59712-22d7-4a8a-8fdb-ef1461b2d8be" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <ns6421:connector>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_DENOMNIATION">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                            <ns6421:value>automatic</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                    </ns6421:connector>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>dataOutput_40f59712-22d7-4a8a-8fdb-ef1461b2d8be</semantic:sourceRef>
+                <semantic:targetRef>dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:dataStoreReference id="Bpmn_DataStoreReference_xkakgAQsEeev4LOvjrydZw" name="Employee Details" dataStoreRef="Bpmn_DataStore_q6Az8AQqEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+        <semantic:textAnnotation id="_e9ce1132-090e-4135-8783-3b7b46cebb8f">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:text>With PowerShell</semantic:text>
+        </semantic:textAnnotation>
+        <semantic:association id="_aac730d2-9387-4d98-8c9a-793dbbac9e76" associationDirection="None" triso:userConstraints="false" sourceRef="_e645bdae-1905-40cb-b0bd-2edcaaa351f9" targetRef="_e9ce1132-090e-4135-8783-3b7b46cebb8f">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_DENOMNIATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:association>
+    </semantic:process>
+    <semantic:process isExecutable="false" processType="None" name="Payroll - Payroll - Process" triso:defaultName="true" id="process_227a38f2-af6e-4efa-b10a-be9c70d53c8f">
+        <semantic:extensionElements>
+            <ns6421:instance>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                    <ns6421:value>No change</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="BOUNDARY_VISIBLE">
+                    <ns6421:value>true</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                    <ns6421:value>16777215</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MAX">
+                    <ns6421:value>1</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MIN">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_POOL" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                <ns6421:record name="OPEN_QUESTIONS"/>
+            </ns6421:instance>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:userTask id="_2404b367-08bf-4cb6-a685-3f9450b5a93e" name="Update payroll system" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_80ec0079-4266-4d71-8f9d-ff979f0d8884</semantic:incoming>
+            <semantic:incoming>_17ebbefb-67fe-4e16-b21d-d7267c965946</semantic:incoming>
+            <semantic:outgoing>_0caff436-0236-4ccc-85df-9ea1bd413f1a</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_4Bf5gAQoEeev4LOvjrydZw">
+                <semantic:dataOutput id="dataOutput_0d4940de-b2cc-4216-8fd7-efc71ecebf80" isCollection="false" itemSubjectRef="itemDefPayrollSystem"/>
+                <semantic:inputSet id="Bpmn_InputSet_4Bf5gQQoEeev4LOvjrydZw"/>
+                <semantic:outputSet id="Bpmn_OutputSet_4Bf5ggQoEeev4LOvjrydZw">
+                    <semantic:dataOutputRefs>dataOutput_0d4940de-b2cc-4216-8fd7-efc71ecebf80</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_0d4940de-b2cc-4216-8fd7-efc71ecebf80" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <ns6421:connector>
+                        <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_DENOMNIATION">
+                            <ns6421:value>false</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                        <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                            <ns6421:value>automatic</ns6421:value>
+                            <ns6421:metavalue/>
+                        </ns6421:attribute>
+                    </ns6421:connector>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>dataOutput_0d4940de-b2cc-4216-8fd7-efc71ecebf80</semantic:sourceRef>
+                <semantic:targetRef>dataStoreReference_88bbd82d-e83a-41c9-82c7-4f12e87faa9c</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_80ec0079-4266-4d71-8f9d-ff979f0d8884" name="Yes" triso:userConstraints="false" sourceRef="_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26" targetRef="_2404b367-08bf-4cb6-a685-3f9450b5a93e">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="STRING" sourcelang="en" novalue="0" notebook="1" name="DENOMINATION">
+                        <ns6421:value>Yes</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_17ebbefb-67fe-4e16-b21d-d7267c965946" triso:userConstraints="true" sourceRef="_92ef5d57-54e8-4717-97ae-c3d8560497c1" targetRef="_2404b367-08bf-4cb6-a685-3f9450b5a93e">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_0caff436-0236-4ccc-85df-9ea1bd413f1a" triso:userConstraints="true" sourceRef="_2404b367-08bf-4cb6-a685-3f9450b5a93e" targetRef="_a2ef4322-1618-48b7-8c00-6acc30cf23f6">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:exclusiveGateway id="_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26" name="All necessary data available?" gatewayDirection="Diverging">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_GATEWAY" lang-independent="v1">
+                        <ns6421:value>below</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_bc6f05af-a198-4b6f-9e16-1b7991481787</semantic:incoming>
+            <semantic:outgoing>_424096a5-1272-4c87-8325-a68b47505510</semantic:outgoing>
+            <semantic:outgoing>_80ec0079-4266-4d71-8f9d-ff979f0d8884</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow id="_bc6f05af-a198-4b6f-9e16-1b7991481787" triso:userConstraints="false" sourceRef="_39a6e320-01a9-48a4-9988-bcbb092c9eba" targetRef="_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:sequenceFlow id="_424096a5-1272-4c87-8325-a68b47505510" name="No" triso:userConstraints="false" sourceRef="_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26" targetRef="_92ef5d57-54e8-4717-97ae-c3d8560497c1">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="STRING" sourcelang="en" novalue="0" notebook="1" name="DENOMINATION">
+                        <ns6421:value>No</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:startEvent id="_381d8a4f-a4be-447a-b58e-e6db6f08fb03" name="New employee hired" isInterrupting="true">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:outgoing>_5da6e12e-f982-469a-bb0a-0bd37d83acb8</semantic:outgoing>
+            <semantic:dataOutput isCollection="false" name="Employee Details" id="Bpmn_DataOutput_iOqigAQsEeev4LOvjrydZw"/>
+            <semantic:dataOutputAssociation id="Bpmn_DataOutputAssociation_iOm4IQQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataOutput_iOqigAQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataObject_iLnOgQQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="Bpmn_OutputSet_iOqigQQsEeev4LOvjrydZw" name="default output set">
+                <semantic:dataOutputRefs>Bpmn_DataOutput_iOqigAQsEeev4LOvjrydZw</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition signalRef="signal_584c4307-b03c-4df7-ad30-d606bee9b472" id="Bpmn_SignalEventDefinition_FaiaYAQtEeev4LOvjrydZw"/>
+        </semantic:startEvent>
+        <semantic:sequenceFlow id="_5da6e12e-f982-469a-bb0a-0bd37d83acb8" triso:userConstraints="true" sourceRef="_381d8a4f-a4be-447a-b58e-e6db6f08fb03" targetRef="_39a6e320-01a9-48a4-9988-bcbb092c9eba">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:dataStoreReference id="dataStoreReference_88bbd82d-e83a-41c9-82c7-4f12e87faa9c" name="Payroll system" dataStoreRef="_88bbd82d-e83a-41c9-82c7-4f12e87faa9c">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="UNLIMITED">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="CAPACITY">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+        <semantic:endEvent id="_a2ef4322-1618-48b7-8c00-6acc30cf23f6" name="Payroll ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="TYPE_END" lang-independent="v0">
+                        <ns6421:value>local</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_0caff436-0236-4ccc-85df-9ea1bd413f1a</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_oiVqkAQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_LFnb8AQvEeev4LOvjrydZw"/>
+        </semantic:endEvent>
+        <semantic:manualTask id="_92ef5d57-54e8-4717-97ae-c3d8560497c1" name="Clarify missing points" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_424096a5-1272-4c87-8325-a68b47505510</semantic:incoming>
+            <semantic:outgoing>_17ebbefb-67fe-4e16-b21d-d7267c965946</semantic:outgoing>
+            <semantic:standardLoopCharacteristics id="Bpmn_StandardLoopCharacteristics_4BkK8AQoEeev4LOvjrydZw" testBefore="false"/>
+        </semantic:manualTask>
+        <semantic:userTask id="_39a6e320-01a9-48a4-9988-bcbb092c9eba" name="Validate provided information" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_5da6e12e-f982-469a-bb0a-0bd37d83acb8</semantic:incoming>
+            <semantic:outgoing>_bc6f05af-a198-4b6f-9e16-1b7991481787</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_lqNcUAQsEeev4LOvjrydZw">
+                <semantic:dataInput id="Bpmn_DataInput_lqNcUwQsEeev4LOvjrydZw" isCollection="false" itemSubjectRef="itemDefEmployeeDetails" name="Employee Details">
+                    <semantic:extensionElements>
+                        <w4graph:graphStyle>
+                            <w4graph:basic collapsed="false" autoResize="false"/>
+                        </w4graph:graphStyle>
+                    </semantic:extensionElements>
+                </semantic:dataInput>
+                <semantic:inputSet id="Bpmn_InputSet_lqNcUgQsEeev4LOvjrydZw" name="default input set">
+                    <semantic:dataInputRefs>Bpmn_DataInput_lqNcUwQsEeev4LOvjrydZw</semantic:dataInputRefs>
+                    <semantic:outputSetRefs>Bpmn_OutputSet_lqNcUQQsEeev4LOvjrydZw</semantic:outputSetRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="Bpmn_OutputSet_lqNcUQQsEeev4LOvjrydZw" name="default output set">
+                    <semantic:inputSetRefs>Bpmn_InputSet_lqNcUgQsEeev4LOvjrydZw</semantic:inputSetRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="Bpmn_DataInputAssociation_lqM1QgQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataObject_iLnOgQQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataInput_lqNcUwQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:dataStoreReference id="Bpmn_DataObject_iLnOgQQsEeev4LOvjrydZw" name="Employee Details" dataStoreRef="Bpmn_DataStore_q6Az8AQqEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+    </semantic:process>
+    <semantic:process isExecutable="false" processType="None" name="Facilities - Facilities - Process" triso:defaultName="true" id="process_6fd335df-160b-408c-9ce2-2aa5bba323fc">
+        <semantic:extensionElements>
+            <ns6421:instance>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                    <ns6421:value>No change</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="BOUNDARY_VISIBLE">
+                    <ns6421:value>true</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_GRADIENT">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="COLOUR">
+                    <ns6421:value>16777215</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_DISPLAY_WATERMARK">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MAX">
+                    <ns6421:value>1</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                    <ns6421:value>false</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="MULTIPLICITY_MIN">
+                    <ns6421:value>0</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_POOL" lang-independent="v0">
+                    <ns6421:value>None</ns6421:value>
+                    <ns6421:metavalue/>
+                </ns6421:attribute>
+                <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                <ns6421:record name="OPEN_QUESTIONS"/>
+            </ns6421:instance>
+            <w4graph:graphStyle>
+                <w4graph:basic collapsed="false" autoResize="false"/>
+            </w4graph:graphStyle>
+        </semantic:extensionElements>
+        <semantic:startEvent id="_331333d9-a9f7-4bc6-b625-0b43d3d89dbc" name="New employee hired" isInterrupting="true">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:outgoing>_4e16051c-1b37-432a-80d6-647c47b5586c</semantic:outgoing>
+            <semantic:dataOutput isCollection="false" name="Employee&#10; Details" id="Bpmn_DataOutput_RdnAIAQsEeev4LOvjrydZw"/>
+            <semantic:dataOutputAssociation id="Bpmn_DataOutputAssociation_Rdj80QQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataOutput_RdnAIAQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataObject_RX4LkQQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="Bpmn_OutputSet_RdnAIQQsEeev4LOvjrydZw" name="default output set">
+                <semantic:dataOutputRefs>Bpmn_DataOutput_RdnAIAQsEeev4LOvjrydZw</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition signalRef="signal_584c4307-b03c-4df7-ad30-d606bee9b472" id="Bpmn_SignalEventDefinition_II4P8AQtEeev4LOvjrydZw"/>
+        </semantic:startEvent>
+        <semantic:sequenceFlow id="_4e16051c-1b37-432a-80d6-647c47b5586c" triso:userConstraints="true" sourceRef="_331333d9-a9f7-4bc6-b625-0b43d3d89dbc" targetRef="_5298ebe4-6a15-4c62-8da1-8048dec4be38">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:manualTask id="_5298ebe4-6a15-4c62-8da1-8048dec4be38" name="Prepare access card" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_4e16051c-1b37-432a-80d6-647c47b5586c</semantic:incoming>
+            <semantic:outgoing>_81b63d83-b0d6-4941-8df4-4aec650abb56</semantic:outgoing>
+        </semantic:manualTask>
+        <semantic:sequenceFlow id="_81b63d83-b0d6-4941-8df4-4aec650abb56" triso:userConstraints="true" sourceRef="_5298ebe4-6a15-4c62-8da1-8048dec4be38" targetRef="_9eddb25a-f6dc-4456-8c23-92fc35e43bcc">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:userTask id="_9eddb25a-f6dc-4456-8c23-92fc35e43bcc" name="Configure access details" startQuantity="1" completionQuantity="1" isForCompensation="false" implementation="##WebService">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOLS_IF_RISKS_OR_CONTROLS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_COOPERATIONPARTICIPATION">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_SYMBOL_IF_DESCRIPTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="VISUALISE_REFERENCED_IT_SYSTEM_ELEMENTS">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_NAME_TASK" lang-independent="v0">
+                        <ns6421:value>center</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_RESPONSIBLE_FOR_EXECUTION">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_OUTPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_ACCOUNTABLE_FOR_APPROVING_RESULTS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_TO_INFORM">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="A_BEHAVIOUR_DEFINITION"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_81b63d83-b0d6-4941-8df4-4aec650abb56</semantic:incoming>
+            <semantic:outgoing>_d37a24be-32ed-4e3e-8e91-0d14a5af4e46</semantic:outgoing>
+            <semantic:ioSpecification id="Bpmn_InputOutputSpecification_SnLQQAQsEeev4LOvjrydZw">
+                <semantic:dataInput id="Bpmn_DataInput_SnLQQwQsEeev4LOvjrydZw" isCollection="false" name="Employee&#10; Details">
+                    <semantic:extensionElements>
+                        <w4graph:graphStyle>
+                            <w4graph:basic collapsed="false" autoResize="false"/>
+                        </w4graph:graphStyle>
+                    </semantic:extensionElements>
+                </semantic:dataInput>
+                <semantic:inputSet id="Bpmn_InputSet_SnLQQgQsEeev4LOvjrydZw" name="default input set">
+                    <semantic:dataInputRefs>Bpmn_DataInput_SnLQQwQsEeev4LOvjrydZw</semantic:dataInputRefs>
+                    <semantic:outputSetRefs>Bpmn_OutputSet_SnLQQQQsEeev4LOvjrydZw</semantic:outputSetRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="Bpmn_OutputSet_SnLQQQQsEeev4LOvjrydZw" name="default output set">
+                    <semantic:inputSetRefs>Bpmn_InputSet_SnLQQgQsEeev4LOvjrydZw</semantic:inputSetRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="Bpmn_DataInputAssociation_SnKpMAQsEeev4LOvjrydZw" triso:userConstraints="false">
+                <semantic:extensionElements>
+                    <w4graph:graphStyle>
+                        <w4graph:basic collapsed="false" autoResize="false"/>
+                        <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="false"/>
+                    </w4graph:graphStyle>
+                </semantic:extensionElements>
+                <semantic:sourceRef>Bpmn_DataObject_RX4LkQQsEeev4LOvjrydZw</semantic:sourceRef>
+                <semantic:targetRef>Bpmn_DataInput_SnLQQwQsEeev4LOvjrydZw</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:sequenceFlow id="_d37a24be-32ed-4e3e-8e91-0d14a5af4e46" triso:userConstraints="true" sourceRef="_9eddb25a-f6dc-4456-8c23-92fc35e43bcc" targetRef="_1bd46ce2-3b9e-4ce0-a4ad-73f9208ecfa4">
+            <semantic:extensionElements>
+                <ns6421:connector>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="VISUALIZED_VALUES_SUBSEQUENT" lang-independent="v0">
+                        <ns6421:value>Name</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="1" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="REPRESENTATION_HAS_PROCESS" lang-independent="v0">
+                        <ns6421:value>automatic</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="IS_IMMEDIATE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                </ns6421:connector>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:sequenceFlow>
+        <semantic:endEvent id="_1bd46ce2-3b9e-4ce0-a4ad-73f9208ecfa4" name="Access card ready">
+            <semantic:extensionElements>
+                <ns6421:instance>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="IDENTIFICATION_OF_CHANGES" lang-independent="v0">
+                        <ns6421:value>No change</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE_INPUT">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="MONITORING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="A_NEED_FOR_ACTION_CS">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="INTEGER" sourcelang="en" novalue="0" notebook="0" name="FONT_COLOUR">
+                        <ns6421:value>0</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="TYPE_END" lang-independent="v0">
+                        <ns6421:value>local</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="AUDITING">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="ENUM" sourcelang="en" novalue="0" notebook="1" name="OBJECT_TYPE" lang-independent="v2">
+                        <ns6421:value>No entry</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="COLLECTION_DATATYPE">
+                        <ns6421:value>false</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:attribute type="BOOL" sourcelang="en" novalue="0" notebook="1" name="DISPLAY_NAME">
+                        <ns6421:value>true</ns6421:value>
+                        <ns6421:metavalue/>
+                    </ns6421:attribute>
+                    <ns6421:record name="A_ATTACHMENT_LIST_CS"/>
+                    <ns6421:record name="OPEN_QUESTIONS"/>
+                </ns6421:instance>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+            <semantic:incoming>_d37a24be-32ed-4e3e-8e91-0d14a5af4e46</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Bpmn_Message_Usik0AQtEeev4LOvjrydZw" id="Bpmn_MessageEventDefinition_gIQaMAQtEeev4LOvjrydZw"/>
+        </semantic:endEvent>
+        <semantic:dataStoreReference id="Bpmn_DataObject_RX4LkQQsEeev4LOvjrydZw" name="Employee&#10; Details" dataStoreRef="Bpmn_DataStore_q6Az8AQqEeev4LOvjrydZw">
+            <semantic:extensionElements>
+                <w4graph:graphStyle>
+                    <w4graph:basic collapsed="false" autoResize="false"/>
+                    <w4graph:line routerType="Rectilinear" closestRoute="false" avoidObstacleRoute="false" automaticRoute="true"/>
+                </w4graph:graphStyle>
+            </semantic:extensionElements>
+        </semantic:dataStoreReference>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="Diagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c" name="Onboarding employee">
+        <bpmndi:BPMNPlane bpmnElement="Collaboration_35ab9b1f-354a-48cb-9b99-f4e448f7b04c" id="Diagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_plane" trisobpmn:diagramWidth="3528" trisobpmn:diagramHeight="1050">
+            <di:extension/>
+            <bpmndi:BPMNShape id="BPMN_Shape_8356359b-4f38-4f3e-8a61-bf5ddbffdcb3" bpmnElement="_8356359b-4f38-4f3e-8a61-bf5ddbffdcb3" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="20" y="19" width="3428" height="821"/>
+                <!--semId = _8356359b-4f38-4f3e-8a61-bf5ddbffdcb3--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="815" width="12" x="25" y="22"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_2901a455-018e-452a-95de-de74b46bff22" bpmnElement="_2901a455-018e-452a-95de-de74b46bff22" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="50" y="348" width="3398" height="492"/>
+                <!--semId = _2901a455-018e-452a-95de-de74b46bff22--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="486" width="12" x="55" y="351"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_6e212df2-eb0d-43a3-9218-0447e7fb044c" bpmnElement="Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3146" y="559" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_S6a9oSqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="144" x="3149.5" y="584"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_14cd639b-5a75-4351-be98-9709f980859c" bpmnElement="_14cd639b-5a75-4351-be98-9709f980859c" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="3297" y="597"/>
+                <di:waypoint x="3364" y="597"/>
+                <!--semId = _14cd639b-5a75-4351-be98-9709f980859c--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="3297" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_c33b796d-5b30-49ae-aa21-5c362c610d7f" bpmnElement="_c33b796d-5b30-49ae-aa21-5c362c610d7f" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="3089" y="597"/>
+                <di:waypoint x="3146" y="597"/>
+                <!--semId = _c33b796d-5b30-49ae-aa21-5c362c610d7f--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="3089" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_2048e3ce-2768-4406-b56e-823be7835ab4" bpmnElement="Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2141" y="559" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_P2qRsSqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="144" x="2144.5" y="584"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_2bdba22a-0209-4e67-9be3-58bc2e618207" bpmnElement="_2bdba22a-0209-4e67-9be3-58bc2e618207" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2064.062057495117" y="189"/>
+                <di:waypoint x="2102.5310287475586" y="189"/>
+                <di:waypoint x="2102.5310287475586" y="598"/>
+                <di:waypoint x="2141" y="598"/>
+                <!--semId = _2bdba22a-0209-4e67-9be3-58bc2e618207--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2064.062057495117" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_bfb20993-bbf5-4c91-853a-acad6690bf22" bpmnElement="_bfb20993-bbf5-4c91-853a-acad6690bf22" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="2292" y="597"/>
+                <di:waypoint x="2330" y="597"/>
+                <!--semId = _bfb20993-bbf5-4c91-853a-acad6690bf22--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2292" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_5554bc17-7893-4c01-bcbf-3bbf020ce01a" bpmnElement="Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2567" y="569" width="56" height="56"/>
+                <!--semId = Bpmn_ParallelGateway_MQGukQQuEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="70" x="2560.2871869181413" y="634.4786619635529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6" bpmnElement="_0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2595" y="569"/>
+                <di:waypoint x="2595" y="445"/>
+                <di:waypoint x="2699" y="445"/>
+                <!--semId = _0faf8d5f-a3b5-4fa4-ae90-d29ecd5903c6--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2595" y="569"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_8ce148f6-f444-4a02-8625-8c19fc8cb5fb" bpmnElement="_8ce148f6-f444-4a02-8625-8c19fc8cb5fb" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="2481" y="597"/>
+                <di:waypoint x="2567" y="597"/>
+                <!--semId = _8ce148f6-f444-4a02-8625-8c19fc8cb5fb--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2481" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_d9ba759c-0465-43cb-86a2-7e6fb7e6eee6" bpmnElement="_d9ba759c-0465-43cb-86a2-7e6fb7e6eee6" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2623" y="597"/>
+                <di:waypoint x="2699" y="597"/>
+                <!--semId = _d9ba759c-0465-43cb-86a2-7e6fb7e6eee6--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2623" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_fe33bf0a-fb09-44dd-8b07-01b795945ab2" bpmnElement="_fe33bf0a-fb09-44dd-8b07-01b795945ab2" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2595" y="625"/>
+                <di:waypoint x="2595" y="729"/>
+                <di:waypoint x="2699" y="729"/>
+                <!--semId = _fe33bf0a-fb09-44dd-8b07-01b795945ab2--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2595" y="625"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_584c4307-b03c-4df7-ad30-d606bee9b472" bpmnElement="_584c4307-b03c-4df7-ad30-d606bee9b472" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1280" y="569" width="56" height="56"/>
+                <!--semId = _584c4307-b03c-4df7-ad30-d606bee9b472--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="83" x="1266.5" y="634.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_7be50ce1-4794-43f3-8afc-b0f4ae141389" bpmnElement="_7be50ce1-4794-43f3-8afc-b0f4ae141389" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="1336" y="597"/>
+                <di:waypoint x="2038.2871869181415" y="597"/>
+                <di:waypoint x="2038.2871869181415" y="218.08378056362483"/>
+                <!--semId = _7be50ce1-4794-43f3-8afc-b0f4ae141389--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1336" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_3a3a19fc-0c56-4305-b1e2-d7c63aa0c546" bpmnElement="_3a3a19fc-0c56-4305-b1e2-d7c63aa0c546" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1207" y="597"/>
+                <di:waypoint x="1280" y="597"/>
+                <!--semId = _3a3a19fc-0c56-4305-b1e2-d7c63aa0c546--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1207" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_73701b0e-a784-4e60-bddf-80bf629651b8" bpmnElement="_73701b0e-a784-4e60-bddf-80bf629651b8" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2699" y="417" width="56" height="56"/>
+                <!--semId = _73701b0e-a784-4e60-bddf-80bf629651b8--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="93" x="2680.5" y="482.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_64fa4026-30d5-4b19-ad56-00d3bae7c818" bpmnElement="_64fa4026-30d5-4b19-ad56-00d3bae7c818" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2755" y="445"/>
+                <di:waypoint x="2853" y="445"/>
+                <di:waypoint x="2853" y="570"/>
+                <!--semId = _64fa4026-30d5-4b19-ad56-00d3bae7c818--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2755" y="445"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_871c8a75-ffb3-46af-9850-0300e4d59ec6" bpmnElement="_871c8a75-ffb3-46af-9850-0300e4d59ec6" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2699" y="569" width="56" height="56"/>
+                <!--semId = _871c8a75-ffb3-46af-9850-0300e4d59ec6--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="86" x="2684" y="634.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_4c451dd2-6ba3-4709-94ab-c964cdb527fb" bpmnElement="_4c451dd2-6ba3-4709-94ab-c964cdb527fb" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2755" y="597"/>
+                <di:waypoint x="2826" y="597"/>
+                <!--semId = _4c451dd2-6ba3-4709-94ab-c964cdb527fb--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2755" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_8c0abe58-e74b-488b-840b-f02ccd6547cc" bpmnElement="_8c0abe58-e74b-488b-840b-f02ccd6547cc" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3364" y="569" width="56" height="56"/>
+                <!--semId = _8c0abe58-e74b-488b-840b-f02ccd6547cc--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="51" x="3366.5" y="640.5555555555555"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_49d47944-c3c6-4dea-b0bd-3f9a2f53b91e" bpmnElement="Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2330" y="559" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_QO2IMCqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="144" x="2333.5" y="591"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_cf114890-bcf1-4b55-a4fb-f55e886a86f7" bpmnElement="Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1056" y="559" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_TsKjoSqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="144" x="1059.5" y="584"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_804ed46a-48d6-4c00-a57d-95fb43f9e431" bpmnElement="_804ed46a-48d6-4c00-a57d-95fb43f9e431" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="916" y="217"/>
+                <di:waypoint x="916" y="598"/>
+                <di:waypoint x="1056" y="598"/>
+                <!--semId = _804ed46a-48d6-4c00-a57d-95fb43f9e431--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="916" y="217"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_b19e9782-64eb-4f31-bf50-54c731022137" bpmnElement="Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2938" y="559" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_RgGUsCqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="144" x="2941.5" y="591"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_0bd61b86-7bbc-466a-a877-ea7f991d7e6e" bpmnElement="_0bd61b86-7bbc-466a-a877-ea7f991d7e6e" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2882" y="597"/>
+                <di:waypoint x="2938" y="597"/>
+                <!--semId = _0bd61b86-7bbc-466a-a877-ea7f991d7e6e--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2882" y="597"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_d67789fb-e055-47ac-9802-6efa6a7e4390" bpmnElement="_d67789fb-e055-47ac-9802-6efa6a7e4390" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2699" y="701" width="56" height="56"/>
+                <!--semId = _d67789fb-e055-47ac-9802-6efa6a7e4390--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="94" x="2680" y="766.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43" bpmnElement="_fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="2755" y="729"/>
+                <di:waypoint x="2853" y="729"/>
+                <di:waypoint x="2853" y="624"/>
+                <!--semId = _fd140ddd-e6e2-4eed-bdbe-ac8c4f489b43--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="2755" y="729"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_dee6a7df-9aa0-41ab-a950-29d62d153cfd" bpmnElement="Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2826" y="569" width="56" height="56"/>
+                <!--semId = Bpmn_ParallelGateway_LXMJkQQuEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="70" x="2819.2871869181413" y="634.4786619635529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_d1ee7200-ca2b-485e-90e2-a8e6ac6b6dc8" bpmnElement="_d1ee7200-ca2b-485e-90e2-a8e6ac6b6dc8" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="50" y="19" width="3398" height="329"/>
+                <!--semId = _d1ee7200-ca2b-485e-90e2-a8e6ac6b6dc8--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="323" width="12" x="55" y="22"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_4f16497f-746f-4193-894f-f452aab466cf" bpmnElement="_4f16497f-746f-4193-894f-f452aab466cf" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="888" y="161" width="56" height="56"/>
+                <!--semId = _4f16497f-746f-4193-894f-f452aab466cf--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="70" x="881.2871869181415" y="226.4786619635529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_c0325c1b-c662-4a6b-a40d-d1c8650465db" bpmnElement="_c0325c1b-c662-4a6b-a40d-d1c8650465db" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="814" y="189"/>
+                <di:waypoint x="888" y="189"/>
+                <!--semId = _c0325c1b-c662-4a6b-a40d-d1c8650465db--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="814" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_022a5543-01bf-4ad7-a7e9-b310cdbf14f7" bpmnElement="_022a5543-01bf-4ad7-a7e9-b310cdbf14f7" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="944" y="189"/>
+                <di:waypoint x="1062" y="189"/>
+                <!--semId = _022a5543-01bf-4ad7-a7e9-b310cdbf14f7--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="944" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_41ef09e5-7fc0-4cd9-a7d4-ef811cd071f7" bpmnElement="Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1062" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_X-cRISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="144" x="1065.5" y="176"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f" bpmnElement="_fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1213" y="189"/>
+                <di:waypoint x="1270" y="189"/>
+                <!--semId = _fc6b3471-0eb0-4aa4-bd38-e39885ea8c2f--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1213" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_f2140b13-35ce-452a-b905-dbe3fea75dd6" bpmnElement="Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1686" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_dqvsoSqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="144" x="1689.5" y="176"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_680a535d-10e1-43bd-b0fb-ff16afb75c99" bpmnElement="_680a535d-10e1-43bd-b0fb-ff16afb75c99" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="1837" y="189"/>
+                <di:waypoint x="2010" y="188.70169566387662"/>
+                <!--semId = _680a535d-10e1-43bd-b0fb-ff16afb75c99--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1837" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_dRh7YCqSEee9dOUnH0MpZQ" bpmnElement="Bpmn_SequenceFlow_dRgtQCqSEee9dOUnH0MpZQ" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1629" y="189"/>
+                <di:waypoint x="1686" y="189"/>
+                <!--semId = Bpmn_SequenceFlow_dRgtQCqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1629" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_e4367d48-0830-42f4-aba0-d992cde96e09" bpmnElement="Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="285" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_U7bzISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="144" x="288.5" y="183"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_77882ac9-e101-4d8d-bb2e-ce57f0b81a4f" bpmnElement="_77882ac9-e101-4d8d-bb2e-ce57f0b81a4f" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="456" y="76"/>
+                <di:waypoint x="264" y="76"/>
+                <di:waypoint x="264" y="170"/>
+                <di:waypoint x="285" y="170"/>
+                <!--semId = _77882ac9-e101-4d8d-bb2e-ce57f0b81a4f--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="456" y="76"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_c310fe18-3c8f-4f7d-b4b9-db17e41ce02a" bpmnElement="_c310fe18-3c8f-4f7d-b4b9-db17e41ce02a" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="199" y="189"/>
+                <di:waypoint x="285" y="189"/>
+                <!--semId = _c310fe18-3c8f-4f7d-b4b9-db17e41ce02a--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="199" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_79166e63-e378-4424-95ee-a30c7c42a55a" bpmnElement="_79166e63-e378-4424-95ee-a30c7c42a55a" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="436" y="189"/>
+                <di:waypoint x="502" y="189"/>
+                <!--semId = _79166e63-e378-4424-95ee-a30c7c42a55a--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="436" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_74c6a2e9-2b77-4a99-8f1c-25f441138582" bpmnElement="_74c6a2e9-2b77-4a99-8f1c-25f441138582" isMarkerVisible="false" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="502" y="161" width="56" height="56"/>
+                <!--semId = _74c6a2e9-2b77-4a99-8f1c-25f441138582--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="73" x="493.7871869181415" y="226.4786619635529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_8d55b014-266e-436c-bdb9-05e0c747d350" bpmnElement="_8d55b014-266e-436c-bdb9-05e0c747d350" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="558" y="189"/>
+                <di:waypoint x="663" y="189"/>
+                <!--semId = _8d55b014-266e-436c-bdb9-05e0c747d350--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="18.984375" x="601.5078125" y="194"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_294d1aa2-1fdf-4d35-837c-204fc4a4b67b" bpmnElement="_294d1aa2-1fdf-4d35-837c-204fc4a4b67b" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="531" y="160"/>
+                <di:waypoint x="531" y="114"/>
+                <!--semId = _294d1aa2-1fdf-4d35-837c-204fc4a4b67b--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="14" x="524" y="142.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_c120c611-e66f-440c-bffc-68c0a29e4414" bpmnElement="Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1478" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_aCRxISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="40" width="144" x="1481.5" y="169"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_63974b42-2159-4908-b54c-797466ceeb08" bpmnElement="_63974b42-2159-4908-b54c-797466ceeb08" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1421" y="189"/>
+                <di:waypoint x="1478" y="189"/>
+                <!--semId = _63974b42-2159-4908-b54c-797466ceeb08--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1421" y="189"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_cf3eb248-5397-445a-8e22-73197bf9242e" bpmnElement="Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="456" y="38" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_Wl8NISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="144" x="459.5" y="70"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_3e9a1729-6121-4d60-84a1-eceff1073a48" bpmnElement="_3e9a1729-6121-4d60-84a1-eceff1073a48" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="143" y="161" width="56" height="56"/>
+                <!--semId = _3e9a1729-6121-4d60-84a1-eceff1073a48--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="97" x="122.5" y="234.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_6cd78668-0d6c-4617-919d-f0650cfbc1ae" bpmnElement="Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="663" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_XCx6ISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="40" width="144" x="666.5" y="169"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_86c24c30-155f-437b-877f-f66b2e8c9f48" bpmnElement="_86c24c30-155f-437b-877f-f66b2e8c9f48" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2010" y="161" width="56" height="56"/>
+                <!--semId = _86c24c30-155f-437b-877f-f66b2e8c9f48--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="26" width="70" x="2003.2871869181415" y="226.4786619635529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_852af125-b169-45e0-be4a-21435aebc70c" bpmnElement="Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1270" y="151" width="151" height="76"/>
+                <!--semId = Bpmn_UserTask_ZLf6ISqSEee9dOUnH0MpZQ--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="40" width="144" x="1273.5" y="169"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Bpmndi_BPMNShape_kYvfUAQqEeev4LOvjrydZw" bpmnElement="Bpmn_DataObject_kTDHAQQqEeev4LOvjrydZw" color:background-color="#E4E4E4" color:border-color="#999999">
+                <dc:Bounds x="703" y="260" width="68" height="56"/>
+                <!--semId = Bpmn_DataObject_kTDHAQQqEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000" trisobpmn:defaultBounds="true">
+                    <dc:Bounds height="12" width="84" x="697.060606060606" y="329.01725894094005"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_kbhtkAQqEeev4LOvjrydZw" bpmnElement="Bpmn_DataOutputAssociation_kbiUoAQqEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_6cd78668-0d6c-4617-919d-f0650cfbc1ae">
+                <di:waypoint x="738" y="227"/>
+                <di:waypoint x="738" y="260"/>
+                <!--semId = Bpmn_DataOutputAssociation_kbiUoAQqEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="738" y="227"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_3-AOsQQqEeev4LOvjrydZw" bpmnElement="Bpmn_DataInputAssociation_3-A1wAQqEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" targetElement="BPMN_Shape_584c4307-b03c-4df7-ad30-d606bee9b472">
+                <di:waypoint x="771" y="288"/>
+                <di:waypoint x="1308" y="288"/>
+                <di:waypoint x="1308" y="569"/>
+                <!--semId = Bpmn_DataInputAssociation_3-A1wAQqEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="771" y="288"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LSDiagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c_0">
+            <dc:Font name="Arial" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="Diagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90" name="IT">
+        <bpmndi:BPMNPlane bpmnElement="Collaboration_78d0e7ab-8452-45ec-8a47-6c48a6a32b90" id="Diagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_plane" trisobpmn:diagramWidth="1450" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="BPMN_Shape_4c3f552f-cd7a-41a7-a6d2-504a0aee7317" bpmnElement="_4c3f552f-cd7a-41a7-a6d2-504a0aee7317" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="20" y="19" width="1380" height="266"/>
+                <!--semId = _4c3f552f-cd7a-41a7-a6d2-504a0aee7317--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="2760" x="-670" y="285"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_b80dfc69-cd3b-40fc-b271-a1eee0bdb993" bpmnElement="_b80dfc69-cd3b-40fc-b271-a1eee0bdb993" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1306" y="68" width="56" height="56"/>
+                <!--semId = _b80dfc69-cd3b-40fc-b271-a1eee0bdb993--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="112" x="1278" y="124"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_f423b6da-adea-44cf-b2df-b5f3b1021e6a" bpmnElement="_f423b6da-adea-44cf-b2df-b5f3b1021e6a" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1213" y="95"/>
+                <di:waypoint x="1306" y="95"/>
+                <!--semId = _f423b6da-adea-44cf-b2df-b5f3b1021e6a--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1213" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_e9ce1132-090e-4135-8783-3b7b46cebb8f" bpmnElement="_e9ce1132-090e-4135-8783-3b7b46cebb8f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="929" y="189" width="113" height="22"/>
+                <!--semId = _e9ce1132-090e-4135-8783-3b7b46cebb8f--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="226" x="872.5" y="211"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_aac730d2-9387-4d98-8c9a-793dbbac9e76" bpmnElement="_aac730d2-9387-4d98-8c9a-793dbbac9e76" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="948" y="133"/>
+                <di:waypoint x="948" y="189"/>
+                <!--semId = _aac730d2-9387-4d98-8c9a-793dbbac9e76--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="948" y="133"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_93800974-affe-4326-ab78-71f6e095d061" bpmnElement="_93800974-affe-4326-ab78-71f6e095d061" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="106" y="67" width="56" height="56"/>
+                <!--semId = _93800974-affe-4326-ab78-71f6e095d061--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="112" x="78" y="123"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_9bd2bec1-4e16-4796-9116-973580864a83" bpmnElement="_9bd2bec1-4e16-4796-9116-973580864a83" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="162" y="95"/>
+                <di:waypoint x="229" y="95"/>
+                <!--semId = _9bd2bec1-4e16-4796-9116-973580864a83--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="162" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_415821a5-acad-45b0-bf63-1024828e034f" bpmnElement="_415821a5-acad-45b0-bf63-1024828e034f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1062" y="57" width="151" height="76"/>
+                <!--semId = _415821a5-acad-45b0-bf63-1024828e034f--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="147" x="1064" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_425a3093-06b7-490e-9d8e-dd7056fb0095" bpmnElement="_425a3093-06b7-490e-9d8e-dd7056fb0095" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="1004" y="95"/>
+                <di:waypoint x="1062" y="95"/>
+                <!--semId = _425a3093-06b7-490e-9d8e-dd7056fb0095--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="1004" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859" bpmnElement="dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="697" y="180" width="48" height="56"/>
+                <!--semId = dataStoreReference_dd0b0e9f-11af-40ca-ae66-c6bdcbd4c859--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="96" x="673" y="236"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_e02e2802-09de-4ffd-a7f9-850ce33f4e9d" bpmnElement="_e02e2802-09de-4ffd-a7f9-850ce33f4e9d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="437" y="57" width="151" height="76"/>
+                <!--semId = _e02e2802-09de-4ffd-a7f9-850ce33f4e9d--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="147" x="439" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_4b3d40cd-bcf5-4296-b244-b6ca7a458f78" bpmnElement="_4b3d40cd-bcf5-4296-b244-b6ca7a458f78" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="380" y="95"/>
+                <di:waypoint x="437" y="95"/>
+                <!--semId = _4b3d40cd-bcf5-4296-b244-b6ca7a458f78--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="380" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_544ce9a6-a3da-418f-9f29-9244fbf8f5bc" bpmnElement="_544ce9a6-a3da-418f-9f29-9244fbf8f5bc" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="588" y="95"/>
+                <di:waypoint x="645" y="95"/>
+                <!--semId = _544ce9a6-a3da-418f-9f29-9244fbf8f5bc--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="588" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_2639c0ab-4f3b-400b-be49-4761ddfed6ff" bpmnElement="_2639c0ab-4f3b-400b-be49-4761ddfed6ff" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="645" y="57" width="151" height="76"/>
+                <!--semId = _2639c0ab-4f3b-400b-be49-4761ddfed6ff--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="147" x="647" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4" bpmnElement="_1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="796" y="95"/>
+                <di:waypoint x="853" y="95"/>
+                <!--semId = _1a4f06b1-2ba2-4e0f-a6bb-1f51e59e31d4--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="796" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_e645bdae-1905-40cb-b0bd-2edcaaa351f9" bpmnElement="_e645bdae-1905-40cb-b0bd-2edcaaa351f9" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="853" y="57" width="151" height="76"/>
+                <!--semId = _e645bdae-1905-40cb-b0bd-2edcaaa351f9--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="147" x="855" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f" bpmnElement="_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="229" y="57" width="151" height="76"/>
+                <!--semId = _0d3f9854-c8bb-45df-93ea-b4ec6fe0710f--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="33" width="147" x="231" y="95"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Bpmndi_BPMNShape_xljM8AQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataStoreReference_xkakgAQsEeev4LOvjrydZw" color:background-color="#E4E4E4" color:border-color="#999999">
+                <dc:Bounds x="170" y="194" width="49" height="44"/>
+                <!--semId = Bpmn_DataStoreReference_xkakgAQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="98" x="145.5" y="238"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0" bpmnElement="_14e102e8-c9a3-4f05-b536-8c3ddd5a52f0" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_2639c0ab-4f3b-400b-be49-4761ddfed6ff">
+                <di:waypoint x="721" y="138"/>
+                <di:waypoint x="721" y="180"/>
+                <!--semId = _14e102e8-c9a3-4f05-b536-8c3ddd5a52f0--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="721" y="138"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_40f59712-22d7-4a8a-8fdb-ef1461b2d8be" bpmnElement="_40f59712-22d7-4a8a-8fdb-ef1461b2d8be" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f">
+                <di:waypoint x="304" y="133"/>
+                <di:waypoint x="304" y="208"/>
+                <di:waypoint x="697" y="208"/>
+                <!--semId = _40f59712-22d7-4a8a-8fdb-ef1461b2d8be--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="304" y="133"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_a7686b51-3e57-4c5c-bfd3-582d75e85ef2" bpmnElement="_a7686b51-3e57-4c5c-bfd3-582d75e85ef2" color:border-color="#000000" triso:userconstraints="false" targetElement="BPMN_Shape_e645bdae-1905-40cb-b0bd-2edcaaa351f9">
+                <di:waypoint x="745" y="207"/>
+                <di:waypoint x="891" y="207"/>
+                <di:waypoint x="891" y="133"/>
+                <!--semId = _a7686b51-3e57-4c5c-bfd3-582d75e85ef2--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="745" y="207"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_zKOrwAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataInputAssociation_zKPS0AQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" targetElement="BPMN_Shape_0d3f9854-c8bb-45df-93ea-b4ec6fe0710f">
+                <di:waypoint x="219" y="216"/>
+                <di:waypoint x="271" y="216"/>
+                <di:waypoint x="271" y="133"/>
+                <!--semId = Bpmn_DataInputAssociation_zKPS0AQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="219" y="216"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_0F1_cAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataOutputAssociation_0F1_cgQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_93800974-affe-4326-ab78-71f6e095d061">
+                <di:waypoint x="134" y="123"/>
+                <di:waypoint x="134" y="211"/>
+                <di:waypoint x="170" y="211"/>
+                <!--semId = Bpmn_DataOutputAssociation_0F1_cgQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="134" y="123"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LSDiagram_78d0e7ab-8452-45ec-8a47-6c48a6a32b90_0">
+            <dc:Font name="Arial" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="Diagram_80fecfcd-0165-4c36-90b6-3ea384265fe7" name="Payroll">
+        <bpmndi:BPMNPlane bpmnElement="Collaboration_80fecfcd-0165-4c36-90b6-3ea384265fe7" id="Diagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_plane" trisobpmn:diagramWidth="1209" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="BPMN_Shape_227a38f2-af6e-4efa-b10a-be9c70d53c8f" bpmnElement="_227a38f2-af6e-4efa-b10a-be9c70d53c8f" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="17" y="26" width="1142" height="284"/>
+                <!--semId = _227a38f2-af6e-4efa-b10a-be9c70d53c8f--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="2284" x="-554" y="310"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_2404b367-08bf-4cb6-a685-3f9450b5a93e" bpmnElement="_2404b367-08bf-4cb6-a685-3f9450b5a93e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="775" y="64" width="151" height="76"/>
+                <!--semId = _2404b367-08bf-4cb6-a685-3f9450b5a93e--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="33" width="147" x="777" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_80ec0079-4266-4d71-8f9d-ff979f0d8884" bpmnElement="_80ec0079-4266-4d71-8f9d-ff979f0d8884" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="499" y="102"/>
+                <di:waypoint x="775" y="102"/>
+                <!--semId = _80ec0079-4266-4d71-8f9d-ff979f0d8884--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="499" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_17ebbefb-67fe-4e16-b21d-d7267c965946" bpmnElement="_17ebbefb-67fe-4e16-b21d-d7267c965946" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="717" y="234"/>
+                <di:waypoint x="745" y="234"/>
+                <di:waypoint x="745" y="121"/>
+                <di:waypoint x="775" y="121"/>
+                <!--semId = _17ebbefb-67fe-4e16-b21d-d7267c965946--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="717" y="234"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_0caff436-0236-4ccc-85df-9ea1bd413f1a" bpmnElement="_0caff436-0236-4ccc-85df-9ea1bd413f1a" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="926" y="102"/>
+                <di:waypoint x="1049" y="102"/>
+                <!--semId = _0caff436-0236-4ccc-85df-9ea1bd413f1a--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="926" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26" bpmnElement="_2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26" isMarkerVisible="false" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="443" y="74" width="56" height="56"/>
+                <!--semId = _2aa9e64a-85d1-4a14-a9e5-d2aa180f2d26--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="33" width="112" x="415" y="130"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_bc6f05af-a198-4b6f-9e16-1b7991481787" bpmnElement="_bc6f05af-a198-4b6f-9e16-1b7991481787" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="377" y="102"/>
+                <di:waypoint x="443" y="102"/>
+                <!--semId = _bc6f05af-a198-4b6f-9e16-1b7991481787--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="377" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMN_Edge_424096a5-1272-4c87-8325-a68b47505510" bpmnElement="_424096a5-1272-4c87-8325-a68b47505510" color:border-color="#000000" triso:userconstraints="false">
+                <di:waypoint x="471" y="131"/>
+                <di:waypoint x="471" y="234"/>
+                <di:waypoint x="566" y="234"/>
+                <!--semId = _424096a5-1272-4c87-8325-a68b47505510--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="471" y="131"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_381d8a4f-a4be-447a-b58e-e6db6f08fb03" bpmnElement="_381d8a4f-a4be-447a-b58e-e6db6f08fb03" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="103" y="74" width="56" height="56"/>
+                <!--semId = _381d8a4f-a4be-447a-b58e-e6db6f08fb03--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="33" width="112" x="75" y="130"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_5da6e12e-f982-469a-bb0a-0bd37d83acb8" bpmnElement="_5da6e12e-f982-469a-bb0a-0bd37d83acb8" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="159" y="102"/>
+                <di:waypoint x="226" y="102"/>
+                <!--semId = _5da6e12e-f982-469a-bb0a-0bd37d83acb8--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="159" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_88bbd82d-e83a-41c9-82c7-4f12e87faa9c" bpmnElement="dataStoreReference_88bbd82d-e83a-41c9-82c7-4f12e87faa9c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="847" y="203" width="48" height="56"/>
+                <!--semId = dataStoreReference_88bbd82d-e83a-41c9-82c7-4f12e87faa9c--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="96" x="823" y="259"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_a2ef4322-1618-48b7-8c00-6acc30cf23f6" bpmnElement="_a2ef4322-1618-48b7-8c00-6acc30cf23f6" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1049" y="74" width="56" height="56"/>
+                <!--semId = _a2ef4322-1618-48b7-8c00-6acc30cf23f6--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="112" x="1021" y="130"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_92ef5d57-54e8-4717-97ae-c3d8560497c1" bpmnElement="_92ef5d57-54e8-4717-97ae-c3d8560497c1" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="566" y="196" width="151" height="76"/>
+                <!--semId = _92ef5d57-54e8-4717-97ae-c3d8560497c1--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="33" width="147" x="568" y="234"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_39a6e320-01a9-48a4-9988-bcbb092c9eba" bpmnElement="_39a6e320-01a9-48a4-9988-bcbb092c9eba" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="226" y="64" width="151" height="76"/>
+                <!--semId = _39a6e320-01a9-48a4-9988-bcbb092c9eba--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="33" width="147" x="228" y="102"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Bpmndi_BPMNShape_iMafwAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataObject_iLnOgQQsEeev4LOvjrydZw" color:background-color="#E4E4E4" color:border-color="#999999">
+                <dc:Bounds x="198" y="215" width="35" height="35"/>
+                <!--semId = Bpmn_DataObject_iLnOgQQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="70" x="180.5" y="250"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_0d4940de-b2cc-4216-8fd7-efc71ecebf80" bpmnElement="_0d4940de-b2cc-4216-8fd7-efc71ecebf80" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_2404b367-08bf-4cb6-a685-3f9450b5a93e">
+                <di:waypoint x="825" y="140"/>
+                <di:waypoint x="825" y="171"/>
+                <di:waypoint x="871" y="171"/>
+                <di:waypoint x="871" y="203"/>
+                <!--semId = _0d4940de-b2cc-4216-8fd7-efc71ecebf80--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="825" y="140"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_iOm4IAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataOutputAssociation_iOm4IQQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_381d8a4f-a4be-447a-b58e-e6db6f08fb03">
+                <di:waypoint x="131" y="130"/>
+                <di:waypoint x="131" y="232"/>
+                <di:waypoint x="198" y="232"/>
+                <!--semId = Bpmn_DataOutputAssociation_iOm4IQQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="131" y="130"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_lqM1QAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataInputAssociation_lqM1QgQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" targetElement="BPMN_Shape_39a6e320-01a9-48a4-9988-bcbb092c9eba">
+                <di:waypoint x="233" y="231"/>
+                <di:waypoint x="301" y="231"/>
+                <di:waypoint x="301" y="140"/>
+                <!--semId = Bpmn_DataInputAssociation_lqM1QgQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="233" y="231"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LSDiagram_80fecfcd-0165-4c36-90b6-3ea384265fe7_0">
+            <dc:Font name="Arial" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="Diagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e" name="Facilities">
+        <bpmndi:BPMNPlane bpmnElement="Collaboration_94435ba7-4027-4df9-ad3b-df1f6e068e5e" id="Diagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_plane" trisobpmn:diagramWidth="829" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="BPMN_Shape_6fd335df-160b-408c-9ce2-2aa5bba323fc" bpmnElement="_6fd335df-160b-408c-9ce2-2aa5bba323fc" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="17" y="27.5" width="762" height="253"/>
+                <!--semId = _6fd335df-160b-408c-9ce2-2aa5bba323fc--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="1524" x="-364" y="280.5"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BPMN_Shape_331333d9-a9f7-4bc6-b625-0b43d3d89dbc" bpmnElement="_331333d9-a9f7-4bc6-b625-0b43d3d89dbc" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="103" y="73" width="56" height="56"/>
+                <!--semId = _331333d9-a9f7-4bc6-b625-0b43d3d89dbc--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="33" width="112" x="75" y="129"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_4e16051c-1b37-432a-80d6-647c47b5586c" bpmnElement="_4e16051c-1b37-432a-80d6-647c47b5586c" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="159" y="101"/>
+                <di:waypoint x="226" y="101"/>
+                <!--semId = _4e16051c-1b37-432a-80d6-647c47b5586c--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="159" y="101"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_5298ebe4-6a15-4c62-8da1-8048dec4be38" bpmnElement="_5298ebe4-6a15-4c62-8da1-8048dec4be38" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="226" y="65.5" width="151" height="76"/>
+                <!--semId = _5298ebe4-6a15-4c62-8da1-8048dec4be38--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="147" x="228" y="103.5"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_81b63d83-b0d6-4941-8df4-4aec650abb56" bpmnElement="_81b63d83-b0d6-4941-8df4-4aec650abb56" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="377" y="103"/>
+                <di:waypoint x="434" y="103"/>
+                <!--semId = _81b63d83-b0d6-4941-8df4-4aec650abb56--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="377" y="103"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_9eddb25a-f6dc-4456-8c23-92fc35e43bcc" bpmnElement="_9eddb25a-f6dc-4456-8c23-92fc35e43bcc" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="434" y="65.5" width="151" height="76"/>
+                <!--semId = _9eddb25a-f6dc-4456-8c23-92fc35e43bcc--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="33" width="147" x="436" y="103.5"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMN_Edge_d37a24be-32ed-4e3e-8e91-0d14a5af4e46" bpmnElement="_d37a24be-32ed-4e3e-8e91-0d14a5af4e46" color:border-color="#000000" triso:userconstraints="true">
+                <di:waypoint x="585" y="103"/>
+                <di:waypoint x="671" y="103"/>
+                <!--semId = _d37a24be-32ed-4e3e-8e91-0d14a5af4e46--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="585" y="103"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="BPMN_Shape_1bd46ce2-3b9e-4ce0-a4ad-73f9208ecfa4" bpmnElement="_1bd46ce2-3b9e-4ce0-a4ad-73f9208ecfa4" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="671" y="73.5" width="56" height="56"/>
+                <!--semId = _1bd46ce2-3b9e-4ce0-a4ad-73f9208ecfa4--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="112" x="643" y="129.5"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Bpmndi_BPMNShape_RakTMAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataObject_RX4LkQQsEeev4LOvjrydZw" color:background-color="#E4E4E4" color:border-color="#999999">
+                <dc:Bounds x="315" y="189" width="65" height="50"/>
+                <!--semId = Bpmn_DataObject_RX4LkQQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="130" x="282.5" y="239"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_Rdj80AQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataOutputAssociation_Rdj80QQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" sourceElement="BPMN_Shape_331333d9-a9f7-4bc6-b625-0b43d3d89dbc">
+                <di:waypoint x="131" y="129"/>
+                <di:waypoint x="131" y="214"/>
+                <di:waypoint x="315" y="214"/>
+                <!--semId = Bpmn_DataOutputAssociation_Rdj80QQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="131" y="129"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_SnKCIAQsEeev4LOvjrydZw" bpmnElement="Bpmn_DataInputAssociation_SnKpMAQsEeev4LOvjrydZw" color:border-color="#000000" triso:userconstraints="false" targetElement="BPMN_Shape_9eddb25a-f6dc-4456-8c23-92fc35e43bcc">
+                <di:waypoint x="380" y="214"/>
+                <di:waypoint x="503" y="214"/>
+                <di:waypoint x="503" y="141"/>
+                <!--semId = Bpmn_DataInputAssociation_SnKpMAQsEeev4LOvjrydZw--><bpmndi:BPMNLabel labelStyle="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0" color:color="#000000"><dc:Bounds height="16.5" width="0" x="380" y="214"/></bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LSDiagram_94435ba7-4027-4df9-ad3b-df1f6e068e5e_0">
+            <dc:Font name="Arial" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -8,6 +8,10 @@ import Viewer from 'lib/Viewer';
 
 import inherits from 'inherits';
 
+import {
+  isFunction
+} from 'min-dash';
+
 
 describe('Viewer', function() {
 
@@ -18,10 +22,15 @@ describe('Viewer', function() {
   });
 
 
-  function createViewer(xml, done) {
+  function createViewer(xml, diagramId, done) {
+    if (isFunction(diagramId)) {
+      done = diagramId;
+      diagramId = null;
+    }
+
     var viewer = new Viewer({ container: container });
 
-    viewer.importXML(xml, function(err, warnings) {
+    viewer.importXML(xml, diagramId, function(err, warnings) {
       done(err, warnings, viewer);
     });
   }
@@ -660,6 +669,68 @@ describe('Viewer', function() {
       var viewer = new Viewer({ container: container });
 
       var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      // when
+      viewer.importXML(xml);
+
+      // then
+      viewer.on('import.done', function(event) {
+        done();
+      });
+    });
+
+
+    it('should import BPMN with multiple diagrams without diagram id specified', function(done) {
+
+      // given
+      var xml = require('../fixtures/bpmn/multiple-diagrams.bpmn');
+
+      // when
+      createViewer(xml, function(err) {
+
+        // then
+        done(err);
+      });
+    });
+
+
+    it('should import BPMN with multiple diagrams with diagram id specified', function(done) {
+
+      // given
+      var xml = require('../fixtures/bpmn/multiple-diagrams.bpmn');
+
+      // when
+      createViewer(xml, 'Diagram_80fecfcd-0165-4c36-90b6-3ea384265fe7', function(err) {
+
+        // then
+        done(err);
+      });
+    });
+
+
+    it('should complete with error if diagram of provided ID does not exist', function(done) {
+
+      // given
+      var xml = require('../fixtures/bpmn/multiple-diagrams.bpmn');
+
+      // when
+      createViewer(xml, 'Diagram_IDontExist', function(err) {
+
+        // then
+        expect(err).to.exist;
+        expect(err.message).to.eql('BPMNDiagram not found');
+
+        done();
+      });
+    });
+
+
+    it('should import BPMN with multiple diagrams when only xml is provided', function(done) {
+
+      // given
+      var viewer = new Viewer({ container: container });
+
+      var xml = require('../fixtures/bpmn/multiple-diagrams.bpmn');
 
       // when
       viewer.importXML(xml);

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -763,15 +763,40 @@ describe('Viewer', function() {
 
         expect(definitions).to.exist;
 
-        viewer.open(diagramId2, function(err, warnings) {
+        viewer.open(diagramId2, function(err) {
 
           // then
           expect(err).not.to.exist;
-          expect(warnings).to.be.empty;
 
           var definitions = viewer.getDefinitions();
 
           expect(definitions).to.exist;
+
+          done();
+        });
+      });
+    });
+
+
+    it('should open the first diagram if id was not provided', function(done) {
+
+      // given
+      var firstDiagramId = 'Diagram_35ab9b1f-354a-48cb-9b99-f4e448f7b04c';
+
+      // when
+      createViewer(xml, firstDiagramId, function(err, warnings, viewer) {
+
+        // then
+        var elements1 = viewer.get('elementRegistry').getAll().slice();
+
+        viewer.open(function(err) {
+
+          // then
+          expect(err).not.to.exist;
+
+          var elements2 = viewer.get('elementRegistry').getAll();
+
+          expect(elements2).to.have.lengthOf(elements1.length);
 
           done();
         });
@@ -837,7 +862,7 @@ describe('Viewer', function() {
       var events = [];
 
       // when
-      viewer.importXML(xml, diagramId1, function(err) {
+      viewer.importXML(xml, diagramId1, function() {
 
         // when
         viewer.on([


### PR DESCRIPTION
Different diagrams (processes or collaborations) can be saved inside a single XML file, following BPMN 2.0 standard, but bpmn-js renders only the first diagram.

This commit allows a developer to select a specific diagram to be rendered, using the ID of the process or collaboration in this simply way:

`bpmnViewer.importXML(bpmnXML, done, processId);`

The first diagram (like before) will be rendered if processId is null

bpmn-js internally already supported the selection of a specific diagram to render, but the interfaces did not allow this

This is useful for #87 