### PR TITLE
feat(modeling): create generic ids for new elements

### DIFF
--- a/lib/features/modeling/BpmnFactory.js
+++ b/lib/features/modeling/BpmnFactory.js
@@ -8,6 +8,10 @@ import {
   isAny
 } from './util/ModelingUtil';
 
+import {
+  is
+} from '../../util/ModelUtil';
+
 
 export default function BpmnFactory(moddle) {
   this._model = moddle;
@@ -41,7 +45,21 @@ BpmnFactory.prototype._ensureId = function(element) {
 
   // generate semantic ids for elements
   // bpmn:SequenceFlow -> SequenceFlow_ID
-  var prefix = (element.$type || '').replace(/^[^:]*:/g, '') + '_';
+  var prefix;
+
+  if (is(element, 'bpmn:Activity')) {
+    prefix = 'Activity';
+  } else if (is(element, 'bpmn:Event')) {
+    prefix = 'Event';
+  } else if (is(element, 'bpmn:Gateway')) {
+    prefix = 'Gateway';
+  } else if (is(element, 'bpmn:FlowElement')) {
+    prefix = 'Flow';
+  } else {
+    prefix = (element.$type || '').replace(/^[^:]*:/g, '');
+  }
+
+  prefix += '_';
 
   if (!element.id && this._needsId(element)) {
     element.id = this._model.ids.nextPrefixed(prefix, element);

--- a/test/spec/features/modeling/BpmnFactorySpec.js
+++ b/test/spec/features/modeling/BpmnFactorySpec.js
@@ -27,14 +27,6 @@ describe('features - bpmn-factory', function() {
 
 
     it('should assign id (with semantic prefix)', inject(function(bpmnFactory) {
-      var task = bpmnFactory.create('bpmn:ServiceTask');
-
-      expect(task.$type).to.equal('bpmn:ServiceTask');
-      expect(task.id).to.match(/^ServiceTask_/g);
-    }));
-
-
-    it('should assign id (with semantic prefix)', inject(function(bpmnFactory) {
       var plane = bpmnFactory.create('bpmndi:BPMNPlane');
 
       expect(plane.$type).to.equal('bpmndi:BPMNPlane');
@@ -48,6 +40,42 @@ describe('features - bpmn-factory', function() {
       expect(set.id).to.exist;
     }));
 
+
+    describe('generic id', function() {
+
+      it('should assign id with generic semantic prefix (Activity)', inject(function(bpmnFactory) {
+        var task = bpmnFactory.create('bpmn:ServiceTask');
+
+        expect(task.$type).to.equal('bpmn:ServiceTask');
+        expect(task.id).to.match(/^Activity_/g);
+      }));
+
+
+      it('should assign id with generic semantic prefix (Gateway)', inject(function(bpmnFactory) {
+        var task = bpmnFactory.create('bpmn:ParallelGateway');
+
+        expect(task.$type).to.equal('bpmn:ParallelGateway');
+        expect(task.id).to.match(/^Gateway_/g);
+      }));
+
+
+      it('should assign id with generic semantic prefix (Event)', inject(function(bpmnFactory) {
+        var task = bpmnFactory.create('bpmn:EndEvent');
+
+        expect(task.$type).to.equal('bpmn:EndEvent');
+        expect(task.id).to.match(/^Event_/g);
+      }));
+
+
+      it('should assign id with generic semantic prefix (FlowElement)', inject(
+        function(bpmnFactory) {
+          var task = bpmnFactory.create('bpmn:SequenceFlow');
+
+          expect(task.$type).to.equal('bpmn:SequenceFlow');
+          expect(task.id).to.match(/^Flow_/g);
+        })
+      );
+    });
   });
 
 


### PR DESCRIPTION
This makes sure that the semantic ID prefix reflects
the common type of all replace options.

ID prefixes for elements will match the examples:
  * `bpmn:ServiceTask` => `Activity_<id_suffix>`
  * `bpmn:EndEvent` => `Event_<id_suffix>`
  * `bpmn:EventBasedGateway` => `Gateway_<id_suffix>`
  * `bpmn:SequenceFlow` => `Flow_<id_suffix>`

Related to https://github.com/camunda/camunda-modeler/issues/1654

---

Why `bpmn:ServiceTask` => `Activity_<id_suffix>`? Because we allow to morph tasks into subprocesses and call activities.
