### PR TITLE
feat(modeling): adjust default collapsed participant height to 60px

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -159,7 +159,7 @@ ElementFactory.prototype._getDefaultSize = function(semantic) {
 
   if (is(semantic, 'bpmn:Participant')) {
     if (!isExpanded(semantic)) {
-      return { width: 400, height: 100 };
+      return { width: 400, height: 60 };
     } else {
       return { width: 600, height: 250 };
     }

--- a/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
+++ b/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
@@ -165,9 +165,9 @@ describe('features/grid-snapping', function() {
       it('participant (no auto resize)', inject(function(bpmnReplace) {
 
         // given
-        var bounds = assign(
+        var collapsedBounds = assign(
           getBounds(participant),
-          { height: 100 }
+          { height: 60 }
         );
 
         // when
@@ -179,7 +179,7 @@ describe('features/grid-snapping', function() {
         );
 
         // then
-        expect(collapsedParticipant).to.have.bounds(bounds);
+        expect(collapsedParticipant).to.have.bounds(collapsedBounds);
       }));
 
 

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -3,6 +3,11 @@ import {
   inject
 } from 'test/TestHelper';
 
+import {
+  assign,
+  pick
+} from 'min-dash';
+
 import modelingModule from 'lib/features/modeling';
 import replaceModule from 'lib/features/replace';
 import moveModule from 'diagram-js/lib/features/move';
@@ -292,16 +297,19 @@ describe('features/replace - bpmn replace', function() {
       // given
       var shape = elementRegistry.get('Participant_1');
 
+      var collapsedBounds = assign({}, getBounds(shape), { height: 60 });
+
       // when
-      var newShape = bpmnReplace.replaceElement(shape, { type: 'bpmn:Participant', isExpanded: false });
+      var newShape = bpmnReplace.replaceElement(shape, {
+        type: 'bpmn:Participant',
+        isExpanded: false
+      });
 
       // then
       expect(isExpanded(newShape)).to.be.false; // collapsed
       expect(newShape.children).to.be.empty;
 
-      expect(newShape.width).to.equal(shape.width);
-      // default height for collapsed pool
-      expect(newShape.height).to.equal(100);
+      expect(newShape).to.have.bounds(collapsedBounds);
     }));
 
 
@@ -1512,4 +1520,8 @@ function skipId(key, value) {
   }
 
   return value;
+}
+
+function getBounds(shape) {
+  return pick(shape, [ 'x', 'y', 'width', 'height' ]);
 }

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -318,16 +318,19 @@ describe('features/replace - bpmn replace', function() {
       // given
       var shape = elementRegistry.get('Participant_2');
 
+      var expandedBounds = assign({}, getBounds(shape), { height: 250 });
+
       // when
-      var newShape = bpmnReplace.replaceElement(shape, { type: 'bpmn:Participant', isExpanded: true });
+      var newShape = bpmnReplace.replaceElement(shape, {
+        type: 'bpmn:Participant',
+        isExpanded: true
+      });
 
       // then
       expect(isExpanded(newShape)).to.be.true; // expanded
       expect(newShape.children).to.be.empty;
 
-      expect(newShape.width).to.equal(shape.width);
-      // default height for expanded pool
-      expect(newShape.height).to.equal(250);
+      expect(newShape).to.have.bounds(expandedBounds);
     }));
 
   });


### PR DESCRIPTION
This is a follow up to https://github.com/bpmn-io/bpmn-js/pull/975.

It sets the default height of collapsed pools to `60px` to better align with the behavior of other tools.