### PR TITLE
feat(translations): add new keywords

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -313,7 +313,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       assign(actions, {
         'append.end-event': appendAction(
           'bpmn:EndEvent',
-          'bpmn-icon-end-event-none'
+          'bpmn-icon-end-event-none',
+          translate('Append EndEvent')
         ),
         'append.gateway': appendAction(
           'bpmn:ExclusiveGateway',
@@ -322,7 +323,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         ),
         'append.append-task': appendAction(
           'bpmn:Task',
-          'bpmn-icon-task'
+          'bpmn-icon-task',
+          translate('Append Task')
         ),
         'append.intermediate-event': appendAction(
           'bpmn:IntermediateThrowEvent',

--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -121,27 +121,32 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
       separator: true
     },
     'create.start-event': createAction(
-      'bpmn:StartEvent', 'event', 'bpmn-icon-start-event-none'
+      'bpmn:StartEvent', 'event', 'bpmn-icon-start-event-none',
+      translate('Create StartEvent')
     ),
     'create.intermediate-event': createAction(
       'bpmn:IntermediateThrowEvent', 'event', 'bpmn-icon-intermediate-event-none',
       translate('Create Intermediate/Boundary Event')
     ),
     'create.end-event': createAction(
-      'bpmn:EndEvent', 'event', 'bpmn-icon-end-event-none'
+      'bpmn:EndEvent', 'event', 'bpmn-icon-end-event-none',
+      translate('Create EndEvent')
     ),
     'create.exclusive-gateway': createAction(
       'bpmn:ExclusiveGateway', 'gateway', 'bpmn-icon-gateway-none',
       translate('Create Gateway')
     ),
     'create.task': createAction(
-      'bpmn:Task', 'activity', 'bpmn-icon-task'
+      'bpmn:Task', 'activity', 'bpmn-icon-task',
+      translate('Create Task')
     ),
     'create.data-object': createAction(
-      'bpmn:DataObjectReference', 'data-object', 'bpmn-icon-data-object'
+      'bpmn:DataObjectReference', 'data-object', 'bpmn-icon-data-object',
+      translate('Create DataObjectReference')
     ),
     'create.data-store': createAction(
-      'bpmn:DataStoreReference', 'data-store', 'bpmn-icon-data-store'
+      'bpmn:DataStoreReference', 'data-store', 'bpmn-icon-data-store',
+      translate('Create DataStoreReference')
     ),
     'create.subprocess-expanded': createAction(
       'bpmn:SubProcess', 'activity', 'bpmn-icon-subprocess-expanded',


### PR DESCRIPTION
When I use translations there are some tooltips on my pallet that are still in English like `StartEvent`, `EndEvent` or `Task`.
It's a little bit weird because the phrase begins in my language and ends in other language.
The reason for that is because there is a generic keyword `Create {type}`.
I'm suggesting create specific keywords for these cases.