### PR TITLE
chore(project): use source maps in tests

### DIFF
--- a/test/config/karma.unit.js
+++ b/test/config/karma.unit.js
@@ -105,7 +105,8 @@ module.exports = function(karma) {
           'node_modules',
           absoluteBasePath
         ]
-      }
+      },
+      devtool: 'eval-source-map'
     }
   });
 };


### PR DESCRIPTION
Source maps are really helpful when debugging and don't significantly change the bundle time.