### PR TITLE
fix(modeling): calculate appropriate new bounds on subprocess collapse

### DIFF
--- a/lib/features/modeling/behavior/SubProcessBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessBehavior.js
@@ -4,7 +4,10 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import { is } from '../../../util/ModelUtil';
 
-import { expandedBounds } from './ToggleElementCollapseBehaviour';
+import {
+  expandedBounds,
+  collapsedBounds
+} from './ToggleElementCollapseBehaviour';
 
 
 export default function SubProcessBehavior(elementFactory, eventBus, modeling) {
@@ -41,13 +44,18 @@ export default function SubProcessBehavior(elementFactory, eventBus, modeling) {
         newBounds;
 
     if (!is(shape, 'bpmn:SubProcess') ||
-      shape.collapsed ||
       !hasIncomingSequenceFlows(shape) ||
       hasOutgoingSequenceFlows(shape)) {
       return;
     }
 
-    newBounds = expandedBounds(shape, defaultSize);
+    if (shape.collapsed) {
+      newBounds = collapsedBounds(shape, defaultSize);
+    }
+
+    if (!shape.collapsed) {
+      newBounds = expandedBounds(shape, defaultSize);
+    }
 
     modeling.moveShape(shape, {
       x: shape.x - newBounds.x,

--- a/test/spec/features/modeling/behavior/SubProcessBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessBehaviorSpec.js
@@ -188,17 +188,23 @@ describe('features/modeling/behavior - sub process', function() {
 
     describe('expanded sub process -> collapsed sub process', function() {
 
-      it('should NOT move', inject(function(elementRegistry, modeling) {
+      it('should move', inject(function(elementRegistry, modeling) {
 
         // given
-        var subProcess = elementRegistry.get('SubProcess_4'),
-            subProcessMid = getMid(subProcess);
+        var subProcess = elementRegistry.get('SubProcess_4');
 
         // when
         modeling.toggleCollapse(subProcess);
 
         // then
-        expect(getMid(subProcess)).to.eql(subProcessMid);
+        var expectedBounds = {
+          x: 525,
+          y: 360,
+          width: 100,
+          height: 80
+        };
+
+        expect(subProcess).to.have.bounds(expectedBounds);
       }));
 
     });


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

_Which issue does this PR address?_

Closes #1031

![bpmn-js#1031](https://user-images.githubusercontent.com/3981598/58475859-634e8300-814f-11e9-97c1-0915dbf63ab3.gif)

Connection layout breaking is a [known issue](https://github.com/bpmn-io/bpmn-js/issues/1019).
