### PR TITLE
Allow associations wherever data associations are allowed, too

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -802,7 +802,13 @@ function canConnectAssociation(source, target) {
   }
 
   // allow connection of associations between <!TextAnnotation> and <TextAnnotation>
-  return isOneTextAnnotation(source, target);
+  if (isOneTextAnnotation(source, target)) {
+    return true;
+  }
+
+  // can connect associations where we can connect
+  // data associations, too (!)
+  return !!canConnectDataAssociation(source, target);
 }
 
 function canConnectMessageFlow(source, target) {

--- a/test/spec/features/modeling/MoveElements.collaboration-association.bpmn
+++ b/test/spec/features/modeling/MoveElements.collaboration-association.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:signavio="http://www.signavio.com" id="sid-0b0aaa25-3baf-4875-9d7a-0907d599a9ef" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="6.1.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <dataStore id="FinancialAccountingSystem" name="Financial Accounting System" isUnlimited="false">
+    <dataState id="DataState_1" />
+  </dataStore>
+  <message id="foxMessage_en" name="foxMessage_en" />
+  <collaboration id="collaboration_3">
+    <participant id="Process_Engine_1" name="Invoice Receipt" processRef="invoice" />
+  </collaboration>
+  <process id="invoice" name="Invoice Receipt" isExecutable="true" camunda:versionTag="V1.0" camunda:historyTimeToLive="30">
+    <laneSet id="laneSet_5">
+      <lane id="Accountant" name="Accountant">
+        <flowNodeRef>prepareBankTransfer</flowNodeRef>
+      </lane>
+      <lane id="teamAssistant" name="Team Assistant" />
+      <lane id="Approver" name="Approver" />
+    </laneSet>
+    <dataStoreReference id="DataStoreReference_1" name="Financial Accounting System" dataStoreRef="FinancialAccountingSystem" />
+    <userTask id="prepareBankTransfer" name="Prepare&#10;Bank&#10;Transfer" camunda:formKey="embedded:app:forms/prepare-bank-transfer.html" camunda:candidateGroups="accounting" camunda:dueDate="${dateTime().plusWeeks(1).toDate()}">
+      <documentation>Prepare the bank transfer.</documentation>
+    </userTask>
+    <association id="Association_1" sourceRef="DataStoreReference_1" targetRef="prepareBankTransfer" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_73">
+    <bpmndi:BPMNPlane id="BPMNPlane_73" bpmnElement="collaboration_3">
+      <bpmndi:BPMNShape id="Process_Engine_1_gui" bpmnElement="Process_Engine_1" isHorizontal="true">
+        <omgdc:Bounds x="160" y="80" width="1118" height="496" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Freigebender_105_gui" bpmnElement="Approver" isHorizontal="true">
+        <omgdc:Bounds x="190" y="272" width="1088" height="161" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Team-Assistenz_110_gui" bpmnElement="teamAssistant" isHorizontal="true">
+        <omgdc:Bounds x="190" y="80" width="1088" height="193" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Buchhaltung_119_gui" bpmnElement="Accountant" isHorizontal="true">
+        <omgdc:Bounds x="190" y="432" width="1088" height="144" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="zberweisung_vorbereiten_169_gui" bpmnElement="prepareBankTransfer" isHorizontal="true">
+        <omgdc:Bounds x="907" y="473" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_1_gui" bpmnElement="DataStoreReference_1" isHorizontal="true">
+        <omgdc:Bounds x="804" y="606" width="63" height="61" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="808" y="672" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1_gui" bpmnElement="Association_1" sourceElement="DataStoreReference_1_gui" targetElement="zberweisung_vorbereiten_169_gui">
+        <omgdi:waypoint x="835" y="606" />
+        <omgdi:waypoint x="905" y="543" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/modeling/MoveElementsSpec.js
+++ b/test/spec/features/modeling/MoveElementsSpec.js
@@ -176,6 +176,40 @@ describe('features/modeling - move elements', function() {
   });
 
 
+  describe('association', function() {
+
+    var testXML = require('./MoveElements.collaboration-association.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, {
+      modules: [
+        coreModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('move association', inject(function(elementRegistry, modeling) {
+
+      // given
+      var association = elementRegistry.get('Association_1'),
+          participant = elementRegistry.get('Process_Engine_1');
+
+      var elements = [
+        elementRegistry.get('DataStoreReference_1'),
+        association,
+        elementRegistry.get('prepareBankTransfer')
+      ];
+
+      // when
+      modeling.moveElements(elements, { x: 10, y: 10 }, participant);
+
+      // then
+      expect(association.parent).to.exist;
+    }));
+
+  });
+
+
   describe('incoming sequence flows of event based targets', function() {
 
     var diagramXML = require('./MoveElements.eventBasedTargets.bpmn');

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -296,7 +296,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('StartEvent_None', 'DataObjectReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -307,7 +307,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataObjectReference', 'EndEvent_None', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -329,7 +329,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('Task', 'DataObjectReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -340,7 +340,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataObjectReference', 'Task', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -351,7 +351,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('SubProcess', 'DataObjectReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -362,7 +362,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataObjectReference', 'SubProcess', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -428,7 +428,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('StartEvent_None', 'DataStoreReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -439,7 +439,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataStoreReference', 'EndEvent_None', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -461,7 +461,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('Task', 'DataStoreReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -472,7 +472,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataStoreReference', 'Task', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -483,7 +483,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('SubProcess', 'DataStoreReference', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataOutputAssociation' }
       });
     }));
@@ -494,7 +494,7 @@ describe('features/modeling/rules - BpmnRules', function() {
       expectCanConnect('DataStoreReference', 'SubProcess', {
         sequenceFlow: false,
         messageFlow: false,
-        association: false,
+        association: true,
         dataAssociation: { type: 'bpmn:DataInputAssociation' }
       });
     }));
@@ -666,17 +666,6 @@ describe('features/modeling/rules - BpmnRules', function() {
       }));
 
 
-      it('connect EventBasedGateway -> IntermediateCatchEvent_Message', inject(function() {
-
-        expectCanConnect('EventBasedGateway', 'IntermediateCatchEvent_Message', {
-          sequenceFlow: true,
-          messageFlow: false,
-          association: false,
-          dataAssociation: false
-        });
-      }));
-
-
       it('connect EventBasedGateway -> IntermediateCatchEvent_Signal', inject(function() {
 
         expectCanConnect('EventBasedGateway', 'IntermediateCatchEvent_Signal', {
@@ -746,17 +735,6 @@ describe('features/modeling/rules - BpmnRules', function() {
       it('connect EventBasedGateway -> Task_None', inject(function() {
 
         expectCanConnect('EventBasedGateway', 'Task_None', {
-          sequenceFlow: false,
-          messageFlow: false,
-          association: false,
-          dataAssociation: false
-        });
-      }));
-
-
-      it('connect EventBasedGateway -> ParallelGateway', inject(function() {
-
-        expectCanConnect('EventBasedGateway', 'ParallelGateway', {
           sequenceFlow: false,
           messageFlow: false,
           association: false,
@@ -1498,6 +1476,7 @@ describe('features/modeling/rules - BpmnRules', function() {
         move: true
       });
     }));
+
   });
 
 


### PR DESCRIPTION
This relates to https://github.com/camunda/camunda-modeler/issues/1635.

In the past we would allow assocations between all kinds of elements. While we allow only data associations to be modeled (explicit direction), this ensures that associations, when still being present, are not removed during save (or move):
 
![capture nfUolQ_optimized](https://user-images.githubusercontent.com/58601/70911922-28406e00-2013-11ea-8d14-6ebd5d6fd138.gif)
