### PR TITLE
chore(project): do not link upstream PRs against master

### DIFF
--- a/tasks/wiredeps
+++ b/tasks/wiredeps
@@ -4,7 +4,7 @@ FEATURE_BRANCH=
 
 # https://docs.travis-ci.com/user/environment-variables
 
-if [ "$TRAVIS_TAG" <> "" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_TAG" != "" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
   exit 0;
 fi
 

--- a/tasks/wiredeps
+++ b/tasks/wiredeps
@@ -2,20 +2,24 @@
 
 FEATURE_BRANCH=
 
-if [ "$TRAVIS_TAG" == "" ]; then
-  if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
-    FEATURE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH";
-  else
-    FEATURE_BRANCH="$TRAVIS_BRANCH";
-  fi
+# https://docs.travis-ci.com/user/environment-variables
 
-  echo "Attempting to install diagram-js@$FEATURE_BRANCH";
+if [ "$TRAVIS_TAG" <> "" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+  exit 0;
+fi
 
-  npm install "diagram-js@bpmn-io/diagram-js#$FEATURE_BRANCH";
+if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+  FEATURE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH";
+else
+  FEATURE_BRANCH="$TRAVIS_BRANCH";
+fi
 
-  if [ $? -ne 0 ]; then
-    echo "Falling back to diagram-js@develop";
+echo "Attempting to install diagram-js@$FEATURE_BRANCH";
 
-    npm install "diagram-js@bpmn-io/diagram-js#develop";
-  fi
+npm install "diagram-js@bpmn-io/diagram-js#$FEATURE_BRANCH";
+
+if [ $? -ne 0 ]; then
+  echo "Falling back to diagram-js@develop";
+
+  npm install "diagram-js@bpmn-io/diagram-js#develop";
 fi


### PR DESCRIPTION
As discussed, we do not ever want to link upstream feature branches _if_ we target the `master` branch. This change implements the behavior.

This should fix https://github.com/bpmn-io/bpmn-js/pull/1240.