### PR TITLE
Improve layouting of boundary elements and connections on host/source/target resize

### DIFF
--- a/test/fixtures/bpmn/boundary-events.bpmn
+++ b/test/fixtures/bpmn/boundary-events.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_tkxkICCPEeWwcL3w8i7dvw" targetNamespace="http://activiti.org/bpmn" exporter="camunda modeler" exporterVersion="2.7.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_tkxkICCPEeWwcL3w8i7dvw" targetNamespace="http://activiti.org/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
   <bpmn2:process id="Process_1" isExecutable="false">
     <bpmn2:subProcess id="SubProcess_1">
       <bpmn2:startEvent id="StartEvent_1">
@@ -15,42 +15,31 @@
     <bpmn2:boundaryEvent id="BoundaryEvent_2" name="superman" attachedToRef="Task_2" />
     <bpmn2:task id="CompensationTask" isForCompensation="true" />
     <bpmn2:intermediateThrowEvent id="IntermediateThrowEvent_1" name="joker" />
+    <bpmn2:boundaryEvent id="BoundaryEvent_3" name="wonder woman" attachedToRef="SubProcess_1" />
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_2" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="204" y="78" width="457" height="289" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_StartEvent_2" targetElement="_BPMNShape_Task_2">
+        <di:waypoint x="311" y="232" />
+        <di:waypoint x="431" y="232" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="332" y="236" width="6" height="6" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="275" y="214" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="293" y="255" width="0" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_2" bpmnElement="SubProcess_1" isExpanded="true">
-        <dc:Bounds x="204" y="78" width="457" height="289" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_Task_2" bpmnElement="Task_1">
         <dc:Bounds x="431" y="192" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_StartEvent_2" targetElement="_BPMNShape_Task_2">
-        <di:waypoint xsi:type="dc:Point" x="311" y="232" />
-        <di:waypoint xsi:type="dc:Point" x="431" y="232" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="332" y="236" width="6" height="6" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BoundaryEvent_1_di" bpmnElement="BoundaryEvent_1">
-        <dc:Bounds x="185" y="349" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="155" y="390" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="795" y="75" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_2_di" bpmnElement="BoundaryEvent_2">
-        <dc:Bounds x="781" y="140" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="754" y="176" width="90" height="20" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CompensationTask_di" bpmnElement="CompensationTask">
         <dc:Bounds x="795" y="249" width="100" height="80" />
@@ -59,6 +48,24 @@
         <dc:Bounds x="185" y="480" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="191" y="525" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_2_di" bpmnElement="BoundaryEvent_2">
+        <dc:Bounds x="781" y="140" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="754" y="176" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="185" y="349" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="155" y="390" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kn7msk_di" bpmnElement="BoundaryEvent_3">
+        <dc:Bounds x="412" y="349" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="392" width="75" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/modeling/ResizeShapeSpec.js
+++ b/test/spec/features/modeling/ResizeShapeSpec.js
@@ -3,6 +3,8 @@ import {
   inject
 } from 'test/TestHelper';
 
+import { pick } from 'min-dash';
+
 import {
   getBusinessObject
 } from 'lib/util/ModelUtil';
@@ -123,4 +125,35 @@ describe('features/modeling - resize shape', function() {
 
   });
 
+
+  describe('integration', function() {
+
+    var diagramXML = require('../../../fixtures/bpmn/boundary-events.bpmn');
+
+    var testModules = [ coreModule, modelingModule ];
+
+    beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+    it('should not move Boundary Event if unnecessary', inject(function(elementRegistry, modeling) {
+
+      // given
+      var boundaryEvent = elementRegistry.get('BoundaryEvent_3'),
+          originalPosition = getPosition(boundaryEvent),
+          subProcessElement = elementRegistry.get('SubProcess_1');
+
+      // when
+      modeling.resizeShape(subProcessElement, { x: 204, y: 28, width: 400, height: 339 });
+
+      // then
+      expect(getPosition(boundaryEvent)).to.jsonEqual(originalPosition);
+    }));
+
+  });
+
 });
+
+// helper /////
+function getPosition(shape) {
+  return pick(shape, [ 'x', 'y' ]);
+}

