### PR TITLE
chore(deps): make bpmn-font a development dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,7 +1103,8 @@
     "bpmn-font": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.9.3.tgz",
-      "integrity": "sha512-kzRGXGLzTROLRNCSskkOyj/+SbtTAn2unKfgB9tNt7RWJFybg/Wbe9YjK2ALotI3b64wwlCTkAalXiTiskP6dg=="
+      "integrity": "sha512-kzRGXGLzTROLRNCSskkOyj/+SbtTAn2unKfgB9tNt7RWJFybg/Wbe9YjK2ALotI3b64wwlCTkAalXiTiskP6dg==",
+      "dev": true
     },
     "bpmn-moddle": {
       "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "*.css"
   ],
   "devDependencies": {
+    "bpmn-font": "^0.9.3",
     "camunda-bpmn-moddle": "^4.0.1",
     "chai": "^4.1.2",
     "chai-match": "^1.1.1",
@@ -79,7 +80,6 @@
     "webpack": "^4.35.3"
   },
   "dependencies": {
-    "bpmn-font": "^0.9.3",
     "bpmn-moddle": "^6.0.5",
     "css.escape": "^1.5.1",
     "diagram-js": "^6.5.0",


### PR DESCRIPTION
There is no need to download it in production as we already bundle it
with the bpmn-js distribution.