### PR TITLE
Prevent participant resizing on group interaction

### DIFF
--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -158,7 +158,7 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
 
 
     // if the element is already in the child list at
-    // a smaller index, we need to adjust the inser index.
+    // a smaller index, we need to adjust the insert index.
     // this takes into account that the element is being removed
     // before being re-inserted
     if (insertIndex !== -1) {

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -63,7 +63,16 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
       }
     },
     { type: 'bpmn:BoundaryEvent', order: { level: 8 } },
-    { type: 'bpmn:Group', order: { level: 10 } },
+    {
+      type: 'bpmn:Group',
+      order: {
+        level: 10,
+        containers: [
+          'bpmn:Collaboration',
+          'bpmn:Process'
+        ]
+      }
+    },
     { type: 'bpmn:FlowElement', order: { level: 5 } },
     { type: 'bpmn:Participant', order: { level: -2 } },
     { type: 'bpmn:Lane', order: { level: -1 } }

--- a/lib/features/snapping/BpmnSnapping.js
+++ b/lib/features/snapping/BpmnSnapping.js
@@ -403,7 +403,7 @@ function initParticipantSnapping(context, shape, elements) {
   }
 
   var snapBox = getBoundingBox(elements.filter(function(e) {
-    return !e.labelTarget && !e.waypoints;
+    return !e.labelTarget && !e.waypoints && !is(e, 'bpmn:Group');
   }));
 
   snapBox.x -= 50;

--- a/test/fixtures/bpmn/collaboration/process.bpmn
+++ b/test/fixtures/bpmn/collaboration/process.bpmn
@@ -14,6 +14,7 @@
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
     </bpmn2:endEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="SubProcess_1" targetRef="EndEvent_1"/>
+    <bpmn2:group id="Group_1" />
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -38,6 +39,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_1">
         <dc:Bounds height="36.0" width="36.0" x="562.0" y="129.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
+        <dc:Bounds x="645" y="96" width="170" height="120" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_BPMNShape_SubProcess_2" targetElement="_BPMNShape_EndEvent_2">
         <di:waypoint xsi:type="dc:Point" x="512.0" y="147.0"/>