--- a/test/spec/features/modeling/lanes/AddLaneSpec.js
+++ b/test/spec/features/modeling/lanes/AddLaneSpec.js
@@ -5,6 +5,7 @@ import {
 } from 'test/TestHelper';
 
 import {
+  map,
   pick
 } from 'min-dash';
 
@@ -329,19 +330,32 @@ describe('features/modeling - add Lane', function() {
       });
     }
 
+    function addLaneBelow(laneId) {
+
+      return getBpmnJS().invoke(function(elementRegistry, modeling) {
+        var existingLane = elementRegistry.get(laneId);
+
+        expect(existingLane).to.exist;
+
+        return modeling.addLane(existingLane, 'bottom');
+      });
+    }
+
 
     it('should move flow nodes', inject(function(elementRegistry, modeling) {
 
       // given
       var task_Boundary = elementRegistry.get('Task_Boundary'),
-          boundary = elementRegistry.get('Boundary');
+          taskPosition = getPosition(task_Boundary),
+          boundary = elementRegistry.get('Boundary'),
+          boundaryPosition = getPosition(boundary);
 
       // when
       addLaneAbove('Nested_Lane_B');
 
       // then
-      expect(task_Boundary).to.have.position({ x: 344, y: -7 });
-      expect(boundary).to.have.position({ x: 391, y: 55 });
+      expect(task_Boundary).to.have.position({ x: taskPosition.x, y: taskPosition.y - 120 });
+      expect(boundary).to.have.position({ x: boundaryPosition.x, y: boundaryPosition.y - 120 });
     }));
 
 
@@ -349,22 +363,54 @@ describe('features/modeling - add Lane', function() {
 
       // given
       var sequenceFlow = elementRegistry.get('SequenceFlow'),
-          sequenceFlow_From_Boundary = elementRegistry.get('SequenceFlow_From_Boundary');
+          sequenceFlowWaypoints = sequenceFlow.waypoints,
+          sequenceFlow_From_Boundary = elementRegistry.get('SequenceFlow_From_Boundary'),
+          sequenceFlow_From_BoundaryWaypoints = sequenceFlow_From_Boundary.waypoints;
 
       // when
       addLaneAbove('Nested_Lane_B');
 
       // then
-      expect(sequenceFlow_From_Boundary).to.have.waypoints([
-        { x: 409, y: 91 },
-        { x: 409, y: 118 },
-        { x: 562, y: 118 },
-        { x: 562, y: 73 }
-      ]);
+      expect(sequenceFlow_From_Boundary).to.have.waypoints(
+        moveWaypoints(sequenceFlow_From_BoundaryWaypoints, 0, -120)
+      );
 
-      expect(sequenceFlow).to.have.waypoints([
-        { x: 444, y: 33 },
-        { x: 512, y: 33 }
+      expect(sequenceFlow).to.have.waypoints(
+        moveWaypoints(sequenceFlowWaypoints, 0, -120)
+      );
+    }));
+
+
+    it('should move message flows when lane added above', inject(function(elementRegistry) {
+
+      // given
+      var messageFlow = elementRegistry.get('MessageFlowAbove'),
+          messageFlowWaypoints = messageFlow.waypoints;
+
+      // when
+      addLaneAbove('Nested_Lane_B');
+
+      // then
+      expect(messageFlow).to.have.waypoints([
+        movePosition(messageFlowWaypoints[0], 0, -120),
+        messageFlowWaypoints[1]
+      ]);
+    }));
+
+
+    it('should move message flows when lane added below', inject(function(elementRegistry) {
+
+      // given
+      var messageFlow = elementRegistry.get('MessageFlowBelow'),
+          messageFlowWaypoints = messageFlow.waypoints;
+
+      // when
+      addLaneBelow('Nested_Lane_B');
+
+      // then
+      expect(messageFlow).to.have.waypoints([
+        messageFlowWaypoints[0],
+        movePosition(messageFlowWaypoints[1], 0, 120)
       ]);
     }));
 
@@ -373,7 +419,8 @@ describe('features/modeling - add Lane', function() {
 
       // given
       var event = elementRegistry.get('Event'),
-          label = event.label;
+          label = event.label,
+          labelPosition = getPosition(label);
 
       // TODO(nikku): consolidate import + editing behavior => not consistent right now
 
@@ -384,7 +431,10 @@ describe('features/modeling - add Lane', function() {
       addLaneAbove('Nested_Lane_B');
 
       // then
-      expect(label.y).to.eql(58);
+      expect(label).to.have.position({
+        x: labelPosition.x,
+        y: labelPosition.y - 120
+      });
     }));
 
   });
