### PR TITLE
fix(BpmnTreeWalker): pass context to unhandled process handler

### DIFF
--- a/lib/import/BpmnTreeWalker.js
+++ b/lib/import/BpmnTreeWalker.js
@@ -255,7 +255,7 @@ export default function BpmnTreeWalker(handler, translate) {
     handled(process);
   }
 
-  function handleUnhandledProcesses(rootElements) {
+  function handleUnhandledProcesses(rootElements, ctx) {
 
     // walk through all processes that have not yet been drawn and draw them
     // if they contain lanes with DI information.
@@ -264,7 +264,7 @@ export default function BpmnTreeWalker(handler, translate) {
       return !isHandled(e) && is(e, 'bpmn:Process') && e.laneSets;
     });
 
-    processes.forEach(contextual(handleProcess));
+    processes.forEach(contextual(handleProcess, ctx));
   }
 
   function handleMessageFlow(messageFlow, context) {

--- a/test/fixtures/bpmn/import/data-store.outside-participant.dangling.bpmn
+++ b/test/fixtures/bpmn/import/data-store.outside-participant.dangling.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0s7ms7v" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="3.3.1">
+  <bpmn:collaboration id="Collaboration">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false" />
+  <bpmn:process id="Process_2" isExecutable="false">
+    <bpmn:laneSet id="LaneSet">
+        <bpmn:lane name="Lane 1" id="Lane" />>
+    </bpmn:laneSet>
+    <bpmn:dataStoreReference id="DataStoreReference" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="158" y="73" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_di" bpmnElement="DataStoreReference">
+        <dc:Bounds x="42" y="350" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/import/ImporterSpec.js
+++ b/test/spec/import/ImporterSpec.js
@@ -338,7 +338,8 @@ describe('import - Importer', function() {
 
     });
 
-    it('should import data store in particpant as child of collaboration', function(done) {
+
+    it('should import data store in participant as child of collaboration', function(done) {
 
       // given
       var xml = require('../../fixtures/bpmn/import/data-store.outside-participant.participant.bpmn');
@@ -377,6 +378,23 @@ describe('import - Importer', function() {
 
         done(err);
       });
+    });
+
+
+    it('should import data store outside of participant without warnings', function(done) {
+
+      // given
+      var xml = require('../../fixtures/bpmn/import/data-store.outside-participant.dangling.bpmn');
+
+      // when
+      runImport(diagram, xml, function(err, warnings) {
+
+        // then
+        expect(warnings).to.be.empty;
+
+        done(err);
+      });
+
     });
 
   });


### PR DESCRIPTION
Previously, we wouldn't pass context to `contextual` which didn't make any sense. This was created as part of https://github.com/bpmn-io/bpmn-js/pull/967 or `bpmn-js/select-diagram`. 