### PR TITLE
Clean test

### DIFF
--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -112,14 +112,13 @@ export function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
       );
     }
 
-    // clean up old bpmn-js instance
-    if (BPMN_JS) {
-      BPMN_JS.destroy();
-    }
+    clearBpmnJS();
 
-    BPMN_JS = new BpmnJS(_options);
+    var instance = new BpmnJS(_options);
 
-    BPMN_JS.importXML(diagram, done);
+    setBpmnJS(instance);
+
+    instance.importXML(diagram, done);
   };
 }
 
@@ -227,6 +226,19 @@ export function getBpmnJS() {
   return BPMN_JS;
 }
 
+export function clearBpmnJS() {
+
+  // clean up old bpmn-js instance
+  if (BPMN_JS) {
+    BPMN_JS.destroy();
+
+    BPMN_JS = null;
+  }
+}
+
+export function setBpmnJS(instance) {
+  BPMN_JS = instance;
+}
 
 export function insertCSS(name, css) {
   if (document.querySelector('[data-css-file="' + name + '"]')) {

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -8,6 +8,11 @@ import {
   createEvent
 } from '../util/MockEvents';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('Modeler', function() {
 
@@ -21,12 +26,16 @@ describe('Modeler', function() {
 
   function createModeler(xml, done) {
 
+    clearBpmnJS();
+
     modeler = new Modeler({
       container: container,
       keyboard: {
         bindTo: document
       }
     });
+
+    setBpmnJS(modeler);
 
     modeler.importXML(xml, function(err, warnings) {
       done(err, warnings, modeler);

--- a/test/spec/NavigatedViewerSpec.js
+++ b/test/spec/NavigatedViewerSpec.js
@@ -4,6 +4,11 @@ import EditorActionsModule from 'lib/features/editor-actions';
 
 import TestContainer from 'mocha-test-container-support';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('NavigatedViewer', function() {
 
@@ -14,9 +19,14 @@ describe('NavigatedViewer', function() {
   });
 
   function createViewer(xml, done) {
+
+    clearBpmnJS();
+
     var viewer = new NavigatedViewer({
       container: container
     });
+
+    setBpmnJS(viewer);
 
     viewer.importXML(xml, function(err, warnings) {
       done(err, warnings, viewer);

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -12,6 +12,11 @@ import {
   isFunction
 } from 'min-dash';
 
+import {
+  setBpmnJS,
+  clearBpmnJS
+} from 'test/TestHelper';
+
 
 describe('Viewer', function() {
 
@@ -28,7 +33,11 @@ describe('Viewer', function() {
       diagramId = null;
     }
 
+    clearBpmnJS();
+
     var viewer = new Viewer({ container: container });
+
+    setBpmnJS(viewer);
 
     viewer.importXML(xml, diagramId, function(err, warnings) {
       done(err, warnings, viewer);


### PR DESCRIPTION
Ensure that modeler instances created outside a `bootstrapModeler` can be cleaned up like any other bpmn-js test instance.