@@ -447,4 +497,24 @@ function padEvent(entry) {
       clientY: 100
     };
   });
+}
+
+function getPosition(element) {
+  return {
+    x: element.x,
+    y: element.y
+  };
+}
+
+function moveWaypoints(waypoints, deltaX, deltaY) {
+  return map(waypoints, function(waypoint) {
+    return movePosition(waypoint, deltaX, deltaY);
+  });
+}
+
+function movePosition(point, deltaX, deltaY) {
+  return {
+    x: point.x + deltaX,
+    y: point.y + deltaY
+  };
 }

--- a/test/spec/features/modeling/lanes/lanes-flow-nodes.bpmn
+++ b/test/spec/features/modeling/lanes/lanes-flow-nodes.bpmn
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_4bAZoD9WEeWLcNBL4nCk1A" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="6.3.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_4bAZoD9WEeWLcNBL4nCk1A" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
   <bpmn2:collaboration id="_Collaboration_2">
     <bpmn2:participant id="Participant_Lane" name="Participant_Lane" processRef="Process_Lane" />
+    <bpmn2:participant id="ParticipantBelow" name="ParticipantBelow" processRef="Process_0kzdcfx" />
+    <bpmn2:participant id="ParticipantAbove" name="ParticipantAbove" processRef="Process_1nej7ck" />
+    <bpmn2:messageFlow id="MessageFlowBelow" sourceRef="ParticipantBelow" targetRef="Participant_Lane" />
+    <bpmn2:messageFlow id="MessageFlowAbove" name="MessageFlowAbove" sourceRef="Participant_Lane" targetRef="ParticipantAbove" />
   </bpmn2:collaboration>
   <bpmn2:process id="Process_Lane" isExecutable="false">
     <bpmn2:laneSet id="LaneSet_1" name="Lane Set 1">
@@ -11,13 +15,13 @@
         <bpmn2:flowNodeRef>Event</bpmn2:flowNodeRef>
         <bpmn2:flowNodeRef>Boundary</bpmn2:flowNodeRef>
         <bpmn2:childLaneSet id="LaneSet_2">
-          <bpmn2:lane id="Nested_Lane_B" name="Nested_Lane_B" />
           <bpmn2:lane id="Nested_Lane_A" name="Nested_Lane_A">
             <bpmn2:flowNodeRef>Task_Boundary</bpmn2:flowNodeRef>
             <bpmn2:flowNodeRef>Task</bpmn2:flowNodeRef>
             <bpmn2:flowNodeRef>Event</bpmn2:flowNodeRef>
             <bpmn2:flowNodeRef>Boundary</bpmn2:flowNodeRef>
           </bpmn2:lane>
+          <bpmn2:lane id="Nested_Lane_B" name="Nested_Lane_B" />
         </bpmn2:childLaneSet>
       </bpmn2:lane>
     </bpmn2:laneSet>
@@ -32,57 +36,76 @@
     <bpmn2:boundaryEvent id="Boundary" name="Boundary" attachedToRef="Task_Boundary">
       <bpmn2:outgoing>SequenceFlow_From_Boundary</bpmn2:outgoing>
     </bpmn2:boundaryEvent>
-    <bpmn2:sequenceFlow id="SequenceFlow" name="Flow" sourceRef="Task_Boundary" targetRef="Task" />
     <bpmn2:sequenceFlow id="SequenceFlow_From_Boundary" name="" sourceRef="Boundary" targetRef="Task" />
+    <bpmn2:sequenceFlow id="SequenceFlow" name="Flow" sourceRef="Task_Boundary" targetRef="Task" />
   </bpmn2:process>
+  <bpmn2:process id="Process_0kzdcfx" isExecutable="false" />
+  <bpmn2:process id="Process_1nej7ck" isExecutable="false" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="_Collaboration_2">
       <bpmndi:BPMNShape id="_BPMNShape_Participant_2" bpmnElement="Participant_Lane" isHorizontal="true">
