### PR TITLE
fix(grid-snapping): use correct align values for segment snapping

### DIFF
--- a/lib/features/grid-snapping/behavior/LayoutConnectionBehavior.js
+++ b/lib/features/grid-snapping/behavior/LayoutConnectionBehavior.js
@@ -62,13 +62,13 @@ LayoutConnectionBehavior.prototype.snapMiddleSegments = function(waypoints) {
     if (horizontallyAligned(aligned)) {
 
       // snap horizontally
-      segmentStart.x = segmentEnd.x = gridSnapping.snapValue(segmentStart.x);
+      segmentStart.y = segmentEnd.y = gridSnapping.snapValue(segmentStart.y);
     }
 
     if (verticallyAligned(aligned)) {
 
       // snap vertically
-      segmentStart.y = segmentEnd.y = gridSnapping.snapValue(segmentStart.y);
+      segmentStart.x = segmentEnd.x = gridSnapping.snapValue(segmentStart.x);
     }
   });
 


### PR DESCRIPTION
Requires https://github.com/bpmn-io/diagram-js/pull/345
