### PR TITLE
fix: updates spelling of "condition" in context provider

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -278,7 +278,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
           translate('Append TimerIntermediateCatchEvent'),
           { eventDefinitionType: 'bpmn:TimerEventDefinition' }
         ),
-        'append.condtion-intermediate-event': appendAction(
+        'append.condition-intermediate-event': appendAction(
           'bpmn:IntermediateCatchEvent',
           'bpmn-icon-intermediate-event-catch-condition',
           translate('Append ConditionIntermediateCatchEvent'),

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -220,7 +220,7 @@ describe('features - context-pad', function() {
         'append.receive-task',
         'append.message-intermediate-event',
         'append.timer-intermediate-event',
-        'append.condtion-intermediate-event',
+        'append.condition-intermediate-event',
         'append.signal-intermediate-event',
         'append.text-annotation',
         '!append.task'


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

_Which issue does this PR address?_

None

Closes # None

Updates spelling of condtion to condition in context pad
