### PR TITLE
fix(copy-paste): emit <moddleCopy.canSetCopiedProperty> with existing property

### DIFF
--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -164,7 +164,7 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
     var copiedProperty = self.copyProperty(sourceProperty, targetElement, propertyName);
 
     var canSetProperty = self._eventBus.fire('moddleCopy.canSetCopiedProperty', {
-      parent: parent,
+      parent: targetElement,
       property: copiedProperty,
       propertyName: propertyName
     });

--- a/test/spec/features/copy-paste/ModdleCopySpec.js
+++ b/test/spec/features/copy-paste/ModdleCopySpec.js
@@ -607,6 +607,12 @@ describe('features/copy-paste/ModdleCopy', function() {
       });
 
       eventBus.on('moddleCopy.canCopyProperty', HIGH_PRIORITY, function(context) {
+
+        // verify provided properties
+        expect(context).to.have.property('parent');
+        expect(context).to.have.property('property');
+        expect(context).to.have.property('propertyName');
+
         var propertyName = context.propertyName;
 
         if (propertyName === 'name') {
@@ -630,6 +636,12 @@ describe('features/copy-paste/ModdleCopy', function() {
       });
 
       eventBus.on('moddleCopy.canSetCopiedProperty', HIGH_PRIORITY, function(context) {
+
+        // verify provided properties
+        expect(context).to.have.property('parent');
+        expect(context).to.have.property('property');
+        expect(context).to.have.property('propertyName');
+
         var property = context.property;
 
         if (property === 'foo') {


### PR DESCRIPTION
`parent` was previously not defined.

The only reason it did not :boom: in most contexts is that there exists a global `window.parent` property that :face_with_head_bandage: things.

---

Related to https://github.com/bpmn-io/vs-code-bpmn-io/issues/65