### PR TITLE
Allow to change intermediate events to boundary events

### DIFF
--- a/lib/features/modeling/behavior/AttachEventBehavior.js
+++ b/lib/features/modeling/behavior/AttachEventBehavior.js
@@ -2,13 +2,14 @@ import inherits from 'inherits';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { is } from '../../../util/ModelUtil';
+import { isAny } from '../util/ModelingUtil';
+import { getBusinessObject } from '../../../util/ModelUtil';
 
 
 /**
  * BPMN specific attach event behavior
  */
-export default function AttachEventBehavior(eventBus, bpmnFactory, bpmnReplace) {
+export default function AttachEventBehavior(eventBus, bpmnReplace) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -21,9 +22,9 @@ export default function AttachEventBehavior(eventBus, bpmnFactory, bpmnReplace) 
     var shapes = context.shapes,
         host = context.newHost,
         shape,
-        newShape,
-        businessObject,
-        boundaryEvent;
+        eventDefinition,
+        boundaryEvent,
+        newShape;
 
     if (shapes.length !== 1) {
       return;
@@ -31,19 +32,17 @@ export default function AttachEventBehavior(eventBus, bpmnFactory, bpmnReplace) 
 
     shape = shapes[0];
 
-    var attrs = {
-      cancelActivity: true
-    };
+    if (host && isAny(shape, [ 'bpmn:IntermediateThrowEvent', 'bpmn:IntermediateCatchEvent' ])) {
 
-    if (host && is(shape, 'bpmn:IntermediateThrowEvent')) {
-      attrs.attachedToRef = host.businessObject;
-
-      businessObject = bpmnFactory.create('bpmn:BoundaryEvent', attrs);
+      eventDefinition = getEventDefinition(shape);
 
       boundaryEvent = {
-        type: 'bpmn:BoundaryEvent',
-        businessObject: businessObject
+        type: 'bpmn:BoundaryEvent'
       };
+
+      if (eventDefinition) {
+        boundaryEvent.eventDefinitionType = eventDefinition.$type;
+      }
 
       newShape = bpmnReplace.replaceElement(shape, boundaryEvent);
 
@@ -54,8 +53,16 @@ export default function AttachEventBehavior(eventBus, bpmnFactory, bpmnReplace) 
 
 AttachEventBehavior.$inject = [
   'eventBus',
-  'bpmnFactory',
   'bpmnReplace'
 ];
 
 inherits(AttachEventBehavior, CommandInterceptor);
+
+
+
+// helper /////
+function getEventDefinition(element) {
+  var bo = getBusinessObject(element);
+
+  return bo && bo.eventDefinitions && bo.eventDefinitions[0];
+}

--- a/lib/features/modeling/behavior/AttachEventBehavior.js
+++ b/lib/features/modeling/behavior/AttachEventBehavior.js
@@ -1,0 +1,61 @@
+import inherits from 'inherits';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { is } from '../../../util/ModelUtil';
+
+
+/**
+ * BPMN specific attach event behavior
+ */
+export default function AttachEventBehavior(eventBus, bpmnFactory, bpmnReplace) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  /**
+   * replace intermediate event with boundary event when
+   * attaching it to a shape
+   */
+
+  this.preExecute('elements.move', function(context) {
+    var shapes = context.shapes,
+        host = context.newHost,
+        shape,
+        newShape,
+        businessObject,
+        boundaryEvent;
+
+    if (shapes.length !== 1) {
+      return;
+    }
+
+    shape = shapes[0];
+
+    var attrs = {
+      cancelActivity: true
+    };
+
+    if (host && is(shape, 'bpmn:IntermediateThrowEvent')) {
+      attrs.attachedToRef = host.businessObject;
+
+      businessObject = bpmnFactory.create('bpmn:BoundaryEvent', attrs);
+
+      boundaryEvent = {
+        type: 'bpmn:BoundaryEvent',
+        businessObject: businessObject
+      };
+
+      newShape = bpmnReplace.replaceElement(shape, boundaryEvent);
+
+      context.shapes = [ newShape ];
+    }
+  }, true);
+}
+
+AttachEventBehavior.$inject = [
+  'eventBus',
+  'bpmnFactory',
+  'bpmnReplace'
+];
+
+inherits(AttachEventBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/AttachEventBehavior.js
+++ b/lib/features/modeling/behavior/AttachEventBehavior.js
@@ -37,7 +37,8 @@ export default function AttachEventBehavior(eventBus, bpmnReplace) {
       eventDefinition = getEventDefinition(shape);
 
       boundaryEvent = {
-        type: 'bpmn:BoundaryEvent'
+        type: 'bpmn:BoundaryEvent',
+        host: host
       };
 
       if (eventDefinition) {

--- a/lib/features/modeling/behavior/AttachEventBehavior.js
+++ b/lib/features/modeling/behavior/AttachEventBehavior.js
@@ -45,7 +45,7 @@ export default function AttachEventBehavior(eventBus, bpmnReplace) {
         boundaryEvent.eventDefinitionType = eventDefinition.$type;
       }
 
-      newShape = bpmnReplace.replaceElement(shape, boundaryEvent);
+      newShape = bpmnReplace.replaceElement(shape, boundaryEvent, { layoutConnection: false });
 
       context.shapes = [ newShape ];
     }

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -1,5 +1,6 @@
 import AdaptiveLabelPositioningBehavior from './AdaptiveLabelPositioningBehavior';
 import AppendBehavior from './AppendBehavior';
+import AttachEventBehavior from './AttachEventBehavior';
 import BoundaryEventBehavior from './BoundaryEventBehavior';
 import CopyPasteBehavior from './CopyPasteBehavior';
 import CreateBoundaryEventBehavior from './CreateBoundaryEventBehavior';
@@ -31,6 +32,7 @@ export default {
   __init__: [
     'adaptiveLabelPositioningBehavior',
     'appendBehavior',
+    'attachEventBehavior',
     'boundaryEventBehavior',
     'copyPasteBehavior',
     'createBoundaryEventBehavior',
@@ -60,6 +62,7 @@ export default {
   ],
   adaptiveLabelPositioningBehavior: [ 'type', AdaptiveLabelPositioningBehavior ],
   appendBehavior: [ 'type', AppendBehavior ],
+  attachEventBehavior: [ 'type', AttachEventBehavior ],
   boundaryEventBehavior: [ 'type', BoundaryEventBehavior ],
   copyPasteBehavior: [ 'type', CopyPasteBehavior ],
   createBoundaryEventBehavior: [ 'type', CreateBoundaryEventBehavior ],

--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -217,6 +217,14 @@ export default function BpmnReplace(
       newBusinessObject.default = oldBusinessObject.default;
     }
 
+    if (
+      target.host &&
+      !is(oldBusinessObject, 'bpmn:BoundaryEvent') &&
+      is(newBusinessObject, 'bpmn:BoundaryEvent')
+    ) {
+      newElement.host = target.host;
+    }
+
     if ('fill' in oldBusinessObject.di || 'stroke' in oldBusinessObject.di) {
       assign(newElement, { colors: pick(oldBusinessObject.di, [ 'fill', 'stroke' ]) });
     }

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -564,7 +564,18 @@ function isLane(element) {
  * this must be reflected in the rules.
  */
 function isBoundaryCandidate(element) {
-  return isBoundaryEvent(element) || is(element, 'bpmn:IntermediateThrowEvent');
+  if (isBoundaryEvent(element)) {
+    return true;
+  }
+
+  if (is(element, 'bpmn:IntermediateThrowEvent') && hasNoEventDefinition(element)) {
+    return true;
+  }
+
+  return (
+    is(element, 'bpmn:IntermediateCatchEvent') &&
+    hasCommonBoundaryIntermediateEventDefinition(element)
+  );
 }
 
 function hasNoEventDefinition(element) {

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -564,8 +564,7 @@ function isLane(element) {
  * this must be reflected in the rules.
  */
 function isBoundaryCandidate(element) {
-  return isBoundaryEvent(element) ||
-        (is(element, 'bpmn:IntermediateThrowEvent') && !element.parent);
+  return isBoundaryEvent(element) || is(element, 'bpmn:IntermediateThrowEvent');
 }
 
 function hasNoEventDefinition(element) {
@@ -603,11 +602,6 @@ function canAttach(elements, target, source, position) {
 
   if (!Array.isArray(elements)) {
     elements = [ elements ];
-  }
-
-  // disallow appending as boundary event
-  if (source) {
-    return false;
   }
 
   // only (re-)attach one element at a time

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -627,11 +627,6 @@ function canAttach(elements, target, source, position) {
     return false;
   }
 
-  // allow default move operation
-  if (!target) {
-    return true;
-  }
-
   // disallow drop on event sub processes
   if (isEventSubProcess(target)) {
     return false;

--- a/test/fixtures/bpmn/boundary-events.bpmn
+++ b/test/fixtures/bpmn/boundary-events.bpmn
@@ -14,6 +14,7 @@
     <bpmn2:task id="Task_2" />
     <bpmn2:boundaryEvent id="BoundaryEvent_2" name="superman" attachedToRef="Task_2" />
     <bpmn2:task id="CompensationTask" isForCompensation="true" />
+    <bpmn2:intermediateThrowEvent id="IntermediateThrowEvent_1" name="joker" />
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -53,6 +54,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CompensationTask_di" bpmnElement="CompensationTask">
         <dc:Bounds x="795" y="249" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_1_di" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="185" y="480" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="191" y="525" width="24" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
@@ -1,0 +1,59 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import coreModule from 'lib/core';
+
+
+describe('features/modeling/behavior - attach events', function() {
+
+  var testModules = [ coreModule, modelingModule ];
+
+  var processDiagramXML = require('../../../../fixtures/bpmn/boundary-events.bpmn');
+
+  beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+
+  it('should execute on attach', inject(function(elementRegistry, modeling) {
+
+    // given
+    var eventId = 'IntermediateThrowEvent_1',
+        intermediateThrowEvent = elementRegistry.get(eventId),
+        subProcess = elementRegistry.get('SubProcess_1'),
+        boundaryEvent;
+
+    var elements = [ intermediateThrowEvent ];
+
+    // when
+    modeling.moveElements(elements, { x: 60, y: -131 }, subProcess, { attach: true });
+
+    // then
+    boundaryEvent = elementRegistry.get(eventId);
+
+    expect(intermediateThrowEvent.parent).to.not.exist;
+    expect(boundaryEvent).to.exist;
+    expect(boundaryEvent.type).to.equal('bpmn:BoundaryEvent');
+    expect(boundaryEvent.businessObject.attachedToRef).to.equal(subProcess.businessObject);
+  }));
+
+
+  it('should NOT execute on drop', inject(function(elementRegistry, modeling) {
+
+    // given
+    var eventId = 'IntermediateThrowEvent_1',
+        intermediateThrowEvent = elementRegistry.get(eventId),
+        subProcess = elementRegistry.get('SubProcess_1');
+
+    var elements = [ intermediateThrowEvent ];
+
+    // when
+    modeling.moveElements(elements, { x: 60, y: -191 }, subProcess);
+
+    // then
+    expect(intermediateThrowEvent.parent).to.eql(subProcess);
+    expect(intermediateThrowEvent.type).to.equal('bpmn:IntermediateThrowEvent');
+  }));
+
+});

--- a/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
@@ -11,49 +11,100 @@ describe('features/modeling/behavior - attach events', function() {
 
   var testModules = [ coreModule, modelingModule ];
 
-  var processDiagramXML = require('../../../../fixtures/bpmn/boundary-events.bpmn');
+  var processDiagramXML = require('test/spec/features/rules/BpmnRules.attaching.bpmn');
 
   beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
 
 
-  it('should execute on attach', inject(function(elementRegistry, modeling) {
+  describe('basics', function() {
 
-    // given
-    var eventId = 'IntermediateThrowEvent_1',
-        intermediateThrowEvent = elementRegistry.get(eventId),
-        subProcess = elementRegistry.get('SubProcess_1'),
-        boundaryEvent;
+    it('should execute on attach', inject(function(elementRegistry, modeling) {
 
-    var elements = [ intermediateThrowEvent ];
+      // given
+      var eventId = 'IntermediateThrowEvent',
+          intermediateThrowEvent = elementRegistry.get(eventId),
+          subProcess = elementRegistry.get('SubProcess_1'),
+          boundaryEvent;
 
-    // when
-    modeling.moveElements(elements, { x: 60, y: -131 }, subProcess, { attach: true });
+      var elements = [ intermediateThrowEvent ];
 
-    // then
-    boundaryEvent = elementRegistry.get(eventId);
+      // when
+      modeling.moveElements(elements, { x: 0, y: -90 }, subProcess, { attach: true });
 
-    expect(intermediateThrowEvent.parent).to.not.exist;
-    expect(boundaryEvent).to.exist;
-    expect(boundaryEvent.type).to.equal('bpmn:BoundaryEvent');
-    expect(boundaryEvent.businessObject.attachedToRef).to.equal(subProcess.businessObject);
-  }));
+      // then
+      boundaryEvent = elementRegistry.get(eventId);
+
+      expect(intermediateThrowEvent.parent).to.not.exist;
+      expect(boundaryEvent).to.exist;
+      expect(boundaryEvent.type).to.equal('bpmn:BoundaryEvent');
+      expect(boundaryEvent.businessObject.attachedToRef).to.equal(subProcess.businessObject);
+    }));
 
 
-  it('should NOT execute on drop', inject(function(elementRegistry, modeling) {
+    it('should NOT execute on drop', inject(function(elementRegistry, modeling) {
 
-    // given
-    var eventId = 'IntermediateThrowEvent_1',
-        intermediateThrowEvent = elementRegistry.get(eventId),
-        subProcess = elementRegistry.get('SubProcess_1');
+      // given
+      var eventId = 'IntermediateThrowEvent',
+          intermediateThrowEvent = elementRegistry.get(eventId),
+          subProcess = elementRegistry.get('SubProcess_1');
 
-    var elements = [ intermediateThrowEvent ];
+      var elements = [ intermediateThrowEvent ];
 
-    // when
-    modeling.moveElements(elements, { x: 60, y: -191 }, subProcess);
+      // when
+      modeling.moveElements(elements, { x: 0, y: -150 }, subProcess);
 
-    // then
-    expect(intermediateThrowEvent.parent).to.eql(subProcess);
-    expect(intermediateThrowEvent.type).to.equal('bpmn:IntermediateThrowEvent');
-  }));
+      // then
+      expect(intermediateThrowEvent.parent).to.eql(subProcess);
+      expect(intermediateThrowEvent.type).to.equal('bpmn:IntermediateThrowEvent');
+    }));
+  });
+
+
+  describe('event definition', function() {
+
+    it('should copy event definitions', inject(function(elementRegistry, modeling) {
+
+      // given
+      var attachableEvents = [
+        'IntermediateThrowEvent',
+        'MessageCatchEvent',
+        'TimerCatchEvent',
+        'SignalCatchEvent',
+        'ConditionalCatchEvent'
+      ];
+
+      attachableEvents.forEach(function(eventId) {
+
+        var event = elementRegistry.get(eventId),
+            subProcess = elementRegistry.get('SubProcess_1'),
+            eventDefinitions = event.businessObject.eventDefinitions,
+            boundaryEvent, bo;
+
+        var elements = [ event ];
+
+        // when
+        modeling.moveElements(elements, { x: 0, y: -90 }, subProcess, { attach: true });
+
+        // then
+        boundaryEvent = elementRegistry.get(eventId);
+        bo = boundaryEvent.businessObject;
+
+        expect(boundaryEvent.type).to.equal('bpmn:BoundaryEvent');
+        expect(bo.eventDefinitions).to.jsonEqual(eventDefinitions, skipId);
+      });
+    }));
+  });
 
 });
+
+
+
+// helper //////
+function skipId(key, value) {
+
+  if (key === 'id') {
+    return;
+  }
+
+  return value;
+}

--- a/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
@@ -95,6 +95,51 @@ describe('features/modeling/behavior - attach events', function() {
     }));
   });
 
+
+  describe('connections', function() {
+
+    var eventId = 'IntermediateThrowEventWithConnections';
+
+    it('should remove incoming connection', inject(function(elementRegistry, modeling) {
+
+      var event = elementRegistry.get(eventId),
+          subProcess = elementRegistry.get('SubProcess_1'),
+          gateway = elementRegistry.get('Gateway_1'),
+          boundaryEvent;
+
+      var elements = [ event ];
+
+      // when
+      modeling.moveElements(elements, { x: 0, y: -90 }, subProcess, { attach: true });
+
+      // then
+      boundaryEvent = elementRegistry.get(eventId);
+
+      expect(boundaryEvent.incoming).to.have.lengthOf(0);
+      expect(gateway.outgoing).to.have.lengthOf(0);
+    }));
+
+
+    it('should keep outgoing connection', inject(function(elementRegistry, modeling) {
+
+      var event = elementRegistry.get(eventId),
+          subProcess = elementRegistry.get('SubProcess_1'),
+          task = elementRegistry.get('Task_1'),
+          boundaryEvent;
+
+      var elements = [ event ];
+
+      // when
+      modeling.moveElements(elements, { x: 0, y: -90 }, subProcess, { attach: true });
+
+      // then
+      boundaryEvent = elementRegistry.get(eventId);
+
+      expect(boundaryEvent.outgoing).to.have.lengthOf(1);
+      expect(task.incoming).to.have.lengthOf(1);
+    }));
+  });
+
 });
 
 

--- a/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
@@ -1,3 +1,5 @@
+/* global sinon */
+
 import {
   bootstrapModeler,
   inject
@@ -102,6 +104,7 @@ describe('features/modeling/behavior - attach events', function() {
 
     it('should remove incoming connection', inject(function(elementRegistry, modeling) {
 
+      // given
       var event = elementRegistry.get(eventId),
           subProcess = elementRegistry.get('SubProcess_1'),
           gateway = elementRegistry.get('Gateway_1'),
@@ -122,6 +125,7 @@ describe('features/modeling/behavior - attach events', function() {
 
     it('should keep outgoing connection', inject(function(elementRegistry, modeling) {
 
+      // given
       var event = elementRegistry.get(eventId),
           subProcess = elementRegistry.get('SubProcess_1'),
           task = elementRegistry.get('Task_1'),
@@ -137,6 +141,25 @@ describe('features/modeling/behavior - attach events', function() {
 
       expect(boundaryEvent.outgoing).to.have.lengthOf(1);
       expect(task.incoming).to.have.lengthOf(1);
+    }));
+
+
+    it('should lay out connection once', inject(function(eventBus, elementRegistry, modeling) {
+
+      // given
+      var layoutSpy = sinon.spy(),
+          event = elementRegistry.get(eventId),
+          subProcess = elementRegistry.get('SubProcess_1');
+
+      eventBus.on('commandStack.connection.layout.execute', layoutSpy);
+
+      var elements = [ event ];
+
+      // when
+      modeling.moveElements(elements, { x: 0, y: -90 }, subProcess, { attach: true });
+
+      // then
+      expect(layoutSpy).to.be.calledOnce;
     }));
   });
 

--- a/test/spec/features/modeling/layout/LayoutConnectionSpec.js
+++ b/test/spec/features/modeling/layout/LayoutConnectionSpec.js
@@ -391,6 +391,46 @@ describe('features/modeling - layout connection', function() {
         })
       );
     });
+
+
+    describe('attaching event', function() {
+
+      var diagramXML = require('test/spec/features/rules/BpmnRules.attaching.bpmn');
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        modules: [
+          bendpointsModule,
+          connectionPreviewModule,
+          connectModule,
+          coreModule,
+          createModule,
+          modelingModule
+        ]
+      }));
+
+
+      it('should correctly lay out connection after replacement',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var event = elementRegistry.get('IntermediateThrowEventWithConnections'),
+              parent = elementRegistry.get('SubProcess_1');
+
+          // when
+          modeling.moveElements([ event ], { x: 0, y: -90 }, parent, { attach: true });
+
+          // then
+          var boundaryEvent = elementRegistry.get('IntermediateThrowEventWithConnections');
+
+          expect(boundaryEvent.outgoing[0]).to.have.waypoints([
+            { x: 769, y: 297 },
+            { x: 769, y: 369 },
+            { x: 837, y: 369 }
+          ]);
+        })
+      );
+
+    });
   });
 
 });

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -1413,6 +1413,28 @@ describe('features/replace - bpmn replace', function() {
       })
     );
 
+
+    it('should set host for boundary event if provided',
+      inject(function(elementRegistry, bpmnReplace) {
+
+        // given
+        var startEvent = elementRegistry.get('StartEvent_1'),
+            task = elementRegistry.get('Task_1');
+
+        // when
+        var boundaryEvent = bpmnReplace.replaceElement(startEvent, {
+          type: 'bpmn:BoundaryEvent',
+          host: task
+        });
+
+        // then
+        expect(boundaryEvent).to.exist;
+        expect(boundaryEvent).to.have.property('host', task);
+        expect(task).to.have.property('attachers');
+        expect(task.attachers).to.deep.eql([ boundaryEvent ]);
+      })
+    );
+
   });
 
 

--- a/test/spec/features/rules/BpmnRules.attaching.bpmn
+++ b/test/spec/features/rules/BpmnRules.attaching.bpmn
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess" />
+    <bpmn:intermediateCatchEvent id="MessageCatchEvent" name="2">
+      <bpmn:messageEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="MessageThrowEvent" name="3">
+      <bpmn:messageEventDefinition />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent" name="1" />
+    <bpmn:intermediateCatchEvent id="TimerCatchEvent" name="4">
+      <bpmn:timerEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="EscalationThrowEvent" name="5">
+      <bpmn:escalationEventDefinition />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="ConditionalCatchEvent" name="6">
+      <bpmn:conditionalEventDefinition>
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="LinkCatchEvent" name="7">
+      <bpmn:linkEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="LinkThrowEvent" name="8">
+      <bpmn:linkEventDefinition />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="CompensateThrowEvent" name="9">
+      <bpmn:compensateEventDefinition />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="SignalCatchEvent" name="10">
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="SignalThrowEvent" name="11">
+      <bpmn:signalEventDefinition />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="156" y="30" width="660" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0ckelak_di" bpmnElement="MessageCatchEvent">
+        <dc:Bounds x="234" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="249" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_0h76veu_di" bpmnElement="MessageThrowEvent">
+        <dc:Bounds x="281" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="296" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_di" bpmnElement="IntermediateThrowEvent">
+        <dc:Bounds x="188" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="203" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_1bkb8p2_di" bpmnElement="TimerCatchEvent">
+        <dc:Bounds x="343" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="358" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_0fxof2e_di" bpmnElement="EscalationThrowEvent">
+        <dc:Bounds x="402" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="417" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0r6qqek_di" bpmnElement="ConditionalCatchEvent">
+        <dc:Bounds x="454" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="469" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_179y1zf_di" bpmnElement="LinkCatchEvent">
+        <dc:Bounds x="505" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_169wfo1_di" bpmnElement="LinkThrowEvent">
+        <dc:Bounds x="556" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="571" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_1o8dtmg_di" bpmnElement="CompensateThrowEvent">
+        <dc:Bounds x="605" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="620" y="340" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0du6szv_di" bpmnElement="SignalCatchEvent">
+        <dc:Bounds x="654" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="666" y="340" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_0sqptpn_di" bpmnElement="SignalThrowEvent">
+        <dc:Bounds x="701" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="713" y="340" width="12" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/rules/BpmnRules.attaching.bpmn
+++ b/test/spec/features/rules/BpmnRules.attaching.bpmn
@@ -35,78 +35,113 @@
     <bpmn:intermediateThrowEvent id="SignalThrowEvent" name="11">
       <bpmn:signalEventDefinition />
     </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEventWithConnections" name="12">
+      <bpmn:incoming>SequenceFlow_1pdic6v</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_106kcuw</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:task id="Task_1" name="Task">
+      <bpmn:incoming>SequenceFlow_106kcuw</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_106kcuw" sourceRef="IntermediateThrowEventWithConnections" targetRef="Task_1" />
+    <bpmn:exclusiveGateway id="Gateway_1" name="Gateway">
+      <bpmn:outgoing>SequenceFlow_1pdic6v</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1pdic6v" sourceRef="Gateway_1" targetRef="IntermediateThrowEventWithConnections" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
-        <dc:Bounds x="156" y="30" width="660" height="200" />
+        <dc:Bounds x="156" y="81" width="660" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_0ckelak_di" bpmnElement="MessageCatchEvent">
-        <dc:Bounds x="234" y="300" width="36" height="36" />
+        <dc:Bounds x="234" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="249" y="340" width="7" height="14" />
+          <dc:Bounds x="249" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_0h76veu_di" bpmnElement="MessageThrowEvent">
-        <dc:Bounds x="281" y="300" width="36" height="36" />
+        <dc:Bounds x="281" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="296" y="340" width="7" height="14" />
+          <dc:Bounds x="296" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_di" bpmnElement="IntermediateThrowEvent">
-        <dc:Bounds x="188" y="300" width="36" height="36" />
+        <dc:Bounds x="188" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="203" y="340" width="7" height="14" />
+          <dc:Bounds x="203" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_1bkb8p2_di" bpmnElement="TimerCatchEvent">
-        <dc:Bounds x="343" y="300" width="36" height="36" />
+        <dc:Bounds x="343" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="358" y="340" width="7" height="14" />
+          <dc:Bounds x="358" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_0fxof2e_di" bpmnElement="EscalationThrowEvent">
-        <dc:Bounds x="402" y="300" width="36" height="36" />
+        <dc:Bounds x="402" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="417" y="340" width="7" height="14" />
+          <dc:Bounds x="417" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_0r6qqek_di" bpmnElement="ConditionalCatchEvent">
-        <dc:Bounds x="454" y="300" width="36" height="36" />
+        <dc:Bounds x="454" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="469" y="340" width="7" height="14" />
+          <dc:Bounds x="469" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_179y1zf_di" bpmnElement="LinkCatchEvent">
-        <dc:Bounds x="505" y="300" width="36" height="36" />
+        <dc:Bounds x="505" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="520" y="340" width="7" height="14" />
+          <dc:Bounds x="520" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_169wfo1_di" bpmnElement="LinkThrowEvent">
-        <dc:Bounds x="556" y="300" width="36" height="36" />
+        <dc:Bounds x="556" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="571" y="340" width="7" height="14" />
+          <dc:Bounds x="571" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_1o8dtmg_di" bpmnElement="CompensateThrowEvent">
-        <dc:Bounds x="605" y="300" width="36" height="36" />
+        <dc:Bounds x="605" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="620" y="340" width="7" height="14" />
+          <dc:Bounds x="620" y="391" width="7" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateCatchEvent_0du6szv_di" bpmnElement="SignalCatchEvent">
-        <dc:Bounds x="654" y="300" width="36" height="36" />
+        <dc:Bounds x="654" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="666" y="340" width="13" height="14" />
+          <dc:Bounds x="666" y="391" width="13" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="IntermediateThrowEvent_0sqptpn_di" bpmnElement="SignalThrowEvent">
-        <dc:Bounds x="701" y="300" width="36" height="36" />
+        <dc:Bounds x="701" y="351" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="713" y="340" width="12" height="14" />
+          <dc:Bounds x="713" y="391" width="12" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_1hc8tmi_di" bpmnElement="IntermediateThrowEventWithConnections">
+        <dc:Bounds x="751" y="351" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="762" y="327" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1fq7alz_di" bpmnElement="Task_1">
+        <dc:Bounds x="837" y="329" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_106kcuw_di" bpmnElement="SequenceFlow_106kcuw">
+        <di:waypoint x="787" y="369" />
+        <di:waypoint x="837" y="369" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1yk4171_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="744" y="448" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="747" y="505" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pdic6v_di" bpmnElement="SequenceFlow_1pdic6v">
+        <di:waypoint x="769" y="448" />
+        <di:waypoint x="769" y="387" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1260,6 +1260,23 @@ describe('features/modeling/rules - BpmnRules', function() {
       }
     ));
 
