### PR TITLE
Prepare Release of v6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 6.5.0
+
+* `FEAT`: prefer straight layout for sub-process connections ([#1309](https://github.com/bpmn-io/bpmn-js/pull/1309))
+* `FEAT`: move common auto-place feature to diagram-js, add BPMN-specific auto-place feature ([#1284](https://github.com/bpmn-io/bpmn-js/pull/1284))
+* `CHORE`: make bpmn-font a development dependency ([`63045bdf`](https://github.com/bpmn-io/bpmn-js/commit/63045bdfa87b9f1989a2a7a509facbeb4616acda))
+* `CHORE`: bump to `diagram-js@6.6.1`
+
 ## 6.4.2
 
 * `CHORE`: bump to `bpmn-moddle@6.0.5`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2027,9 +2027,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-6.6.0.tgz",
-      "integrity": "sha512-clyMZRj/EFtShpWz1PxJBwHPM7tqrwFRhslXBQQbH1Vq0kEXd58McqauYtXOr1AXOvjSb5gCJiNa/FHreLjebg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-6.6.1.tgz",
+      "integrity": "sha512-3SlXwT2ieXCZkQn8dVZWfNry9+6d4R+0Q57Oz9t/SfIyNIrRPg0c9IlsaTHpGUhPE3fossXPDjmvqjJD0lmBLw==",
       "requires": {
         "css.escape": "^1.5.1",
         "didi": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "bpmn-moddle": "^6.0.5",
     "css.escape": "^1.5.1",
-    "diagram-js": "^6.6.0",
+    "diagram-js": "^6.6.1",
     "diagram-js-direct-editing": "^1.6.1",
     "ids": "^1.0.0",
     "inherits": "^2.0.1",


### PR DESCRIPTION
* update CHANGELOG
* bump to diagram-js@6.6.1

Related to https://github.com/camunda/camunda-modeler/issues/1776