--- a/test/spec/features/modeling/behavior/CreateParticipantBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CreateParticipantBehaviorSpec.js
@@ -143,7 +143,7 @@ describe('features/modeling - create participant', function() {
 
         // then
         expect(participantShape.children.length).to.equal(0);
-        expect(processShape.children.length).to.equal(7);
+        expect(processShape.children.length).to.equal(8);
 
         // children di is wired
         expect(startEventDi.$parent).to.eql(rootShapeDi);

--- a/test/spec/features/ordering/BpmnOrderingProviderSpec.js
+++ b/test/spec/features/ordering/BpmnOrderingProviderSpec.js
@@ -91,6 +91,16 @@ describe('features/modeling - ordering', function() {
     }));
 
 
+    it('should stay behind Group', inject(function() {
+
+      // when
+      move('Participant', 'Collaboration');
+
+      // then
+      expectZOrder('Participant_StartEvent', 'Participant', 'Group');
+    }));
+
+
     it('should stay behind DataInputAssociation when moving Participant with DataStore', inject(function() {
 
       // when
@@ -319,6 +329,16 @@ describe('features/modeling - ordering', function() {
 
         // then
         expectZOrder('SubProcess', 'Group');
+      }));
+
+
+      it('move <Group> onto <Participant>', inject(function() {
+
+        // when
+        move('Group', { x: 50, y: 0 }, 'Participant', false);
+
+        // then
+        expectZOrder('Participant', 'Group');
       }));
 
     });

--- a/test/spec/features/ordering/groups.bpmn
+++ b/test/spec/features/ordering/groups.bpmn
@@ -3,28 +3,37 @@
   <category id="Category_1">
     <categoryValue id="CategoryValue_1" value="my group" />
   </category>
+  <collaboration id="Collaboration_1">
+    <participant id="Participant" processRef="Process_1" />
+    <group id="Group" categoryValueRef="CategoryValue_1" />
+  </collaboration>
   <process id="Process_1" processType="None" isExecutable="false">
     <startEvent id="StartEvent" />
     <task id="Task" />
     <subProcess id="SubProcess" />
-    <group id="Group" categoryValueRef="CategoryValue_1" />
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Group_1di" bpmnElement="Group">
-        <omgdc:Bounds x="180" y="105" width="188" height="154" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_di" bpmnElement="Participant" isHorizontal="true">
+        <omgdc:Bounds x="156" y="118" width="724" height="250" />
         <bpmndi:BPMNLabel>
-          <omgdc:Bounds x="184" y="107" width="58.28571319580078" height="15" />
+          <omgdc:Bounds x="184" y="107" width="59" height="15" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_0yve8vf_di" bpmnElement="StartEvent">
-        <omgdc:Bounds x="450" y="164" width="36" height="36" />
+        <omgdc:Bounds x="192" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0nb7h9d_di" bpmnElement="Task">
-        <omgdc:Bounds x="418" y="268" width="100" height="80" />
+        <omgdc:Bounds x="280" y="150" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_02cid6e_di" bpmnElement="SubProcess" isExpanded="true">
-        <omgdc:Bounds x="546" y="138" width="350" height="200" />
+        <omgdc:Bounds x="430" y="138" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1di" bpmnElement="Group">
+        <omgdc:Bounds x="220" y="73" width="270" height="387" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="286" y="75" width="46" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/ordering/ordering.bpmn
+++ b/test/spec/features/ordering/ordering.bpmn
@@ -4,6 +4,7 @@
     <bpmn2:participant id="Participant" name="Participant" processRef="Process_Tasks" />
     <bpmn2:participant id="Participant_StartEvent" name="Participant_StartEvent" processRef="Process_StartEvent" />
     <bpmn2:messageFlow id="MessageFlow" name="" sourceRef="Task_With_Boundary" targetRef="Participant_StartEvent" />
+    <bpmn2:group id="Group"/>
   </bpmn2:collaboration>
   <bpmn2:process id="Process_Tasks" isExecutable="false">
     <bpmn2:sequenceFlow id="SequenceFlow" name="SequenceFlow" sourceRef="BoundaryEvent" targetRef="Task" />
@@ -95,6 +96,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_0vcqjeq_di" bpmnElement="Task_With_Output">
         <dc:Bounds x="747" y="473" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_di" bpmnElement="Group">
+        <dc:Bounds x="250" y="73" width="270" height="287" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="DataOutputAssociation_1fcd0id_di" bpmnElement="DataOutputAssociation">
         <di:waypoint x="797" y="473" />

--- a/test/spec/features/snapping/BpmnSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnSnappingSpec.js
@@ -337,6 +337,34 @@ describe('features/snapping - BpmnSnapping', function() {
       );
 
 
+      it('should not snap to group bounds',
+        inject(function(canvas, create, dragging, elementFactory, elementRegistry) {
+
+          // given
+          var participantShape = elementFactory.createParticipantShape(false),
+              rootElement = canvas.getRootElement(),
+              rootGfx = canvas.getGraphics(rootElement),
+              groupElement = elementRegistry.get('Group_1');
+
+          // when
+          create.start(canvasEvent({ x: 50, y: 50 }), participantShape);
+
+          dragging.hover({ element: rootElement, gfx: rootGfx });
+
+          dragging.move(canvasEvent({ x: 400, y: 400 }));
+          dragging.end(canvasEvent({ x: 400, y: 400 }));
+
+          // then
+          var totalWidth = groupElement.x + groupElement.width + 70,
+              totalHeight = groupElement.y + groupElement.height + 40;
+
+          expect(participantShape).not.to.have.bounds({
+            width: totalWidth, height: totalHeight, x: 100, y: 52
+          });
+        })
+      );
+
+
       it('should snap to process children bounds / bottom right',
         inject(function(canvas, create, dragging, elementFactory) {
 


### PR DESCRIPTION
Closes #1043 

* Always render `bpmn:Group` elements on collaboration level, cf. a966ec3
* Prevent participants snap to group bounds, cf. c6670039e48e3ccf10c2976fc20d43b48de412aa

![May-29-2019 08-20-56](https://user-images.githubusercontent.com/9433996/58534144-b9243900-81ea-11e9-9e0a-45d8d661462d.gif)

Note: Unmerged changes in https://github.com/bpmn-io/bpmn-js/pull/1046 refactor the participant-snapping to another place. After merge, the changes in c6670039e48e3ccf10c2976fc20d43b48de412aa should be moved as well.


