### PR TITLE
feat(modeling): make initial host of Boundary Event sticky

### DIFF
--- a/lib/features/modeling/behavior/StickyBoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/StickyBoundaryEventBehavior.js
@@ -1,0 +1,61 @@
+import inherits from 'inherits';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import {
+  classes as svgClasses
+} from 'tiny-svg';
+
+
+var EXTENDED_HIT = 'djs-hit-extended';
+
+/**
+ * BPMN specific detach event behavior
+ */
+export default function StickyBoundaryEventBehavior(eventBus, elementRegistry) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  var hostGfx = null;
+
+  eventBus.on([
+    'shape.move.init'
+  ], function(event) {
+    var shape = event.shape;
+
+    if (shape && shape.host) {
+      hostGfx = elementRegistry.getGraphics(shape.host);
+
+      svgClasses(hostGfx).add(EXTENDED_HIT);
+    }
+  });
+
+  eventBus.on([
+    'shape.move.hover'
+  ], function(event) {
+    if (hostGfx && event.hoverGfx !== hostGfx) {
+      cleanUp();
+    }
+  });
+
+  eventBus.on([
+    'shape.move.cleanup'
+  ], function() {
+    if (hostGfx) {
+      cleanUp();
+    }
+  });
+
+  function cleanUp() {
+    svgClasses(hostGfx).remove(EXTENDED_HIT);
+
+    hostGfx = null;
+  }
+}
+
+StickyBoundaryEventBehavior.$inject = [
+  'eventBus',
+  'elementRegistry'
+];
+
+inherits(StickyBoundaryEventBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -24,6 +24,7 @@ import ReplaceElementBehaviour from './ReplaceElementBehaviour';
 import ResizeBehavior from './ResizeBehavior';
 import ResizeLaneBehavior from './ResizeLaneBehavior';
 import RemoveElementBehavior from './RemoveElementBehavior';
+import StickyBoundaryEventBehavior from './StickyBoundaryEventBehavior';
 import SubProcessStartEventBehavior from './SubProcessStartEventBehavior';
 import ToggleElementCollapseBehaviour from './ToggleElementCollapseBehaviour';
 import UnclaimIdBehavior from './UnclaimIdBehavior';
@@ -58,6 +59,7 @@ export default {
     'replaceElementBehaviour',
     'resizeBehavior',
     'resizeLaneBehavior',
+    'stickyBoundaryEventBehavior',
     'toggleElementCollapseBehaviour',
     'subProcessStartEventBehavior',
     'unclaimIdBehavior',
@@ -90,6 +92,7 @@ export default {
   resizeBehavior: [ 'type', ResizeBehavior ],
   resizeLaneBehavior: [ 'type', ResizeLaneBehavior ],
   removeElementBehavior: [ 'type', RemoveElementBehavior ],
+  stickyBoundaryEventBehavior: [ 'type', StickyBoundaryEventBehavior ],
   toggleElementCollapseBehaviour : [ 'type', ToggleElementCollapseBehaviour ],
   subProcessStartEventBehavior: [ 'type', SubProcessStartEventBehavior ],
   unclaimIdBehavior: [ 'type', UnclaimIdBehavior ],

--- a/test/spec/features/modeling/behavior/StickyBoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/StickyBoundaryEventBehaviorSpec.js
@@ -1,0 +1,94 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import coreModule from 'lib/core';
+import moveModule from 'diagram-js/lib/features/move';
+
+import {
+  createCanvasEvent as canvasEvent
+} from '../../../../util/MockEvents';
+
+
+describe('features/modeling/behavior - sticky boundary events', function() {
+
+  var testModules = [ coreModule, modelingModule, moveModule ];
+
+
+  var processDiagramXML = require('../../../../fixtures/bpmn/boundary-events.bpmn');
+
+  beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+  beforeEach(inject(function(dragging) {
+    dragging.setOptions({ manual: true });
+  }));
+
+
+  it('should extend hit shape of current host', inject(function(elementRegistry, move) {
+
+    // given
+    var boundaryEvent = elementRegistry.get('BoundaryEvent_1'),
+        hostGfx = elementRegistry.getGraphics(boundaryEvent.host);
+
+    // when
+    move.start(canvasEvent({ x: 0, y: 0 }), boundaryEvent);
+
+    // then
+    expect(hostGfx.classList.contains('djs-hit-extended')).to.be.true;
+  }));
+
+
+  it('should NOT extend hit shape after hovering other element',
+    inject(function(canvas, elementRegistry, move, dragging) {
+
+      // given
+      var root = canvas.getRootElement(),
+          rootGfx = canvas.getGraphics(root),
+          boundaryEvent = elementRegistry.get('BoundaryEvent_1'),
+          host = boundaryEvent.host,
+          hostGfx = elementRegistry.getGraphics(host);
+
+      // when
+      move.start(canvasEvent({ x: 0, y: 0 }), boundaryEvent);
+
+      dragging.hover({ element: root, gfx: rootGfx });
+      dragging.hover({ element: host, gfx: hostGfx });
+
+      // then
+      expect(hostGfx.classList.contains('djs-hit-extended')).to.be.false;
+    })
+  );
+
+
+  it('should properly clean classes on end', inject(function(elementRegistry, move, dragging) {
+
+    // given
+    var boundaryEvent = elementRegistry.get('BoundaryEvent_1'),
+        hostGfx = elementRegistry.getGraphics(boundaryEvent.host);
+
+    // when
+    move.start(canvasEvent({ x: 0, y: 0 }), boundaryEvent);
+    dragging.end();
+
+    // then
+    expect(hostGfx.classList.contains('djs-hit-extended')).to.be.false;
+  }));
+
+
+  it('should properly clean classes on cancel', inject(function(elementRegistry, move, dragging) {
+
+    // given
+    var boundaryEvent = elementRegistry.get('BoundaryEvent_1'),
+        hostGfx = elementRegistry.getGraphics(boundaryEvent.host);
+
+    // when
+    move.start(canvasEvent({ x: 0, y: 0 }), boundaryEvent);
+    dragging.cancel();
+
+    // then
+    expect(hostGfx.classList.contains('djs-hit-extended')).to.be.false;
+  }));
+
+});


### PR DESCRIPTION
This PR makes Boundary Event's host initially sticky when moving the attachment. The purpose of this is to avoid accidental detachment. 

The hit box will shrink after the Boundary Event leaves the host and it will not grow back with next hover in order to prevent accidental attachment.

Closes #1078 

Requires https://github.com/bpmn-io/diagram-js/pull/368
