### PR TITLE
chore(bpmn-auto-resize): add test

### DIFF
--- a/lib/features/auto-resize/BpmnAutoResize.js
+++ b/lib/features/auto-resize/BpmnAutoResize.js
@@ -22,10 +22,11 @@ inherits(BpmnAutoResize, AutoResize);
 
 
 /**
- * Resize shapes and lanes
+ * Resize shapes and lanes.
  *
- * @param  {djs.model.Shape} target
- * @param  {Object} newBounds
+ * @param {djs.model.Shape} target
+ * @param {Bounds} newBounds
+ * @param {Object} hints
  */
 BpmnAutoResize.prototype.resize = function(target, newBounds, hints) {
 

--- a/test/spec/features/grid-snapping/behavior/AutoResizeBehavior.bpmn
+++ b/test/spec/features/grid-snapping/behavior/AutoResizeBehavior.bpmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1">
+      <bpmn:task id="Task_1" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="100" y="100" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="275" y="175" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/grid-snapping/behavior/AutoResizeBehaviorSpec.js
+++ b/test/spec/features/grid-snapping/behavior/AutoResizeBehaviorSpec.js
@@ -1,0 +1,48 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import autoResizeModule from 'lib/features/auto-resize';
+import coreModule from 'lib/core';
+import gridSnappingModule from 'lib/features/grid-snapping';
+import modelingModule from 'lib/features/modeling';
+
+
+describe('features/grid-snapping - auto-resize', function() {
+
+  var diagramXML = require('./AutoResizeBehavior.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      autoResizeModule,
+      coreModule,
+      gridSnappingModule,
+      modelingModule
+    ]
+  }));
+
+
+  it('should snap <sw> (width, height)', inject(function(elementRegistry, modeling) {
+
+    // given
+    var subProcess = elementRegistry.get('SubProcess_1'),
+        task = elementRegistry.get('Task_1');
+
+    [
+      { x: 100, y: 100, width: 350, height: 270 },
+      { x: 100, y: 100, width: 450, height: 270 },
+      { x: 100, y: 100, width: 450, height: 360 },
+      { x: 100, y: 100, width: 450, height: 360 },
+      { x: 100, y: 100, width: 560, height: 460 }
+    ].forEach(function(bounds) {
+
+      // when
+      modeling.moveElements([ task ], { x: 36, y: 48 }, subProcess);
+
+      // then
+      expect(subProcess).to.have.bounds(bounds);
+    });
+  }));
+
+});


### PR DESCRIPTION
Since we're overriding `AutoResize#resize` I've added a test ensuring things are still working.

Once we've merged bpmn-io/diagram-js#333 the test will pass.

Requires bpmn-io/diagram-js#333.
Closes #1015.