### PR TITLE
1431 no create on group and label

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -768,7 +768,7 @@ function canCreate(shape, target, source, position) {
     return false;
   }
 
-  if (isLabel(target) || isGroup(target)) {
+  if (isLabel(shape) || isGroup(shape)) {
     return true;
   }
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -111,14 +111,13 @@ export function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
       );
     }
 
-    // clean up old bpmn-js instance
-    if (BPMN_JS) {
-      BPMN_JS.destroy();
-    }
+    clearBpmnJS();
 
-    BPMN_JS = new BpmnJS(_options);
+    var instance = new BpmnJS(_options);
 
-    BPMN_JS.importXML(diagram, done);
+    setBpmnJS(instance);
+
+    instance.importXML(diagram, done);
   };
 }
 
@@ -226,6 +225,18 @@ export function getBpmnJS() {
   return BPMN_JS;
 }
 
+export function clearBpmnJS() {
+  // clean up old bpmn-js instance
+  if (BPMN_JS) {
+    BPMN_JS.destroy();
+
+    BPMN_JS = null;
+  }
+}
+
+export function setBpmnJS(instance) {
+  BPMN_JS = instance;
+}
 
 export function insertCSS(name, css) {
   if (document.querySelector('[data-css-file="' + name + '"]')) {

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -8,6 +8,11 @@ import {
   createEvent
 } from '../util/MockEvents';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('Modeler', function() {
 
@@ -21,12 +26,16 @@ describe('Modeler', function() {
 
   function createModeler(xml, done) {
 
+    clearBpmnJS();
+
     modeler = new Modeler({
       container: container,
       keyboard: {
         bindTo: document
       }
     });
+
+    setBpmnJS(modeler);
 
     modeler.importXML(xml, function(err, warnings) {
       done(err, warnings, modeler);

--- a/test/spec/NavigatedViewerSpec.js
+++ b/test/spec/NavigatedViewerSpec.js
@@ -4,6 +4,11 @@ import EditorActionsModule from 'lib/features/editor-actions';
 
 import TestContainer from 'mocha-test-container-support';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('NavigatedViewer', function() {
 
@@ -14,9 +19,14 @@ describe('NavigatedViewer', function() {
   });
 
   function createViewer(xml, done) {
+
+    clearBpmnJS();
+
     var viewer = new NavigatedViewer({
       container: container
     });
+
+    setBpmnJS(viewer);
 
     viewer.importXML(xml, function(err, warnings) {
       done(err, warnings, viewer);

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -12,6 +12,11 @@ import {
   isFunction
 } from 'min-dash';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('Viewer', function() {
 
@@ -28,7 +33,11 @@ describe('Viewer', function() {
       diagramId = null;
     }
 
+    clearBpmnJS();
+
     var viewer = new Viewer({ container: container });
+
+    setBpmnJS(viewer);
 
     viewer.importXML(xml, diagramId, function(err, warnings) {
       done(err, warnings, viewer);

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -7,7 +7,8 @@ import {
   expectCanConnect,
   expectCanDrop,
   expectCanMove,
-  expectCanInsert
+  expectCanInsert,
+  expectCanCreate
 } from './Helper';
 
 import modelingModule from 'lib/features/modeling';
@@ -1052,6 +1053,111 @@ describe('features/modeling/rules - BpmnRules', function() {
       it('-> Group', function() {
         expectCanDrop(label, 'Group', true);
       });
+
+    });
+
+
+    describe('create Group', function() {
+
+      var group;
+
+      beforeEach(inject(function(elementFactory) {
+        group = elementFactory.createShape({
+          type: 'bpmn:Group',
+          x: 413, y: 254
+        });
+      }));
+
+
+      it('-> MessageFlow', function() {
+        expectCanCreate(group, 'MessageFlow_labeled', true);
+      });
+
+
+      it('-> CollapsedParticipant', function() {
+        expectCanCreate(group, 'CollapsedParticipant', true);
+      });
+
+
+      it('-> Collaboration', function() {
+        // then
+        expectCanCreate(group, 'Collaboration', true);
+      });
+
+
+      it('-> Task_in_SubProcess', function() {
+        expectCanCreate(group, 'Task_in_SubProcess', true);
+      });
+
+
+      it('-> SequenceFlow', function() {
+        expectCanCreate(group, 'SequenceFlow', true);
+      });
+
+
+      it('-> DataOutputAssociation', function() {
+        expectCanCreate(group, 'DataOutputAssociation', true);
+      });
+
+
+      it('-> Group', function() {
+        expectCanCreate(group, 'Group', true);
+      });
+
+    });
+
+
+    describe('reject create on Group', function() {
+
+      it('DataStoreReference ->', inject(function(elementFactory) {
+        var dataStoreReference = elementFactory.createShape({
+          type: 'bpmn:DataStoreReference',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(dataStoreReference, 'Group', false);
+      }));
+
+
+      it('Task ->', inject(function(elementFactory) {
+        var task = elementFactory.createShape({
+          type: 'bpmn:Task',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(task, 'Group', false);
+      }));
+
+    });
+
+
+    describe('reject create on label', function() {
+
+      var label;
+
+      beforeEach(inject(function(elementRegistry) {
+        label = elementRegistry.get('MessageFlow_labeled').label;
+      }));
+
+
+      it('DataStoreReference ->', inject(function(elementFactory) {
+        var dataStoreReference = elementFactory.createShape({
+          type: 'bpmn:DataStoreReference',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(dataStoreReference, label, false);
+      }));
+
+
+      it('Task ->', inject(function(elementFactory) {
+        var task = elementFactory.createShape({
+          type: 'bpmn:Task',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(task, label, false);
+      }));
 
     });
 

--- a/test/spec/features/rules/Helper.js
+++ b/test/spec/features/rules/Helper.js
@@ -47,6 +47,16 @@ export function expectCanDrop(element, target, expectedResult) {
 }
 
 
+export function expectCanCreate(element, target, expectedResult) {
+
+  var result = getBpmnJS().invoke(function(bpmnRules) {
+    return bpmnRules.canCreate(get(element), get(target));
+  });
+
+  expect(result).to.eql(expectedResult);
+}
+
+
 export function expectCanInsert(element, target, expectedResult) {
 
   var result = getBpmnJS().invoke(function(bpmnRules) {


### PR DESCRIPTION
This fixes a wrong rule that allows an illegal operation, blowing up the editor :boom: :dash:.

![capture sK6UQI_optimized](https://user-images.githubusercontent.com/58601/61628469-b42bb500-ac82-11e9-84f4-258d0add1b4b.gif)

Required by https://github.com/camunda/camunda-modeler/issues/1431