### PR TITLE
fix(modeling): do not resize label target when setting empty label

### DIFF
--- a/lib/features/label-editing/cmd/UpdateLabelHandler.js
+++ b/lib/features/label-editing/cmd/UpdateLabelHandler.js
@@ -88,17 +88,17 @@ export default function UpdateLabelHandler(modeling, textRenderer) {
         newBounds = ctx.newBounds,
         hints = ctx.hints || {};
 
+    // ignore internal labels for elements except text annotations
+    if (!isLabel(label) && !is(label, 'bpmn:TextAnnotation')) {
+      return;
+    }
+
     if (isLabel(label) && isEmptyText(newLabel)) {
 
       if (hints.removeShape !== false) {
         modeling.removeShape(label, { unsetLabel: false });
       }
 
-      return;
-    }
-
-    // ignore internal labels for elements except text annotations
-    if (!isLabelExternal(element) && !is(element, 'bpmn:TextAnnotation')) {
       return;
     }
 

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -50,6 +50,27 @@ describe('features/modeling - update label', function() {
   ));
 
 
+  it('should not create label on empty text', inject(
+    function(modeling, elementRegistry) {
+
+      // given
+      var startEvent_2 = elementRegistry.get('StartEvent_2');
+
+      // when
+      modeling.updateLabel(startEvent_2, '');
+
+      // then
+      expect(startEvent_2.businessObject.name).to.equal('');
+      expect(startEvent_2.label).not.to.exist;
+
+      expect(startEvent_2).to.have.dimensions({
+        width: 36,
+        height: 36
+      });
+    }
+  ));
+
+
   describe('should delete label', function() {
 
     it('when setting null', inject(


### PR DESCRIPTION
This prevents a bug that cause the label target to be accidentally
resized if the user updates the label value to an empty string (or null).

Closes #1294