### PR TITLE
Allow to drop Boundary Events only on containers

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -479,10 +479,9 @@ function canDrop(element, target, position) {
     return is(target, 'bpmn:Participant') || is(target, 'bpmn:Lane');
   }
 
-  if (is(element, 'bpmn:BoundaryEvent')) {
-    return getBusinessObject(element).cancelActivity && (
-      hasNoEventDefinition(element) || hasCommonBoundaryIntermediateEventDefinition(element)
-    );
+  // disallow dropping boundary events which cannot replace with intermediate event
+  if (is(element, 'bpmn:BoundaryEvent') && !isDroppableBoundaryEvent(element)) {
+    return false;
   }
 
   // drop flow elements onto flow element containers
@@ -515,6 +514,12 @@ function canDrop(element, target, position) {
   }
 
   return false;
+}
+
+function isDroppableBoundaryEvent(event) {
+  return getBusinessObject(event).cancelActivity && (
+    hasNoEventDefinition(event) || hasCommonBoundaryIntermediateEventDefinition(event)
+  );
 }
 
 function canPaste(tree, target) {

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -470,6 +470,10 @@ describe('features/modeling/rules - BpmnRules', function() {
       });
     }));
 
+
+    it('drop BoundaryEvent -> Task', function() {
+      expectCanDrop('BoundaryEvent_on_SubProcess', 'Task_in_OtherProcess', false);
+    });
   });
 
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/bpmn-js/issues/1095