### PR TITLE
fix(rules): disallow dropping on labels and groups

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -768,7 +768,7 @@ function canCreate(shape, target, source, position) {
     return false;
   }
 
-  if (isLabel(target) || isGroup(target)) {
+  if (isLabel(shape) || isGroup(shape)) {
     return true;
   }
 

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -7,7 +7,8 @@ import {
   expectCanConnect,
   expectCanDrop,
   expectCanMove,
-  expectCanInsert
+  expectCanInsert,
+  expectCanCreate
 } from './Helper';
 
 import modelingModule from 'lib/features/modeling';
@@ -1052,6 +1053,111 @@ describe('features/modeling/rules - BpmnRules', function() {
       it('-> Group', function() {
         expectCanDrop(label, 'Group', true);
       });
+
+    });
+
+
+    describe('create Group', function() {
+
+      var group;
+
+      beforeEach(inject(function(elementFactory) {
+        group = elementFactory.createShape({
+          type: 'bpmn:Group',
+          x: 413, y: 254
+        });
+      }));
+
+
+      it('-> MessageFlow', function() {
+        expectCanCreate(group, 'MessageFlow_labeled', true);
+      });
+
+
+      it('-> CollapsedParticipant', function() {
+        expectCanCreate(group, 'CollapsedParticipant', true);
+      });
+
+
+      it('-> Collaboration', function() {
+        // then
+        expectCanCreate(group, 'Collaboration', true);
+      });
+
+
+      it('-> Task_in_SubProcess', function() {
+        expectCanCreate(group, 'Task_in_SubProcess', true);
+      });
+
+
+      it('-> SequenceFlow', function() {
+        expectCanCreate(group, 'SequenceFlow', true);
+      });
+
+
+      it('-> DataOutputAssociation', function() {
+        expectCanCreate(group, 'DataOutputAssociation', true);
+      });
+
+
+      it('-> Group', function() {
+        expectCanCreate(group, 'Group', true);
+      });
+
+    });
+
+
+    describe('reject create on Group', function() {
+
+      it('DataStoreReference ->', inject(function(elementFactory) {
+        var dataStoreReference = elementFactory.createShape({
+          type: 'bpmn:DataStoreReference',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(dataStoreReference, 'Group', false);
+      }));
+
+
+      it('Task ->', inject(function(elementFactory) {
+        var task = elementFactory.createShape({
+          type: 'bpmn:Task',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(task, 'Group', false);
+      }));
+
+    });
+
+
+    describe('reject create on label', function() {
+
+      var label;
+
+      beforeEach(inject(function(elementRegistry) {
+        label = elementRegistry.get('MessageFlow_labeled').label;
+      }));
+
+
+      it('DataStoreReference ->', inject(function(elementFactory) {
+        var dataStoreReference = elementFactory.createShape({
+          type: 'bpmn:DataStoreReference',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(dataStoreReference, label, false);
+      }));
+
+
+      it('Task ->', inject(function(elementFactory) {
+        var task = elementFactory.createShape({
+          type: 'bpmn:Task',
+          x: 413, y: 254
+        });
+
+        expectCanCreate(task, label, false);
+      }));
 
     });
 

--- a/test/spec/features/rules/Helper.js
+++ b/test/spec/features/rules/Helper.js
@@ -47,6 +47,16 @@ export function expectCanDrop(element, target, expectedResult) {
 }
 
 
+export function expectCanCreate(element, target, expectedResult) {
+
+  var result = getBpmnJS().invoke(function(bpmnRules) {
+    return bpmnRules.canCreate(get(element), get(target));
+  });
+
+  expect(result).to.eql(expectedResult);
+}
+
+
 export function expectCanInsert(element, target, expectedResult) {
 
   var result = getBpmnJS().invoke(function(bpmnRules) {


### PR DESCRIPTION
> This fixes a wrong rule that allows an illegal operation, blowing up the editor 💥 💨.
> 
> ![capture sK6UQI_optimized](https://user-images.githubusercontent.com/58601/61628469-b42bb500-ac82-11e9-84f4-258d0add1b4b.gif)
> 
> Required by [camunda/camunda-modeler#1431](https://github.com/camunda/camunda-modeler/issues/1431)

Author: @nikku 