### PR TITLE
chore(modeling): update the comment in replace connection

### DIFF
--- a/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
+++ b/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
@@ -116,7 +116,7 @@ export default function ReplaceConnectionBehavior(eventBus, modeling, bpmnRules,
     }
   }
 
-  // monkey-patch selection saved in dragging in order to not re-select non-existing connection
+  // monkey-patch selection saved in dragging in order to re-select it when operation is finished
   function cleanDraggingSelection(oldConnection, newConnection) {
     var context = dragging.context(),
         previousSelection = context && context.payload.previousSelection,


### PR DESCRIPTION
Since there is no danger of re-selecting non-existing elements, the comment should be updated.

Requires https://github.com/bpmn-io/diagram-js/pull/422
