### PR TITLE
brings center-snap back to glory

### DIFF
--- a/lib/features/snapping/BpmnConnectSnapping.js
+++ b/lib/features/snapping/BpmnConnectSnapping.js
@@ -13,6 +13,8 @@ import { is } from '../../util/ModelUtil';
 
 import { some } from 'min-dash';
 
+import { isAny } from '../modeling/util/ModelingUtil';
+
 var HIGHER_PRIORITY = 1250;
 
 var BOUNDARY_TO_HOST_THRESHOLD = 40;
@@ -66,9 +68,14 @@ export default function BpmnConnectSnapping(eventBus, rules) {
       // snap source
       context.sourcePosition = mid(source);
 
+      if (isAny(target, ['bpmn:Event', 'bpmn:Gateway'])) {
+        snapToPosition(event, mid(target));
+      }
+
       if (is(source, 'bpmn:BoundaryEvent') && target === source.host) {
         snapBoundaryEventLoop(event, source, target);
       }
+
     } else if (isType(connectionAttrs, 'bpmn:MessageFlow')) {
 
       if (is(source, 'bpmn:Event')) {

--- a/lib/features/snapping/BpmnConnectSnapping.js
+++ b/lib/features/snapping/BpmnConnectSnapping.js
@@ -11,7 +11,10 @@ import {
 
 import { is } from '../../util/ModelUtil';
 
-import { some } from 'min-dash';
+import {
+  every,
+  some
+} from 'min-dash';
 
 import { isAny } from '../modeling/util/ModelingUtil';
 
@@ -20,6 +23,8 @@ var HIGHER_PRIORITY = 1250;
 var BOUNDARY_TO_HOST_THRESHOLD = 40;
 
 var TARGET_BOUNDS_PADDING = 20;
+
+var TARGET_CENTER_PADDING = 20;
 
 var AXES = [ 'x', 'y' ];
 
@@ -55,7 +60,7 @@ export default function BpmnConnectSnapping(eventBus, rules) {
     });
 
     if (target && connectionAttrs) {
-      snapInsideTarget(event, target);
+      snapInsideTarget(event, target, getTargetBoundsPadding(target));
     }
 
     if (target && isAnyType(connectionAttrs, [
@@ -70,6 +75,10 @@ export default function BpmnConnectSnapping(eventBus, rules) {
 
       if (isAny(target, ['bpmn:Event', 'bpmn:Gateway'])) {
         snapToPosition(event, mid(target));
+      }
+
+      if (is(target, 'bpmn:Task')) {
+        snapTargetMidOnCenter(event, target);
       }
 
       if (is(source, 'bpmn:BoundaryEvent') && target === source.host) {
@@ -103,22 +112,39 @@ BpmnConnectSnapping.$inject = [
   'rules'
 ];
 
-function snapInsideTarget(event, target) {
+function snapInsideTarget(event, target, padding) {
 
   AXES.forEach(function(axis) {
     var matchingTargetDimension = getDimensionForAxis(axis, target),
         newCoordinate;
 
-    if (event[axis] < target[axis] + TARGET_BOUNDS_PADDING) {
-      newCoordinate = target[axis] + TARGET_BOUNDS_PADDING;
-    } else if (event[axis] > target[axis] + matchingTargetDimension - TARGET_BOUNDS_PADDING) {
-      newCoordinate = target[axis] + matchingTargetDimension - TARGET_BOUNDS_PADDING;
+    if (event[axis] < target[axis] + padding) {
+      newCoordinate = target[axis] + padding;
+    } else if (event[axis] > target[axis] + matchingTargetDimension - padding) {
+      newCoordinate = target[axis] + matchingTargetDimension - padding;
     }
 
     if (newCoordinate) {
       setSnapped(event, axis, newCoordinate);
     }
   });
+}
+
+// snap to target mid if event position in center area
+function snapTargetMidOnCenter(event, target) {
+
+  var isCenter = every(AXES, function(axis) {
+    var coordinate = event[axis],
+        matchingTargetDimension = getDimensionForAxis(axis, target);
+
+    return coordinate > target[axis] + TARGET_CENTER_PADDING
+      && coordinate < target[axis] + matchingTargetDimension - TARGET_CENTER_PADDING;
+  });
+
+  if (isCenter) {
+    snapToPosition(event, mid(target));
+  }
+
 }
 
 // snap outside of Boundary Event surroundings
@@ -170,4 +196,12 @@ function isAnyType(attrs, types) {
 
 function getDimensionForAxis(axis, element) {
   return axis === 'x' ? element.width : element.height;
+}
+
+function getTargetBoundsPadding(target) {
+  if (is(target, 'bpmn:Task')) {
+    return 10;
+  } else {
+    return TARGET_BOUNDS_PADDING;
+  }
 }

--- a/test/spec/features/modeling/MoveElements.centered-connection.bpmn
+++ b/test/spec/features/modeling/MoveElements.centered-connection.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Task_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Task_2">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="Task_1" targetRef="Task_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="150" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="250" y="120" />
+        <di:waypoint x="300" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/MoveElementsSpec.js
+++ b/test/spec/features/modeling/MoveElementsSpec.js
@@ -221,6 +221,41 @@ describe('features/modeling - move elements', function() {
     }));
   });
 
+
+  describe('center-to-center connection', function() {
+
+    var diagramXML = require('./MoveElements.centered-connection.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        modelingModule
+      ]
+    }));
+
+    it('should properly adjust connection', inject(function(elementRegistry, modeling) {
+
+      // given
+      var targetElement = elementRegistry.get('Task_2');
+
+      var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+      // move from centric-left to centric-below
+      var delta = { x: -150, y: 150 };
+
+      var expectedWaypoints = [
+        { x: 200, y: 160 },
+        { x: 200, y: 230 }
+      ];
+
+      // when
+      modeling.moveElements([ targetElement ], delta);
+
+      // then
+      expect(sequenceFlow).to.have.waypoints(expectedWaypoints);
+    }));
+  });
+
 });
 
 

--- a/test/spec/features/snapping/BpmnConnectSnapping.bpmn
+++ b/test/spec/features/snapping/BpmnConnectSnapping.bpmn
@@ -10,6 +10,7 @@
     <bpmn:task id="Task_1" />
     <bpmn:dataObjectReference id="DataObjectReference_1" dataObjectRef="DataObject_16xfc7e" />
     <bpmn:dataObject id="DataObject_16xfc7e" />
+    <bpmn:exclusiveGateway id="Gateway_1" />
     <bpmn:subProcess id="SubProcess" />
     <bpmn:boundaryEvent id="BoundaryEvent" attachedToRef="SubProcess" />
     <bpmn:boundaryEvent id="BoundaryEventRight" attachedToRef="SubProcess" />
@@ -60,6 +61,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEventRight_di" bpmnElement="BoundaryEventRight">
         <dc:Bounds x="743" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1nir8te_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="299" y="75" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/snapping/BpmnConnectSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnConnectSnappingSpec.js
@@ -142,6 +142,59 @@ describe('features/snapping - BpmnConnectSnapping', function() {
       });
 
 
+      describe('Task target', function() {
+
+        it('should snap to task mid',
+          inject(function(connect, dragging, elementRegistry) {
+
+            // given
+            var startEvent = elementRegistry.get('StartEvent_1'),
+                task = elementRegistry.get('Task_1'),
+                taskGfx = elementRegistry.getGraphics(task);
+
+            // when
+            connect.start(canvasEvent({ x: 210, y: 60 }), startEvent);
+
+            dragging.hover({ element: task, gfx: taskGfx });
+
+            dragging.move(canvasEvent({ x: 300, y: 300 }));
+
+            dragging.end();
+
+            // then
+            var waypoints = startEvent.outgoing[0].waypoints;
+
+            expect(waypoints[3].y).to.eql(300);
+          })
+        );
+
+
+        it('should snap to grid point',
+          inject(function(connect, dragging, elementRegistry) {
+
+            // given
+            var startEvent = elementRegistry.get('StartEvent_1'),
+                task = elementRegistry.get('Task_1'),
+                taskGfx = elementRegistry.getGraphics(task);
+
+            // when
+            connect.start(canvasEvent({ x: 210, y: 60 }), startEvent);
+
+            dragging.hover({ element: task, gfx: taskGfx });
+
+            dragging.move(canvasEvent({ x: 300, y: 260 }));
+
+            dragging.end();
+
+            // then
+            var waypoints = startEvent.outgoing[0].waypoints;
+
+            expect(waypoints[3].y).to.eql(270);
+          })
+        );
+      });
+
+
       it('should snap event if close to target bounds',
         inject(function(connect, dragging, elementRegistry) {
 

--- a/test/spec/features/snapping/BpmnConnectSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnConnectSnappingSpec.js
@@ -165,6 +165,57 @@ describe('features/snapping - BpmnConnectSnapping', function() {
           expect(waypoints[3].y).to.eql(280);
         })
       );
+
+
+      it('should snap gateway target mid',
+        inject(function(connect, dragging, elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_1'),
+              gateway = elementRegistry.get('Gateway_1'),
+              gatewayGfx = elementRegistry.getGraphics(gateway);
+
+          // when
+          connect.start(canvasEvent({ x: 210, y: 60 }), startEvent);
+
+          dragging.hover({ element: gateway, gfx: gatewayGfx });
+
+          dragging.move(canvasEvent({ x: 300, y: 80 }));
+
+          dragging.end();
+
+          // then
+          var waypoints = startEvent.outgoing[0].waypoints;
+
+          expect(waypoints[1].y).to.eql(100);
+        })
+      );
+
+
+      it('should snap event target mid',
+        inject(function(connect, dragging, elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_1'),
+              endEvent = elementRegistry.get('EndEvent_1'),
+              endEventGfx = elementRegistry.getGraphics(endEvent);
+
+          // when
+          connect.start(canvasEvent({ x: 210, y: 60 }), startEvent);
+
+          dragging.hover({ element: endEvent, gfx: endEventGfx });
+
+          dragging.move(canvasEvent({ x: 310, y: 275 }));
+
+          dragging.end();
+
+          // then
+          var waypoints = startEvent.outgoing[0].waypoints;
+
+          expect(waypoints[2].y).to.eql(200);
+        })
+      );
+
     });
   });
 


### PR DESCRIPTION
This brings center-snap on connecting back for certain scenarios:
* When connecting to `bpmn:Event` or `bpmn:Gateway` (cf. #1079)
* When connecting to `bpmn:Task` center area (cf. #1086) 

Closes #1079 
Closes #1086 

Look & Feel:

![Jun-19-2019 09-24-18](https://user-images.githubusercontent.com/9433996/59744987-08064100-9274-11e9-9dd9-19ea8a7a5215.gif)

![Jun-19-2019 09-23-07](https://user-images.githubusercontent.com/9433996/59744930-ec9b3600-9273-11e9-8e2b-fb37089f6d0e.gif)

