### PR TITLE
Select Start Event After Creating Sub Process

### DIFF
--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -86,7 +86,11 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
       parent: subProcess
     });
 
-    create.start(event, [ subProcess, startEvent ]);
+    create.start(event, [ subProcess, startEvent ], {
+      hints: {
+        autoSelect: [ startEvent ]
+      }
+    });
   }
 
   function createParticipant(event) {

--- a/test/spec/features/palette/PaletteProviderSpec.js
+++ b/test/spec/features/palette/PaletteProviderSpec.js
@@ -14,6 +14,10 @@ import { createMoveEvent } from 'diagram-js/lib/features/mouse/Mouse';
 import { is } from 'lib/util/ModelUtil';
 
 import {
+  createCanvasEvent as canvasEvent
+} from '../../../util/MockEvents';
+
+import {
   query as domQuery,
   queryAll as domQueryAll
 } from 'min-dom';
@@ -46,7 +50,7 @@ describe('features/palette', function() {
 
   describe('sub process', function() {
 
-    it('should create sub process with start event', inject(function(dragging, palette) {
+    it('should create sub process with start event', inject(function(dragging) {
 
       // when
       triggerPaletteEntry('create.subprocess-expanded');
@@ -58,6 +62,28 @@ describe('features/palette', function() {
       expect(elements).to.have.length(2);
       expect(is(elements[0], 'bpmn:SubProcess')).to.be.true;
       expect(is(elements[1], 'bpmn:StartEvent')).to.be.true;
+    }));
+
+
+    it('should select start event', inject(function(canvas, dragging, selection) {
+
+      // given
+      var rootElement = canvas.getRootElement(),
+          rootGfx = canvas.getGraphics(rootElement);
+
+      triggerPaletteEntry('create.subprocess-expanded');
+
+      // when
+      dragging.hover({ element: rootElement, gfx: rootGfx });
+
+      dragging.move(canvasEvent({ x: 100, y: 100 }));
+
+      // when
+      dragging.end();
+
+      // then
+      expect(selection.get()).to.have.length(1);
+      expect(is(selection.get()[0], 'bpmn:StartEvent')).to.be.true;
     }));
 
   });


### PR DESCRIPTION
Only selects start event after creating sub process through specifying `autoSelect`.

Depends on https://github.com/bpmn-io/diagram-js/pull/392

Related to #1152

![Aug-08-2019 15-47-49](https://user-images.githubusercontent.com/9433996/62708538-e9126880-b9f3-11e9-9aa5-b4a49cda4bce.gif)

