### PR TITLE
WIP Disallow to collapse sub process

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -193,6 +193,18 @@ ReplaceMenuProvider.prototype.getEntries = function(element) {
     return this._createEntries(element, entries);
   }
 
+  // collapsed sub processes
+  if (is(businessObject, 'bpmn:SubProcess') && !isExpanded(businessObject)) {
+
+    entries = replaceOptions.COLLAPSED_SUBPROCESS;
+
+    if (!hasChildren(element)) {
+      entries = filter(replaceOptions.TASK, differentType).concat(entries);
+    }
+
+    return this._createEntries(element, entries);
+  }
+
   // collapsed ad hoc sub processes
   if (is(businessObject, 'bpmn:AdHocSubProcess') && !isExpanded(businessObject)) {
 
@@ -218,13 +230,6 @@ ReplaceMenuProvider.prototype.getEntries = function(element) {
   // flow nodes
   if (is(businessObject, 'bpmn:FlowNode')) {
     entries = filter(replaceOptions.TASK, differentType);
-
-    // collapsed SubProcess can not be replaced with itself
-    if (is(businessObject, 'bpmn:SubProcess') && !isExpanded(businessObject)) {
-      entries = filter(entries, function(entry) {
-        return entry.label !== 'Sub Process (collapsed)';
-      });
-    }
 
     return this._createEntries(element, entries);
   }
@@ -499,3 +504,10 @@ ReplaceMenuProvider.prototype._getAdHocEntry = function(element) {
 
   return adHocEntry;
 };
+
+
+// helper
+
+function hasChildren(element) {
+  return !!(element.children && element.children.length);
+}

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -356,14 +356,16 @@ export var SUBPROCESS_EXPANDED = [
       triggeredByEvent: true,
       isExpanded: true
     }
-  },
+  }
+];
+
+export var COLLAPSED_SUBPROCESS = [
   {
-    label: 'Sub Process (collapsed)',
-    actionName: 'replace-with-collapsed-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
+    label: 'Expand (not reversible)',
+    actionName: 'expand-subprocess',
     target: {
       type: 'bpmn:SubProcess',
-      isExpanded: false
+      isExpanded: true
     }
   }
 ];
@@ -485,21 +487,12 @@ export var TASK = [
     }
   },
   {
-    label: 'Sub Process (collapsed)',
-    actionName: 'replace-with-collapsed-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: false
-    }
-  },
-  {
-    label: 'Sub Process (expanded)',
-    actionName: 'replace-with-expanded-subprocess',
+    label: 'Sub Process',
+    actionName: 'replace-with-subprocess',
     className: 'bpmn-icon-subprocess-expanded',
     target: {
       type: 'bpmn:SubProcess',
-      isExpanded: true
+      isExpanded: false
     }
   }
 ];

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -1016,7 +1016,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(taskElement);
 
         var callActivityEntry = queryEntry('replace-with-call-activity'),
-            subProcessEntry = queryEntry('replace-with-collapsed-subprocess');
+            subProcessEntry = queryEntry('replace-with-subprocess');
 
         // then
         expect(callActivityEntry).to.exist;
@@ -1044,6 +1044,21 @@ describe('features/popup-menu - replace menu provider', function() {
 
         // then
         expect(collapsedSubProcessEntry).not.to.exist;
+      }));
+
+
+      it('should allow to expand when sub process has children', inject(function(elementRegistry) {
+
+        // given
+        var collapsedSubProcess = elementRegistry.get('SubProcess_1');
+
+        // when
+        openPopup(collapsedSubProcess);
+
+        var expandEntry = queryEntry('expand-subprocess');
+
+        // then
+        expect(expandEntry).to.exist;
       }));
 
     });


### PR DESCRIPTION
This removes the actions that previously allowed to replace
expanded Sub Process with its collapsed variant. A collapsed
Sub Process can still be created via programmatic API
and a Task's replace menu.

BREAKING CHANGES

* Replace Menu: Sub Process cannot be collapsed anymore.

Related to https://github.com/camunda/camunda-modeler/issues/1486