### PR TITLE
chore(ci): don't install diagram-js@develop if target is master

### DIFF
--- a/tasks/wiredeps
+++ b/tasks/wiredeps
@@ -13,7 +13,7 @@ if [ "$TRAVIS_TAG" == "" ]; then
 
   npm install "diagram-js@bpmn-io/diagram-js#$FEATURE_BRANCH";
 
-  if [ $? -ne 0 ]; then
+  if [ $? -ne 0 ] && [ "$TRAVIS_BRANCH" != "master" ]; then
     echo "Falling back to diagram-js@develop";
 
     npm install "diagram-js@bpmn-io/diagram-js#develop";


### PR DESCRIPTION
This should prevent `bpmn-js` fix branches from failing when there are breaking changes pending on `diagram-js@develop`.

Related to https://github.com/bpmn-io/bpmn-js/pull/1239#event-2803052610