### PR TITLE
fix(copy-paste): adjust categoryValueRef when group is copied

### DIFF
--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -101,6 +101,10 @@ export default function BpmnCopyPaste(
       descriptor.parent = rootElement;
     }
 
+    if (descriptor.type === 'bpmn:Group') {
+      newBusinessObject.categoryValueRef = oldBusinessObject.categoryValueRef;
+    }
+
     if (is(parent, 'bpmn:Lane')) {
       descriptor.parent = parent.parent;
     }

--- a/test/fixtures/bpmn/features/copy-paste/properties.bpmn
+++ b/test/fixtures/bpmn/features/copy-paste/properties.bpmn
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-dev">
+  <bpmn:category id="Category">
+    <bpmn:categoryValue id="CategoryValue" value="Group" />
+  </bpmn:category>
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:subProcess id="Sub_non_interrupt" />
     <bpmn:subProcess id="Sub_event_subprocess" triggeredByEvent="true" />
@@ -11,6 +14,7 @@
       <bpmn:timerEventDefinition />
     </bpmn:boundaryEvent>
     <bpmn:transaction id="Sub_transaction" />
+    <bpmn:group id="Group" categoryValueRef="CategoryValue" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -37,6 +41,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Transaction_1so7kki_di" bpmnElement="Sub_transaction" isExpanded="true">
         <dc:Bounds x="329" y="207" width="140" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_di" bpmnElement="Group">
+        <dc:Bounds x="529" y="40" width="140" height="120" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -21,7 +21,10 @@ import {
 
 import DescriptorTree from './DescriptorTree';
 
-import { is } from 'lib/util/ModelUtil';
+import {
+  getBusinessObject,
+  is
+} from 'lib/util/ModelUtil';
 
 
 describe('features/copy-paste', function() {
@@ -400,6 +403,25 @@ describe('features/copy-paste', function() {
         })[0];
 
         expect(transaction).to.exist;
+      })
+    );
+
+
+    it('should copy & paste groups',
+      inject(function(elementRegistry, canvas, copyPaste, modeling) {
+
+        // when
+        copyPasteElement(elementRegistry, canvas, copyPaste, modeling, 'Group');
+
+        var group = elementRegistry.filter(function(element) {
+          return element.type === 'bpmn:Group';
+        })[0];
+
+        var categoryValue = getBusinessObject(group).categoryValueRef;
+
+        expect(group).to.exist;
+        expect(categoryValue).to.exist;
+        expect(categoryValue.id).to.equal('CategoryValue');
       })
     );
 


### PR DESCRIPTION
This enables copying `categoryValueRef` attributes from `bpmn:Group` elements. Per default, [references will not be copied](https://github.com/bpmn-io/bpmn-js/blob/master/lib/util/model/ModelCloneHelper.js#L72). However, in this case, it makes sense to do so.

Closes #958

![May-15-2019 13-02-42](https://user-images.githubusercontent.com/9433996/57770965-c7198a80-7711-11e9-8804-8460ee63e36f.gif)
