### PR TITLE
Group direct editing

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -13,6 +13,10 @@ import {
   isEventSubProcess
 } from '../util/DiUtil';
 
+import {
+  getLabel
+} from '../features/label-editing/LabelUtil';
+
 import { is } from '../util/ModelUtil';
 
 import {
@@ -472,7 +476,7 @@ export default function BpmnRenderer(
   }
 
   function renderExternalLabel(parentGfx, element) {
-    var semantic = getSemantic(element);
+
     var box = {
       width: 90,
       height: 30,
@@ -480,7 +484,7 @@ export default function BpmnRenderer(
       y: element.height / 2 + element.y
     };
 
-    return renderLabel(parentGfx, semantic.name, {
+    return renderLabel(parentGfx, getLabel(element), {
       box: box,
       fitBox: true,
       style: assign(
@@ -1580,8 +1584,6 @@ export default function BpmnRenderer(
       return outer;
     },
     'bpmn:Group': function(parentGfx, element) {
-      var semantic = getSemantic(element),
-          di = getDi(element);
 
       var group = drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
         strokeWidth: 1,
@@ -1589,19 +1591,6 @@ export default function BpmnRenderer(
         fill: 'none',
         pointerEvents: 'none'
       });
-
-      var categoryValueRef = semantic.categoryValueRef || {};
-
-      if (categoryValueRef.value) {
-        var box = di.label ? di.label.bounds : element;
-
-        renderLabel(parentGfx, categoryValueRef.value, {
-          box: box,
-          style: {
-            fill: getStrokeColor(element, defaultStrokeColor)
-          }
-        });
-      }
 
       return group;
     },

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -279,7 +279,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
       paddingTop = 7 * zoom,
       paddingBottom = 4 * zoom;
 
-  // external labels for events, data elements, gateways and connections
+  // external labels for events, data elements, gateways, groups and connections
   if (target.labelTarget) {
     assign(bounds, {
       width: width,

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -6,7 +6,15 @@ import {
   getLabel
 } from './LabelUtil';
 
-import { is } from '../../util/ModelUtil';
+import {
+  getBusinessObject,
+  is
+} from '../../util/ModelUtil';
+
+import {
+  createCategoryValue
+} from '../modeling/behavior/util/CategoryUtil';
+
 import { isAny } from '../modeling/util/ModelingUtil';
 import { isExpanded } from '../../util/DiUtil';
 
@@ -19,9 +27,10 @@ import {
 
 
 export default function LabelEditingProvider(
-    eventBus, canvas, directEditing,
+    eventBus, bpmnFactory, canvas, directEditing,
     modeling, resizeHandles, textRenderer) {
 
+  this._bpmnFactory = bpmnFactory;
   this._canvas = canvas;
   this._modeling = modeling;
   this._textRenderer = textRenderer;
@@ -102,6 +111,7 @@ export default function LabelEditingProvider(
 
 LabelEditingProvider.$inject = [
   'eventBus',
+  'bpmnFactory',
   'canvas',
   'directEditing',
   'modeling',
@@ -368,6 +378,23 @@ LabelEditingProvider.prototype.update = function(
       width: element.width / bbox.width * bounds.width,
       height: element.height / bbox.height * bounds.height
     };
+  }
+
+  if (is(element, 'bpmn:Group')) {
+
+    var businessObject = getBusinessObject(element);
+
+    // initialize categoryValue if not existing
+    if (!businessObject.categoryValueRef) {
+
+      var rootElement = this._canvas.getRootElement(),
+          definitions = getBusinessObject(rootElement).$parent;
+
+      var categoryValue = createCategoryValue(definitions, this._bpmnFactory);
+
+      getBusinessObject(element).categoryValueRef = categoryValue;
+    }
+
   }
 
   if (isEmptyText(newLabel)) {

--- a/lib/features/label-editing/LabelUtil.js
+++ b/lib/features/label-editing/LabelUtil.js
@@ -16,6 +16,21 @@ function getLabelAttr(semantic) {
   if (is(semantic, 'bpmn:TextAnnotation')) {
     return 'text';
   }
+
+  if (is(semantic, 'bpmn:Group')) {
+    return 'categoryValueRef';
+  }
+}
+
+function getCategoryValue(semantic) {
+  var categoryValueRef = semantic['categoryValueRef'];
+
+  if (!categoryValueRef) {
+    return '';
+  }
+
+
+  return categoryValueRef.value || '';
 }
 
 export function getLabel(element) {
@@ -23,6 +38,12 @@ export function getLabel(element) {
       attr = getLabelAttr(semantic);
 
   if (attr) {
+
+    if (attr === 'categoryValueRef') {
+
+      return getCategoryValue(semantic);
+    }
+
     return semantic[attr] || '';
   }
 }
@@ -33,7 +54,13 @@ export function setLabel(element, text, isExternal) {
       attr = getLabelAttr(semantic);
 
   if (attr) {
-    semantic[attr] = text;
+
+    if (attr === 'categoryValueRef') {
+      semantic['categoryValueRef'].value = text;
+    } else {
+      semantic[attr] = text;
+    }
+
   }
 
   return element;

--- a/lib/features/label-editing/cmd/UpdateLabelHandler.js
+++ b/lib/features/label-editing/cmd/UpdateLabelHandler.js
@@ -11,7 +11,6 @@ import {
 } from '../../../util/LabelUtil';
 
 import {
-  getBusinessObject,
   is
 } from '../../../util/ModelUtil';
 
@@ -103,9 +102,7 @@ export default function UpdateLabelHandler(modeling, textRenderer) {
       return;
     }
 
-    var bo = getBusinessObject(label);
-
-    var text = bo.name || bo.text;
+    var text = getLabel(label);
 
     // don't resize without text
     if (!text) {

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -12,6 +12,9 @@ import {
   is
 } from '../../../util/ModelUtil';
 
+import {
+  createCategoryValue
+} from './util/CategoryUtil';
 
 /**
  * BPMN specific Group behavior
@@ -146,17 +149,8 @@ export default function GroupBehavior(eventBus, bpmnFactory, canvas, elementRegi
 
     if (is(businessObject, 'bpmn:Group') && !businessObject.categoryValueRef) {
 
-      var definitions = getDefinitions();
-
-      var categoryValue = bpmnFactory.create('bpmn:CategoryValue'),
-          category = bpmnFactory.create('bpmn:Category', {
-            categoryValue: [ categoryValue ]
-          });
-
-      // add to correct place
-      collectionAdd(definitions.get('rootElements'), category);
-      getBusinessObject(category).$parent = definitions;
-      getBusinessObject(categoryValue).$parent = category;
+      var definitions = getDefinitions(),
+          categoryValue = createCategoryValue(definitions, bpmnFactory);
 
       // link the reference to the Group
       businessObject.categoryValueRef = categoryValue;

--- a/lib/features/modeling/behavior/util/CategoryUtil.js
+++ b/lib/features/modeling/behavior/util/CategoryUtil.js
@@ -1,0 +1,30 @@
+import {
+  add as collectionAdd
+} from 'diagram-js/lib/util/Collections';
+
+import {
+  getBusinessObject
+} from '../../../../util/ModelUtil';
+
+/**
+ * Creates a new bpmn:CategoryValue inside a new bpmn:Category
+ *
+ * @param {ModdleElement} definitions
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement} categoryValue.
+ */
+export function createCategoryValue(definitions, bpmnFactory) {
+  var categoryValue = bpmnFactory.create('bpmn:CategoryValue'),
+      category = bpmnFactory.create('bpmn:Category', {
+        categoryValue: [ categoryValue ]
+      });
+
+  // add to correct place
+  collectionAdd(definitions.get('rootElements'), category);
+  getBusinessObject(category).$parent = definitions;
+  getBusinessObject(categoryValue).$parent = category;
+
+  return categoryValue;
+
+}

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -255,7 +255,7 @@ function isTextAnnotation(element) {
 }
 
 function isGroup(element) {
-  return is(element, 'bpmn:Group');
+  return is(element, 'bpmn:Group') && !element.labelTarget;
 }
 
 function isCompensationBoundary(element) {

--- a/lib/import/BpmnImporter.js
+++ b/lib/import/BpmnImporter.js
@@ -18,6 +18,10 @@ import {
 } from '../util/DiUtil';
 
 import {
+  getLabel
+} from '../features/label-editing/LabelUtil';
+
+import {
   elementToString
 } from './Util';
 
@@ -182,7 +186,7 @@ BpmnImporter.prototype.add = function(semantic, parentElement) {
     }));
   }
   // (optional) LABEL
-  if (isLabelExternal(semantic) && semantic.name) {
+  if (isLabelExternal(semantic) && getLabel(element)) {
     this.addLabel(semantic, element);
   }
 
@@ -239,7 +243,7 @@ BpmnImporter.prototype.addLabel = function(semantic, element) {
 
   bounds = getExternalLabelBounds(semantic, element);
 
-  text = semantic.name;
+  text = getLabel(element);
 
   if (text) {
     // get corrected bounds from actual layouted text
@@ -250,7 +254,7 @@ BpmnImporter.prototype.addLabel = function(semantic, element) {
     id: semantic.id + '_label',
     labelTarget: element,
     type: 'label',
-    hidden: element.hidden || !semantic.name,
+    hidden: element.hidden || !getLabel(element),
     x: Math.round(bounds.x),
     y: Math.round(bounds.y),
     width: Math.round(bounds.width),

--- a/lib/util/LabelUtil.js
+++ b/lib/util/LabelUtil.js
@@ -27,7 +27,8 @@ export function isLabelExternal(semantic) {
          is(semantic, 'bpmn:DataInput') ||
          is(semantic, 'bpmn:DataOutput') ||
          is(semantic, 'bpmn:SequenceFlow') ||
-         is(semantic, 'bpmn:MessageFlow');
+         is(semantic, 'bpmn:MessageFlow') ||
+         is(semantic, 'bpmn:Group');
 }
 
 /**
@@ -97,6 +98,11 @@ export function getExternalLabelMid(element) {
 
   if (element.waypoints) {
     return getFlowLabelPosition(element.waypoints);
+  } else if (is(element, 'bpmn:Group')) {
+    return {
+      x: element.x + element.width / 2,
+      y: element.y + DEFAULT_LABEL_SIZE.height / 2
+    };
   } else {
     return {
       x: element.x + element.width / 2,

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -123,23 +123,6 @@ describe('draw - bpmn renderer', function() {
   });
 
 
-  it('should render group name', function(done) {
-    var xml = require('../../fixtures/bpmn/draw/group-name.bpmn');
-
-    bootstrapViewer(xml).call(this, function(err) {
-
-      inject(function(elementRegistry) {
-
-        var groupGfx = elementRegistry.getGraphics('Group_1');
-
-        expect(domQuery('.djs-label', groupGfx)).to.exist;
-
-        done(err);
-      })();
-    });
-  });
-
-
   it('should render message marker', function(done) {
     var xml = require('../../fixtures/bpmn/draw/message-marker.bpmn');
     bootstrapViewer(xml).call(this, checkErrors(done));

--- a/test/spec/features/label-editing/LabelEditing.bpmn
+++ b/test/spec/features/label-editing/LabelEditing.bpmn
@@ -67,7 +67,12 @@
     <bpmn:dataObject id="DataObject_1rq8hb8" />
     <bpmn:dataStoreReference id="DataStoreReference_1" />
     <bpmn:association id="Association_0ckvfj2" sourceRef="SubProcess_1" targetRef="TextAnnotation_1" />
+    <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
+    <bpmn:group id="Group_2" />
   </bpmn:process>
+  <bpmn:category id="Category_1">
+    <bpmn:categoryValue id="CategoryValue_1" value="FOO" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1o0amh9">
       <bpmndi:BPMNShape id="Participant_15tkgjw_di" bpmnElement="Participant_1">
@@ -184,16 +189,25 @@
         <dc:Bounds x="161" y="646" width="600" height="250" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataOutput_di" bpmnElement="DataOutput">
-        <dc:Bounds x="265" y="150" width="34" height="40"/>
+        <dc:Bounds x="265" y="150" width="34" height="40" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="12" width="30" x="265" y="195"/>
+          <dc:Bounds x="265" y="195" width="30" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataInput_di" bpmnElement="DataInput">
-        <dc:Bounds x="220" y="150" width="34" height="40"/>
+        <dc:Bounds x="220" y="150" width="34" height="40" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="12" width="30" x="220" y="200"/>
+          <dc:Bounds x="220" y="200" width="30" height="12" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
+        <dc:Bounds x="195" y="390" width="225" height="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="296" y="397" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_2_di" bpmnElement="Group_2">
+        <dc:Bounds x="555" y="390" width="85" height="200" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -411,6 +411,11 @@ describe('features - label-editing', function() {
 
       it('data output', directEdit('DataOutput'));
 
+
+      it('group', directEdit('Group_1'));
+
+      it('group via label', directEdit('Group_1_label'));
+
     });
 
   });

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -421,6 +421,38 @@ describe('features - label-editing', function() {
   });
 
 
+  describe('group support', function() {
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        labelEditingModule,
+        coreModule,
+        modelingModule
+      ],
+      canvas: { deferUpdate: false }
+    }));
+
+    it('should initialize categoryValue for empty group', inject(
+      function(elementRegistry, directEditing) {
+
+        // given
+        var shape = elementRegistry.get('Group_2');
+
+        // when
+        directEditing.activate(shape);
+        directEditing._textbox.content.innerText = 'FOO';
+        directEditing.complete();
+
+        // then
+        var label = getLabel(shape);
+
+        expect(shape.businessObject.categoryValueRef).to.exist;
+        expect(label).to.equal('FOO');
+      }
+    ));
+
+  });
+
   describe('sizes', function() {
 
     beforeEach(bootstrapModeler(diagramXML, {

--- a/test/spec/features/modeling/UpdateLabel.bpmn
+++ b/test/spec/features/modeling/UpdateLabel.bpmn
@@ -7,7 +7,11 @@
     <bpmn:textAnnotation id="TextAnnotation_1">
       <bpmn:text></bpmn:text>
     </bpmn:textAnnotation>
+    <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
   </bpmn:process>
+  <bpmn:category id="Category_1">
+    <bpmn:categoryValue id="CategoryValue_1" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
@@ -24,6 +28,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
         <dc:Bounds x="426" y="220" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
+        <dc:Bounds x="165" y="190" width="150" height="120" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -134,6 +134,20 @@ describe('features/modeling - update label', function() {
   ));
 
 
+  it('should change value of group', inject(function(modeling, elementRegistry) {
+
+    // given
+    var group_1 = elementRegistry.get('Group_1');
+
+    // when
+    modeling.updateLabel(group_1, 'foo');
+
+    // then
+    expect(group_1.businessObject.categoryValueRef.value).to.equal('foo');
+    expect(group_1.label).to.exist;
+  }));
+
+
   it('should propertly fire events.changed after event name change', inject(
     function(modeling, elementRegistry, eventBus) {
 


### PR DESCRIPTION
Closes #955 

* Moves Category + Value creation to separate util, cf. ed45a22
* Enables label editing for `bpmn:Group` elements  (via external label), cf. 0217a87
* Creates missing `bpmn:CategoryValue` when not existing, cf. a61609a

![May-22-2019 08-58-22](https://user-images.githubusercontent.com/9433996/58153618-caf86000-7c6f-11e9-9fba-51e5a46d10c2.gif)
