### PR TITLE
fix(auto-place): complete direct editing on autoPlace init

### DIFF
--- a/lib/features/auto-place/AutoPlace.js
+++ b/lib/features/auto-place/AutoPlace.js
@@ -25,8 +25,13 @@ export default function AutoPlace(eventBus, modeling) {
    */
   this.append = function(source, shape) {
 
+    emit('autoPlace.start', {
+      source: source,
+      shape: shape
+    });
+
     // allow others to provide the position
-    var position = emit('autoPlace', {
+    var position = emit('autoPlace.getPosition', {
       source: source,
       shape: shape
     });
@@ -37,8 +42,8 @@ export default function AutoPlace(eventBus, modeling) {
 
     var newShape = modeling.appendShape(source, shape, position, source.parent);
 
-    // notify interested parties on new shape placed
     emit('autoPlace.end', {
+      source: source,
       shape: newShape
     });
 

--- a/lib/features/grid-snapping/behavior/AutoPlaceBehavior.js
+++ b/lib/features/grid-snapping/behavior/AutoPlaceBehavior.js
@@ -5,7 +5,7 @@ import { is } from '../../../util/ModelUtil';
 
 
 export default function AutoPlaceBehavior(eventBus, gridSnapping) {
-  eventBus.on('autoPlace', function(context) {
+  eventBus.on('autoPlace.getPosition', function(context) {
     var source = context.source,
         sourceMid = getMid(source),
         shape = context.shape;

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -44,10 +44,10 @@ export default function LabelEditingProvider(
 
   // complete on followup canvas operation
   eventBus.on([
-    'element.mousedown',
-    'drag.init',
+    'autoPlace.start',
     'canvas.viewbox.changing',
-    'autoPlace',
+    'drag.init',
+    'element.mousedown',
     'popupMenu.open'
   ], function(event) {
 

--- a/test/spec/features/auto-place/AutoPlaceSpec.js
+++ b/test/spec/features/auto-place/AutoPlaceSpec.js
@@ -1,13 +1,19 @@
+/* global sinon */
+
 import {
   bootstrapModeler,
   inject
 } from 'test/TestHelper';
 
 import autoPlaceModule from 'lib/features/auto-place';
+import coreModule from 'lib/core';
+import labelEditingModule from 'lib/features/label-editing';
 import modelingModule from 'lib/features/modeling';
 import selectionModule from 'diagram-js/lib/features/selection';
-import labelEditingModule from 'lib/features/label-editing';
-import coreModule from 'lib/core';
+
+import { getBusinessObject } from '../../../../lib/util/ModelUtil';
+
+import { getMid } from 'diagram-js/lib/layout/LayoutUtil';
 
 
 describe('features/auto-place', function() {
@@ -110,31 +116,52 @@ describe('features/auto-place', function() {
   });
 
 
-  describe('modeling flow', function() {
+  describe('integration', function() {
 
     var diagramXML = require('./AutoPlace.bpmn');
 
     before(bootstrapModeler(diagramXML, {
       modules: [
-        coreModule,
-        modelingModule,
         autoPlaceModule,
-        selectionModule,
-        labelEditingModule
+        coreModule,
+        labelEditingModule,
+        modelingModule,
+        selectionModule
       ]
     }));
+
+
+    it('should complete direct edit on autoPlace', inject(
+      function(autoPlace, directEditing, elementFactory, elementRegistry) {
+
+        // given
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_2');
+
+        directEditing.activate(source);
+
+        directEditing._textbox.content.textContent = 'foo';
+
+        // when
+        autoPlace.append(source, element);
+
+        // then
+        expect(getBusinessObject(source).name).to.equal('foo');
+      }
+    ));
 
 
     it('should select + direct edit on autoPlace', inject(
       function(autoPlace, elementRegistry, elementFactory, selection, directEditing) {
 
         // given
-        var el = elementFactory.createShape({ type: 'bpmn:Task' });
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
 
         var source = elementRegistry.get('TASK_2');
 
         // when
-        var newShape = autoPlace.append(source, el);
+        var newShape = autoPlace.append(source, element);
 
         // then
         expect(selection.get()).to.eql([ newShape ]);
@@ -227,6 +254,108 @@ describe('features/auto-place', function() {
       behind: 'BOUNDARY_SUBPROCESS_TOP',
       expectedBounds: { x: 275, y: 194, width: 100, height: 80 }
     }));
+
+  });
+
+
+  describe('eventbus integration', function() {
+
+    var diagramXML = require('./AutoPlace.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        autoPlaceModule,
+        coreModule,
+        labelEditingModule,
+        modelingModule,
+        selectionModule
+      ]
+    }));
+
+
+    it('<autoPlace.start>', inject(
+      function(autoPlace, elementFactory, elementRegistry, eventBus) {
+
+        // given
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_2');
+
+        var listener = sinon.spy(function(event) {
+
+          // then
+          expect(event.shape).to.equal(element);
+          expect(event.source).to.equal(source);
+        });
+
+        eventBus.on('autoPlace.start', listener);
+
+        // when
+        autoPlace.append(source, element);
+
+        expect(listener).to.have.been.called;
+      }
+    ));
+
+
+    it('<autoPlace.getPosition>', inject(
+      function(autoPlace, elementFactory, elementRegistry, eventBus) {
+
+        // given
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_2');
+
+        var listener = sinon.spy(function(event) {
+
+          // then
+          expect(event.shape).to.equal(element);
+          expect(event.source).to.equal(source);
+
+          return {
+            x: 0,
+            y: 0
+          };
+        });
+
+        eventBus.on('autoPlace.getPosition', listener);
+
+        // when
+        autoPlace.append(source, element);
+
+        expect(listener).to.have.been.called;
+
+        expect(getMid(element)).to.eql({
+          x: 0,
+          y: 0
+        });
+      }
+    ));
+
+
+    it('<autoPlace.end>', inject(
+      function(autoPlace, elementFactory, elementRegistry, eventBus) {
+
+        // given
+        var element = elementFactory.createShape({ type: 'bpmn:Task' });
+
+        var source = elementRegistry.get('TASK_2');
+
+        var listener = sinon.spy(function(event) {
+
+          // then
+          expect(event.shape).to.equal(element);
+          expect(event.source).to.equal(source);
+        });
+
+        eventBus.on('autoPlace.end', listener);
+
+        // when
+        autoPlace.append(source, element);
+
+        expect(listener).to.have.been.called;
+      }
+    ));
 
   });
 


### PR DESCRIPTION
# BREAKING CHANGES

* `autoPlace` event renamed to `autoPlace.getPosition`

Related to camunda/camunda-modeler#1502

![Kapture 2019-09-11 at 11 30 55](https://user-images.githubusercontent.com/9433996/64685730-c0b0da80-d487-11e9-9a66-ec47d1256bc1.gif)

