### PR TITLE
added sideffect BpmnRenderer.js …

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE",
   "sideEffects": [
+    "./lib/draw/BpmnRenderer.js",
     "*.css"
   ],
   "devDependencies": {


### PR DESCRIPTION
When extending BpmnRenderer in a build that has angular-devkit/build-optimizer optimization turned on the inherits library gets marked as pure.

I.E.
/\*@\_\_PURE\_\_\*/ inherits(BpmnRenderer, BaseRenderer);

according to the angular-devkit/build-optimizer
https://www.npmjs.com/package/@angular-devkit/build-optimizer

Some of these optimizations add /\*\@\_\_PURE\_\_\*/ comments. These are used by JS optimization tools to identify pure functions that can potentially be dropped.

in the production build because inherits is marked as pure it is dropped and BpmnRenderer fails to extend BaseRenderer so errors are thrown when getConnectionPath is called. This is because the prototype for the inheritance of BaseRenderer is missing from the object.

the /\*@\_\_PURE\_\_\*/  prefix is added by the getPrefixFunctionsTransformer function in @angular-devkit/build-optimizer/src/transforms/prefix-functions.js

Since BpmnRenderer has a sideEffect of dropping inherits from build optimization when imported directly I believe it is appropriate to add this line to the sideEffect list in the package.json. 

This lets the build optimization tools know not to optimize this file when imported and allows for successful extension of the BpmnRenderer.

__Which issue does this PR address?_ None
