### PR TITLE
Repair event based gateway target pasting

### DIFF
--- a/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
+++ b/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
@@ -14,9 +14,14 @@ export default function EventBasedGatewayBehavior(eventBus, modeling) {
    */
   this.preExecuted('connection.create', function(event) {
 
-    var source = event.context.source,
-        target = event.context.target,
+    var context = event.context,
+        source = context.source,
+        target = context.target,
         existingIncomingConnections = target.incoming.slice();
+
+    if (context.hints && context.hints.createElementsBehavior === false) {
+      return;
+    }
 
     if (
       is(source, 'bpmn:EventBasedGateway') &&

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -40,7 +40,8 @@ describe('features/copy-paste', function() {
       propertiesXML = require('./properties.bpmn'),
       collaborationXML = require('./collaboration.bpmn'),
       collaborationMultipleXML = require('./collaboration-multiple.bpmn'),
-      collaborationAssociationsXML = require('./data-associations.bpmn');
+      collaborationAssociationsXML = require('./data-associations.bpmn'),
+      eventBasedGatewayXML = require('./event-based-gateway.bpmn');
 
 
   describe('basic diagram', function() {
@@ -604,6 +605,20 @@ describe('features/copy-paste', function() {
       expect(newTaskBo.extensionElements).to.jsonEqual(taskBo.extensionElements);
     }));
 
+  });
+
+
+  describe('event based gateway', function() {
+
+    beforeEach(bootstrapModeler(eventBasedGatewayXML, {
+      modules: testModules
+    }));
+
+
+    it('should copy and paste event based gateway connected to an event', integrationTest([
+      'EventBasedGateway_1',
+      'IntermediateCatchEvent_1'
+    ]));
   });
 
 });

--- a/test/spec/features/copy-paste/event-based-gateway.bpmn
+++ b/test/spec/features/copy-paste/event-based-gateway.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:eventBasedGateway id="EventBasedGateway_1">
+      <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+      <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
+      <bpmn:messageEventDefinition />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="EventBasedGateway_1" targetRef="IntermediateCatchEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="EventBasedGateway_1dkii50_di" bpmnElement="EventBasedGateway_1">
+        <dc:Bounds x="156" y="555" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_1pvz0xw_di" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds x="262" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1m3ovdd_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="206" y="580" />
+        <di:waypoint x="262" y="580" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
The incoming connections of an event based gateway
target should not be removed when pasting.

Closes #1163