+
+    it('attach/move IntermediateThrowEvent -> SubProcess', inject(
+      function(elementRegistry) {
+
+        // given
+        var intermediateThrowEvent = elementRegistry.get('IntermediateThrowEvent_1');
+
+        var elements = [ intermediateThrowEvent ];
+
+        // then
+        expectCanMove(elements, 'SubProcess_1', {
+          attach: 'attach',
+          move: true
+        });
+      }
+    ));
+
   });
 
 
@@ -1539,7 +1556,7 @@ describe('features/modeling/rules - BpmnRules', function() {
         );
 
         // then
-        expect(canAttach).to.be.false;
+        expect(canAttach).to.eql('attach');
         expect(canCreate).to.be.false;
       }
     ));

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1278,7 +1278,8 @@ describe('features/modeling/rules - BpmnRules', function() {
         'MessageCatchEvent',
         'TimerCatchEvent',
         'SignalCatchEvent',
-        'ConditionalCatchEvent'
+        'ConditionalCatchEvent',
+        'IntermediateThrowEventWithConnections'
       ];
 
       var events = attachableEvents.map(function(eventId) {

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1260,23 +1260,69 @@ describe('features/modeling/rules - BpmnRules', function() {
       }
     ));
 
+  });
 
-    it('attach/move IntermediateThrowEvent -> SubProcess', inject(
-      function(elementRegistry) {
 
-        // given
-        var intermediateThrowEvent = elementRegistry.get('IntermediateThrowEvent_1');
+  describe('event attaching', function() {
 
-        var elements = [ intermediateThrowEvent ];
+    var testXML = require('./BpmnRules.attaching.bpmn');
 
-        // then
-        expectCanMove(elements, 'SubProcess_1', {
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+
+    it('should allow to attach attachable events to SubProcess', inject(function(elementRegistry) {
+
+      // given
+      var attachableEvents = [
+        'IntermediateThrowEvent',
+        'MessageCatchEvent',
+        'TimerCatchEvent',
+        'SignalCatchEvent',
+        'ConditionalCatchEvent'
+      ];
+
+      var events = attachableEvents.map(function(eventId) {
+        return elementRegistry.get(eventId);
+      });
+
+      // then
+      events.forEach(function(event) {
+
+        expectCanMove([ event ], 'SubProcess_1', {
           attach: 'attach',
           move: true
         });
-      }
-    ));
+      });
+    }));
 
+
+    it('should not allow to attach non-attachable events to SubProcess',
+      inject(function(elementRegistry) {
+
+        // given
+        var nonAttachableEvents = [
+          'MessageThrowEvent',
+          'EscalationThrowEvent',
+          'LinkCatchEvent',
+          'LinkThrowEvent',
+          'CompensateThrowEvent',
+          'SignalThrowEvent'
+        ];
+
+        var events = nonAttachableEvents.map(function(eventId) {
+          return elementRegistry.get(eventId);
+        });
+
+        // then
+        events.forEach(function(event) {
+
+          expectCanMove([ event ], 'SubProcess_1', {
+            attach: false,
+            move: true
+          });
+        });
+      })
+    );
   });
 
 


### PR DESCRIPTION
Closes #478

Builds on top of and includes changes in https://github.com/bpmn-io/bpmn-js/pull/1047

Requires https://github.com/bpmn-io/diagram-js/pull/354