-        <dc:Bounds x="152" y="83" width="540" height="537" />
+        <dc:Bounds x="152" y="633" width="540" height="537" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_Task_2" bpmnElement="Task_Boundary">
-        <dc:Bounds x="344" y="113" width="100" height="80" />
+      <bpmndi:BPMNShape id="_BPMNShape_Lane_3" bpmnElement="Lane_A" isHorizontal="true">
+        <dc:Bounds x="182" y="633" width="510" height="537" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_BoundaryEvent_2" bpmnElement="Boundary">
-        <dc:Bounds x="391" y="175" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="339" y="210" width="48" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="_BPMNShape_Lane_4" bpmnElement="Nested_Lane_A" isHorizontal="true">
+        <dc:Bounds x="212" y="633" width="480" height="180" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_Task_3" bpmnElement="Task">
-        <dc:Bounds x="512" y="113" width="100" height="80" />
+      <bpmndi:BPMNShape id="_BPMNShape_Lane_5" bpmnElement="Nested_Lane_B" isHorizontal="true">
+        <dc:Bounds x="212" y="813" width="480" height="357" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_From_Boundary" sourceElement="_BPMNShape_BoundaryEvent_2" targetElement="_BPMNShape_Task_3">
-        <di:waypoint x="409" y="211" />
-        <di:waypoint x="409" y="238" />
-        <di:waypoint x="562" y="238" />
-        <di:waypoint x="562" y="193" />
+        <di:waypoint x="409" y="761" />
+        <di:waypoint x="409" y="788" />
+        <di:waypoint x="562" y="788" />
+        <di:waypoint x="562" y="743" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="377" y="188" width="6" height="6" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow" sourceElement="_BPMNShape_Task_2" targetElement="_BPMNShape_Task_3">
-        <di:waypoint x="444" y="153" />
-        <di:waypoint x="512" y="153" />
+        <di:waypoint x="444" y="703" />
+        <di:waypoint x="512" y="703" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="466" y="135" width="25" height="14" />
+          <dc:Bounds x="467" y="685" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_Lane_3" bpmnElement="Lane_A" isHorizontal="true">
-        <dc:Bounds x="182" y="83" width="510" height="537" />
+      <bpmndi:BPMNShape id="_BPMNShape_Task_2" bpmnElement="Task_Boundary">
+        <dc:Bounds x="344" y="663" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_Lane_4" bpmnElement="Nested_Lane_A" isHorizontal="true">
-        <dc:Bounds x="212" y="83" width="480" height="180" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_Lane_5" bpmnElement="Nested_Lane_B" isHorizontal="true">
-        <dc:Bounds x="212" y="263" width="480" height="357" />
+      <bpmndi:BPMNShape id="_BPMNShape_Task_3" bpmnElement="Task">
+        <dc:Bounds x="512" y="663" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_di" bpmnElement="Event">
-        <dc:Bounds x="262" y="135" width="36" height="36" />
+        <dc:Bounds x="262" y="685" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="268" y="178" width="24" height="14" />
+          <dc:Bounds x="268" y="728" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_BoundaryEvent_2" bpmnElement="Boundary">
+        <dc:Bounds x="391" y="725" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="760" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_1nh1wgv_di" bpmnElement="ParticipantBelow" isHorizontal="true">
+        <dc:Bounds x="152" y="1500" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_05yp9aj_di" bpmnElement="ParticipantAbove" isHorizontal="true">
+        <dc:Bounds x="152" y="80" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1g3bwbi_di" bpmnElement="MessageFlowBelow">
+        <di:waypoint x="452" y="1500" />
+        <di:waypoint x="452" y="1170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n2j5uv_di" bpmnElement="MessageFlowAbove">
+        <di:waypoint x="422" y="633" />
+        <di:waypoint x="422" y="330" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="479" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn2:definitions>


### PR DESCRIPTION
New behavior: If the attachment or connections can stay in same place after resize, keep it there.

Related to https://github.com/bpmn-io/bpmn-js/issues/1289
Related to https://github.com/camunda/camunda-modeler/issues/1737
Related to https://github.com/camunda/camunda-modeler/issues/655

Requires https://github.com/bpmn-io/diagram-js/pull/452