### PR TITLE
fix(modeling): do not crop waypoints on pasting

### DIFF
--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -47,9 +47,10 @@ export default function BpmnUpdater(
   // crop connection ends during create/update
   function cropConnection(e) {
     var context = e.context,
+        hints = context.hints || {},
         connection;
 
-    if (!context.cropped) {
+    if (!context.cropped && hints.createElementsBehavior !== false) {
       connection = context.connection;
       connection.waypoints = connectionDocking.getCroppedWaypoints(connection);
       context.cropped = true;

--- a/test/spec/features/modeling/BpmnUpdater.bpmn
+++ b/test/spec/features/modeling/BpmnUpdater.bpmn
@@ -27,6 +27,11 @@
       <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="StartEvent_3" targetRef="EndEvent_3" />
+    <bpmn:task id="Task_2">
+      <bpmn:incoming>SequenceFlow_5</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_5" sourceRef="Task_2" targetRef="Task_2" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -93,6 +98,16 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="314" y="364" width="0" height="0" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_15aeig4_di" bpmnElement="Task_2">
+        <dc:Bounds x="258" y="450" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0giidzv_di" bpmnElement="SequenceFlow_5">
+        <di:waypoint x="308" y="530" />
+        <di:waypoint x="308" y="550" />
+        <di:waypoint x="238" y="550" />
+        <di:waypoint x="238" y="490" />
+        <di:waypoint x="258" y="490" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/BpmnUpdaterSpec.js
+++ b/test/spec/features/modeling/BpmnUpdaterSpec.js
@@ -119,6 +119,34 @@ describe('features - bpmn-updater', function() {
       }
     ));
 
+
+    it('should not crop connection after pasting', inject(
+      function(canvas, copyPaste, elementRegistry, connectionDocking) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_5'),
+            target = elementRegistry.get('Task_2'),
+            cropSpy = sinon.spy(connectionDocking, 'getCroppedWaypoints');
+
+        copyPaste.copy([
+          target,
+          sequenceFlow
+        ]);
+
+        // when
+        copyPaste.paste({
+          element: canvas.getRootElement(),
+          point: {
+            x: 500,
+            y: 500
+          }
+        });
+
+        // then
+        expect(cropSpy).not.to.have.been.calledOnce;
+      }
+    ));
+
   });
 
 


### PR DESCRIPTION
Related to camunda/camunda-modeler#1611

______

Prevents connections to be cropped after pasting because it would break the layout of loops, caused by a known bug in our path intersection library, cf. https://github.com/bpmn-io/path-intersection/issues/7
