### PR TITLE
Copy & Paste Behavior for Group elements

### DIFF
--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -101,10 +101,6 @@ export default function BpmnCopyPaste(
       descriptor.parent = rootElement;
     }
 
-    if (descriptor.type === 'bpmn:Group') {
-      newBusinessObject.categoryValueRef = oldBusinessObject.categoryValueRef;
-    }
-
     if (is(parent, 'bpmn:Lane')) {
       descriptor.parent = parent.parent;
     }

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -145,12 +145,18 @@ export default function GroupBehavior(eventBus, bpmnFactory, canvas, elementRegi
 
     var context = event.context,
         shape = context.shape,
-        businessObject = getBusinessObject(shape);
+        businessObject = getBusinessObject(shape),
+        oldBusinessObject = shape.oldBusinessObject;
 
     if (is(businessObject, 'bpmn:Group') && !businessObject.categoryValueRef) {
 
       var definitions = getDefinitions(),
           categoryValue = createCategoryValue(definitions, bpmnFactory);
+
+      // set name from copied group if existing
+      if (oldBusinessObject && oldBusinessObject.categoryValueRef) {
+        categoryValue.value = oldBusinessObject.categoryValueRef.value;
+      }
 
       // link the reference to the Group
       businessObject.categoryValueRef = categoryValue;

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -16,6 +16,10 @@ import {
 } from '../../../util/LabelUtil';
 
 import {
+  getLabel
+} from '../../label-editing/LabelUtil';
+
+import {
   getLabelAdjustment
 } from './util/LabelLayoutUtil';
 
@@ -105,8 +109,8 @@ export default function LabelBehavior(
       return;
     }
 
-    // only create label if name
-    if (!businessObject.name) {
+    // only create label if attribute available
+    if (!getLabel(element)) {
       return;
     }
 
@@ -115,7 +119,7 @@ export default function LabelBehavior(
     // we don't care about x and y
     var labelDimensions = textRenderer.getExternalLabelBounds(
       DEFAULT_LABEL_DIMENSIONS,
-      businessObject.name || ''
+      getLabel(element)
     );
 
     modeling.createLabel(element, labelCenter, {

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -421,7 +421,6 @@ describe('features/copy-paste', function() {
 
         expect(group).to.exist;
         expect(categoryValue).to.exist;
-        expect(categoryValue.id).to.equal('CategoryValue');
       })
     );
 

--- a/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
@@ -151,6 +151,31 @@ describe('behavior - LabelBehavior', function() {
     ));
 
 
+    it('should add to group', inject(
+      function(bpmnFactory, elementRegistry, modeling) {
+
+        // given
+        var parentShape = elementRegistry.get('Process_1'),
+            categoryValue = bpmnFactory.create('bpmn:CategoryValue', {
+              value: 'foo'
+            }),
+            businessObject = bpmnFactory.create('bpmn:Group', {
+              categoryValueRef: categoryValue
+            }),
+            newShapeAttrs = {
+              type: 'bpmn:Group',
+              businessObject: businessObject
+            };
+
+        // when
+        var newShape = modeling.createShape(newShapeAttrs, { x: 50, y: 50 }, parentShape);
+
+        // then
+        expect(newShape.label).to.exist;
+      }
+    ));
+
+
     it('should not add to task', inject(
       function(elementFactory, elementRegistry, modeling) {
 


### PR DESCRIPTION
This fixes the broken copy & paste behavior for `bpmn:Group` elements (cf. camunda/camunda-modeler#1417) by

* Creating a new `bpmn:CategoryValue` for every pasted `bpmn:Group` element
* Sets the copied name value to newly created category value
* Ensures `LabelBehavior` is not restricted to `name` attribute but retrieves label value via `LabelUtil#getLabel`

![Jul-01-2019 12-58-05](https://user-images.githubusercontent.com/9433996/60431366-e9069800-9bff-11e9-90bb-49910fc924bf.gif)

Closes camunda/camunda-modeler#1417

**Note:** Beginning with these changes we do not allow creating `bpmn:Group` elements with same referenced `bpmn:CategoryValue` via our modeling tools. However, #1055 is not completely fixed for diagrams which include groups with same referenced category values (e.g. from other editors). Let's tackle this at another place somewhat in the future, especially when we create a strategy to link and unlink category values to groups. I'll update #1055 to state out the existing problem.
