### PR TITLE
Group-Frame support

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -83,6 +83,12 @@ ElementFactory.prototype.createBpmnElement = function(elementType, attrs) {
     }
   }
 
+  if (is(businessObject, 'bpmn:Group')) {
+    attrs = assign({
+      isFrame: true
+    }, attrs);
+  }
+
   if (attrs.colors) {
     assign(businessObject.di, attrs.colors);
 

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -15,7 +15,7 @@ import {
 /**
  * a simple ordering provider that makes sure:
  *
- * (0) labels are rendered always on top
+ * (0) labels and groups are rendered always on top
  * (1) elements are ordered by a {level} property
  */
 export default function BpmnOrderingProvider(eventBus, canvas, translate) {
@@ -63,6 +63,7 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
       }
     },
     { type: 'bpmn:BoundaryEvent', order: { level: 8 } },
+    { type: 'bpmn:Group', order: { level: 10 } },
     { type: 'bpmn:FlowElement', order: { level: 5 } },
     { type: 'bpmn:Participant', order: { level: -2 } },
     { type: 'bpmn:Lane', order: { level: -1 } }

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -254,6 +254,10 @@ function isTextAnnotation(element) {
   return is(element, 'bpmn:TextAnnotation');
 }
 
+function isGroup(element) {
+  return is(element, 'bpmn:Group');
+}
+
 function isCompensationBoundary(element) {
   return is(element, 'bpmn:BoundaryEvent') &&
          hasEventDefinition(element, 'bpmn:CompensateEventDefinition');
@@ -455,7 +459,7 @@ function canDrop(element, target, position) {
   }
 
   // allow to create new participants on
-  // on existing collaboration and process diagrams
+  // existing collaboration and process diagrams
   if (is(element, 'bpmn:Participant')) {
     return is(target, 'bpmn:Process') || is(target, 'bpmn:Collaboration');
   }
@@ -774,6 +778,10 @@ function canResize(shape, newBounds) {
   }
 
   if (isTextAnnotation(shape)) {
+    return true;
+  }
+
+  if (isGroup(shape)) {
     return true;
   }
 

--- a/test/fixtures/bpmn/simple-resizable.bpmn
+++ b/test/fixtures/bpmn/simple-resizable.bpmn
@@ -13,6 +13,7 @@
       <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="SubProcess_1" targetRef="EndEvent_1" />
+    <bpmn:group id="Group_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -45,6 +46,9 @@
           <dc:Bounds x="710" y="232" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
+        <dc:Bounds x="264" y="42" width="500" height="400" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/features/modeling/ResizeShapeSpec.js
+++ b/test/spec/features/modeling/ResizeShapeSpec.js
@@ -3,6 +3,10 @@ import {
   inject
 } from 'test/TestHelper';
 
+import {
+  getBusinessObject
+} from 'lib/util/ModelUtil';
+
 import modelingModule from 'lib/features/modeling';
 import coreModule from 'lib/core';
 
@@ -18,53 +22,104 @@ describe('features/modeling - resize shape', function() {
 
   describe('shape', function() {
 
-
-    it('should resize', inject(function(elementRegistry, modeling, bpmnFactory) {
+    it('should resize', inject(function(elementRegistry, modeling) {
 
       // given
-      var subProcessElement = elementRegistry.get('SubProcess_1');
-
-      var sequenceFlowElement = elementRegistry.get('SequenceFlow_2'),
-          sequenceFlow = sequenceFlowElement.businessObject;
+      var subProcessElement = elementRegistry.get('SubProcess_1'),
+          originalWidth = subProcessElement.width;
 
       // when
-
-      // Decreasing width by 100px
       modeling.resizeShape(subProcessElement, { x: 339, y: 142, width: 250, height: 200 });
 
       // then
+      expect(subProcessElement.width).to.equal(250);
+      expect(subProcessElement.width).to.not.equal(originalWidth);
 
-      // expect flow layout
-      var diWaypoints = bpmnFactory.createDiWaypoints([
-        { x: 589, y: 242 },
-        { x: 821, y: 242 }
-      ]);
-
-      expect(sequenceFlow.di.waypoint).eql(diWaypoints);
     }));
 
 
-    it('should move', inject(function(elementRegistry, modeling, bpmnFactory) {
+    describe('businessObject', function() {
 
-      // given
-      var subProcessElement = elementRegistry.get('SubProcess_1');
+      it('should update bounds', inject(function(elementRegistry, modeling) {
 
-      var sequenceFlowElement = elementRegistry.get('SequenceFlow_2'),
-          sequenceFlow = sequenceFlowElement.businessObject;
+        // given
+        var subProcessElement = elementRegistry.get('SubProcess_1');
 
-      // when
-      modeling.moveShape(subProcessElement, { x: -50, y: 0 });
+        // when
+        modeling.resizeShape(subProcessElement, { x: 339, y: 142, width: 250, height: 200 });
 
-      // then
+        // then
+        var bo = getBusinessObject(subProcessElement);
+        expect(bo.di.bounds.width).to.equal(250);
+      }));
 
-      // expect flow layout
-      var diWaypoints = bpmnFactory.createDiWaypoints([
-        { x: 639, y: 242 },
-        { x: 821, y: 242 }
-      ]);
 
-      expect(sequenceFlow.di.waypoint).eql(diWaypoints);
-    }));
+      it('should update group bounds', inject(function(elementRegistry, modeling) {
+
+        // given
+        var subProcessElement = elementRegistry.get('Group_1');
+
+        // when
+        modeling.resizeShape(subProcessElement, { x: 250, y: 250, width: 550, height: 400 });
+
+        // then
+        var bo = getBusinessObject(subProcessElement);
+        expect(bo.di.bounds.width).to.equal(550);
+      }));
+
+    });
+
+
+    describe('connected flow', function() {
+
+      it('should resize', inject(function(elementRegistry, modeling, bpmnFactory) {
+
+        // given
+        var subProcessElement = elementRegistry.get('SubProcess_1');
+
+        var sequenceFlowElement = elementRegistry.get('SequenceFlow_2'),
+            sequenceFlow = sequenceFlowElement.businessObject;
+
+        // when
+
+        // Decreasing width by 100px
+        modeling.resizeShape(subProcessElement, { x: 339, y: 142, width: 250, height: 200 });
+
+        // then
+
+        // expect flow layout
+        var diWaypoints = bpmnFactory.createDiWaypoints([
+          { x: 589, y: 242 },
+          { x: 821, y: 242 }
+        ]);
+
+        expect(sequenceFlow.di.waypoint).eql(diWaypoints);
+      }));
+
+
+      it('should move', inject(function(elementRegistry, modeling, bpmnFactory) {
+
+        // given
+        var subProcessElement = elementRegistry.get('SubProcess_1');
+
+        var sequenceFlowElement = elementRegistry.get('SequenceFlow_2'),
+            sequenceFlow = sequenceFlowElement.businessObject;
+
+        // when
+        modeling.moveShape(subProcessElement, { x: -50, y: 0 });
+
+        // then
+
+        // expect flow layout
+        var diWaypoints = bpmnFactory.createDiWaypoints([
+          { x: 639, y: 242 },
+          { x: 821, y: 242 }
+        ]);
+
+        expect(sequenceFlow.di.waypoint).eql(diWaypoints);
+      }));
+
+    });
 
   });
 

--- a/test/spec/features/ordering/BpmnOrderingProviderSpec.js
+++ b/test/spec/features/ordering/BpmnOrderingProviderSpec.js
@@ -283,6 +283,49 @@ describe('features/modeling - ordering', function() {
   });
 
 
+  describe('groups', function() {
+
+    var diagramXML = require('./groups.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+    describe('should stay always in front', function() {
+
+      it('moving <Group> onto <StartEvent>', inject(function() {
+
+        // when
+        move('Group', { x: 100, y: 0 }, 'StartEvent', false);
+
+        // then
+        expectZOrder('StartEvent', 'Group');
+      }));
+
+
+      it('moving <Group> onto <Task>', inject(function() {
+
+        // when
+        move('Group', { x: 200, y: 50 }, 'Task', false);
+
+        // then
+        expectZOrder('Task', 'Group');
+      }));
+
+
+      it('move <Group> onto <SubProcess>', inject(function() {
+
+        // when
+        move('Group', { x: 400, y: 0 }, 'SubProcess', false);
+
+        // then
+        expectZOrder('SubProcess', 'Group');
+      }));
+
+    });
+
+  });
+
+
   describe('connections', function() {
 
     var diagramXML = require('./ordering.bpmn');

--- a/test/spec/features/ordering/groups.bpmn
+++ b/test/spec/features/ordering/groups.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-0fcc2144-457b-4505-9e44-ff673663e3bc" targetNamespace="http://www.signavio.com/bpmn20" exporter="Camunda Modeler" exporterVersion="3.0.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <category id="Category_1">
+    <categoryValue id="CategoryValue_1" value="my group" />
+  </category>
+  <process id="Process_1" processType="None" isExecutable="false">
+    <startEvent id="StartEvent" />
+    <task id="Task" />
+    <subProcess id="SubProcess" />
+    <group id="Group" categoryValueRef="CategoryValue_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Group_1di" bpmnElement="Group">
+        <omgdc:Bounds x="180" y="105" width="188" height="154" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="184" y="107" width="58.28571319580078" height="15" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0yve8vf_di" bpmnElement="StartEvent">
+        <omgdc:Bounds x="450" y="164" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0nb7h9d_di" bpmnElement="Task">
+        <omgdc:Bounds x="418" y="268" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_02cid6e_di" bpmnElement="SubProcess" isExpanded="true">
+        <omgdc:Bounds x="546" y="138" width="350" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/rules/BpmnRules.groups.bpmn
+++ b/test/spec/features/rules/BpmnRules.groups.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:signavio="http://www.signavio.com" xmlns:tns="http://www.signavio.com/bpmn20" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:yaoqiang="http://bpmn.sourceforge.net" id="sid-0fcc2144-457b-4505-9e44-ff673663e3bc" name="" targetNamespace="http://www.signavio.com/bpmn20" exporter="Camunda Modeler" exporterVersion="3.0.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+  <category id="Category_1">
+    <categoryValue id="CategoryValue_1" value="group" />
+  </category>
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_1" />
+    <task id="Task_1" />
+    <subProcess id="SubProcess_1" />
+    <group id="Group_1" categoryValueRef="CategoryValue_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="Group_1">
+        <omgdc:Bounds x="189" y="62" width="400" height="254" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="276" y="98" width="58" height="18.96" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="296" y="379" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_3" bpmnElement="Task_1">
+        <omgdc:Bounds x="370" y="357" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_4" bpmnElement="SubProcess_1" isExpanded="false">
+        <omgdc:Bounds x="501" y="357" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SubProcess_1" />
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1596,6 +1596,31 @@ describe('features/modeling/rules - BpmnRules', function() {
   });
 
 
+  describe('groups', function() {
+
+    var testXML = require('./BpmnRules.groups.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+    describe('should resize', function() {
+
+      it('Group', inject(function(bpmnRules, elementRegistry) {
+
+        // given
+        var groupElement = elementRegistry.get('Group_1');
+
+        // when
+        var canResize = bpmnRules.canResize(groupElement);
+
+        // then
+        expect(canResize).to.be.true;
+      }));
+
+    });
+
+  });
+
+
   describe('lanes', function() {
 
     var testXML = require('./BpmnRules.collaboration-lanes.bpmn');

--- a/test/spec/import/elements/Groups.bpmn
+++ b/test/spec/import/elements/Groups.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-0fcc2144-457b-4505-9e44-ff673663e3bc" targetNamespace="http://www.signavio.com/bpmn20" exporter="Camunda Modeler" exporterVersion="3.0.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <category id="Category_1">
+    <categoryValue id="CategoryValue_1" value="my group" />
+  </category>
+  <process id="Process_1" processType="None" isExecutable="false">
+    <group id="Group_1" categoryValueRef="CategoryValue_1" />
+    <group id="Group_2" categoryValueRef="CategoryValue_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Group_1di" bpmnElement="Group_1">
+        <omgdc:Bounds x="180" y="105" width="188" height="154" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="184" y="107" width="58.28571319580078" height="15" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_2di" bpmnElement="Group_2">
+        <omgdc:Bounds x="180" y="279" width="188" height="154" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="184" y="107" width="58.28571319580078" height="15" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/import/elements/GroupsSpec.js
+++ b/test/spec/import/elements/GroupsSpec.js
@@ -1,0 +1,35 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+
+describe('import - groups', function() {
+
+  describe('should import groups', function() {
+
+    it('with frame property set', function(done) {
+      var xml = require('./Groups.bpmn');
+
+      // given
+      bootstrapModeler(xml)(function(err) {
+
+        // when
+        inject(function(elementRegistry) {
+
+          // then
+          var groupElement = elementRegistry.get('Group_1');
+
+          expect(groupElement).to.exist;
+          expect(groupElement.isFrame).to.be.true;
+
+          done(err);
+        })();
+
+      });
+    });
+
+
+  });
+
+});


### PR DESCRIPTION
This pull request aims to handle `bpmn:Group` elements as frame elements (cf. [new diagram frame feature](https://github.com/bpmn-io/diagram-js/commit/f61579b19a5a125cf0a7eaa92e65c2301e524d4c)) + add basic support for modeling operations (e.g. resizing)

Done by this PR:

* set `isFrame` property to groups on creation 
   * Closes #959 
   * Closes #960 
* allow groups to be resizable
   * Closes #956 
* always draw groups on top
   * Closes #979 