### PR TITLE
fix(create-participant-behavior): ensure available children

### DIFF
--- a/lib/features/modeling/behavior/CreateParticipantBehavior.js
+++ b/lib/features/modeling/behavior/CreateParticipantBehavior.js
@@ -48,6 +48,11 @@ export default function CreateParticipantBehavior(canvas, eventBus, modeling) {
         !isConnection(element);
     });
 
+    // ensure for available children to calculate bounds
+    if (!children.length) {
+      return;
+    }
+
     var childrenBBox = getBBox(children);
 
     var participantBounds = getParticipantBounds(shape, childrenBBox);

--- a/test/spec/features/modeling/behavior/CreateParticipantBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CreateParticipantBehaviorSpec.js
@@ -342,6 +342,39 @@ describe('features/modeling - create participant', function() {
 
     });
 
+
+    describe('fitting participant (only groups)', function() {
+
+      var processDiagramXML = require('../../../../fixtures/bpmn/collaboration/process-empty.bpmn');
+
+      beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+      it('should fit participant', inject(
+        function(canvas, create, dragging, elementFactory, modeling) {
+
+          // given
+          var process = canvas.getRootElement(),
+              processGfx = canvas.getGraphics(process),
+              participant = elementFactory.createParticipantShape(),
+              participantBo = participant.businessObject,
+              groupElement = elementFactory.createShape({ type: 'bpmn:Group' });
+
+          modeling.createShape(groupElement, { x: 100, y: 100 }, process);
+
+          // when
+          create.start(canvasEvent({ x: 100, y: 100 }), participant);
+          dragging.hover({ element: process, gfx: processGfx });
+
+          // then
+          var defaultSize = elementFactory._getDefaultSize(participantBo);
+
+          expect(participant.width).to.equal(defaultSize.width);
+          expect(participant.height).to.equal(defaultSize.height);
+        }
+      ));
+
+    });
+
   });
 
 


### PR DESCRIPTION
This ensures we have left children to properly create new participant's bounds. This case of no left children after the filter operation can happen if we only have `bpmn:Group` elements in the diagram (which wouldn't make sense in practice, but however ...)

Closes #1133

![Aug-05-2019 09-57-37](https://user-images.githubusercontent.com/9433996/62448195-7db46680-b767-11e9-8778-4b479e0e6c3d.gif)

