### PR TITLE
Allow visually ignored movements

### DIFF
--- a/lib/features/replace-preview/BpmnReplacePreview.js
+++ b/lib/features/replace-preview/BpmnReplacePreview.js
@@ -107,7 +107,7 @@ export default function BpmnReplacePreview(
       context.visualReplacements = {};
     }
 
-    if (canExecute.replacements) {
+    if (canExecute && canExecute.replacements) {
       replaceVisual(context);
     } else {
       restoreVisual(context);

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -123,10 +123,25 @@ BpmnRules.prototype.init = function() {
         shapes = context.shapes,
         position = context.position;
 
-    return canAttach(shapes, target, null, position) ||
-           canReplace(shapes, target, position) ||
-           canMove(shapes, target, position) ||
-           canInsert(shapes, target, position);
+    var attach = canAttach(shapes, target, null, position);
+
+    if (attach || attach === null) {
+      return attach;
+    }
+
+    var replace = canReplace(shapes, target, position);
+
+    if (replace || replace === null) {
+      return replace;
+    }
+
+    var move = canMove(shapes, target, position);
+
+    if (move || move === null) {
+      return move;
+    }
+
+    return canInsert(shapes, target, position);
   });
 
   this.addRule('shape.create', function(context) {
@@ -451,7 +466,7 @@ function canDrop(element, target, position) {
 
   // can move labels everywhere
   if (isLabel(element)) {
-    return true;
+    return null;
   }
 
   // disallow to create elements on collapsed pools
@@ -751,9 +766,21 @@ function canMove(elements, target) {
     return true;
   }
 
-  return elements.every(function(element) {
-    return canDrop(element, target);
-  });
+  var move,
+      currentMove;
+
+  for (var i = 0; i < elements.length; i++) {
+
+    currentMove = canDrop(elements[i], target);
+
+    if (currentMove === false) {
+      return false;
+    }
+
+    move = move || currentMove;
+  }
+
+  return move;
 }
 
 function canCreate(shape, target, source, position) {

--- a/test/spec/features/rules/BpmnRules.collaboration.bpmn
+++ b/test/spec/features/rules/BpmnRules.collaboration.bpmn
@@ -7,6 +7,7 @@
     <bpmn2:messageFlow id="MessageFlow_labeled" name="LABEL" sourceRef="Participant" targetRef="OtherParticipant" />
     <bpmn2:messageFlow id="MessageFlow_2" sourceRef="OtherParticipant" targetRef="SubProcess" />
     <bpmn2:textAnnotation id="TextAnnotation_Global" />
+    <bpmn2:group id="Group" />
   </bpmn2:collaboration>
   <bpmn2:process id="Process" isExecutable="false">
     <bpmn2:startEvent id="StartEvent_None" />
@@ -170,6 +171,9 @@
         <di:waypoint x="275" y="252" />
         <di:waypoint x="417" y="252" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_di" bpmnElement="Group">
+        <dc:Bounds x="200" y="200" width="100" height="100" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn2:definitions>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1015,33 +1015,38 @@ describe('features/modeling/rules - BpmnRules', function() {
 
 
       it('-> MessageFlow', function() {
-        expectCanDrop(label, 'MessageFlow_labeled', true);
+        expectCanDrop(label, 'MessageFlow_labeled', null);
       });
 
 
       it('-> CollapsedParticipant', function() {
-        expectCanDrop(label, 'CollapsedParticipant', true);
+        expectCanDrop(label, 'CollapsedParticipant', null);
       });
 
 
       it('-> Collaboration', function() {
         // then
-        expectCanDrop(label, 'Collaboration', true);
+        expectCanDrop(label, 'Collaboration', null);
       });
 
 
       it('-> Task_in_SubProcess', function() {
-        expectCanDrop(label, 'Task_in_SubProcess', true);
+        expectCanDrop(label, 'Task_in_SubProcess', null);
       });
 
 
       it('-> SequenceFlow', function() {
-        expectCanDrop(label, 'SequenceFlow', true);
+        expectCanDrop(label, 'SequenceFlow', null);
       });
 
 
       it('-> DataOutputAssociation', function() {
-        expectCanDrop(label, 'DataOutputAssociation', true);
+        expectCanDrop(label, 'DataOutputAssociation', null);
+      });
+
+
+      it('-> Group', function() {
+        expectCanDrop(label, 'Group', null);
       });
 
     });


### PR DESCRIPTION
Removes the `new-parent` overlay when hovering label over elements. Allows to set `canExecute` for `elements.move` to `null` in a general manner (cf. https://github.com/bpmn-io/diagram-js/pull/357)

![Jun-11-2019 13-46-58](https://user-images.githubusercontent.com/9433996/59269597-b9432080-8c4f-11e9-9b4b-1d2d9128cf9c.gif)

Closes #1054 

Depends on https://github.com/bpmn-io/diagram-js/pull/357.