### PR TITLE
Removed fill and stroke from id for markers

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -124,7 +124,7 @@ export default function BpmnRenderer(
   }
 
   function marker(type, fill, stroke) {
-    var id = type + '-' + fill + '-' + stroke + '-' + rendererId;
+    var id = type + rendererId;
 
     if (!markers[id]) {
       createMarker(type, fill, stroke);
@@ -134,7 +134,7 @@ export default function BpmnRenderer(
   }
 
   function createMarker(type, fill, stroke) {
-    var id = type + '-' + fill + '-' + stroke + '-' + rendererId;
+    var id = type + rendererId;
 
     if (type === 'sequenceflow-end') {
       var sequenceflowEnd = svgCreate('path');


### PR DESCRIPTION
The fill and stroke properties are derived from defaultFillColor and defaultStrokeColor. If you use more complex colors for these values (e.g. rgba(x, x, x, x) which is perfectly ok for the color values in the resulting svg), the resulting id contains characters which are not valid in urls (space and comma in this example). And following that, they cannot be used as reference to the markers definition in the svg.

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?_

Closes #