### PR TITLE
fix(bpmn-renderer): properly escape marker ids

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -128,7 +128,9 @@ export default function BpmnRenderer(
   }
 
   function colorEscape(str) {
-    return str.replace(/[()\s,#]+/g, '_');
+
+    // only allow characters and numbers
+    return str.replace(/[^0-9a-zA-z]+/g, '_');
   }
 
   function marker(type, fill, stroke) {

--- a/test/spec/draw/BpmnRenderer.colors.bpmn
+++ b/test/spec/draw/BpmnRenderer.colors.bpmn
@@ -74,7 +74,7 @@
           <dc:Bounds x="320" y="163" width="45" height="24" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0h9s0mp_di" bpmnElement="SequenceFlow_0h9s0mp">
+      <bpmndi:BPMNEdge id="SequenceFlow_0h9s0mp_di" bpmnElement="SequenceFlow_0h9s0mp" bioc:stroke="rgba(255, 0, 0, 0.9)">
         <di:waypoint x="296" y="229" />
         <di:waypoint x="318" y="229" />
         <bpmndi:BPMNLabel>


### PR DESCRIPTION
Only characters and numbers are allowed. Anything else will be escaped.

Closes #1209