### PR TITLE
chore(util/CompatibilityUtil): correct spacing and simplify warning

### DIFF
--- a/lib/util/CompatibilityUtil.js
+++ b/lib/util/CompatibilityUtil.js
@@ -24,8 +24,8 @@ export function wrapForCompatibility(api) {
       var callback = arguments[argLen - 1];
 
       console.warn(new Error(
-        'Passing callbacks to ' + api.name + ' is deprecated and will be removed in a future major release.' +
-        'Please switch to promises, cf. https://bpmn.io/l/moving-to-promises.html'
+        'Passing callbacks to ' + api.name + ' is deprecated and will be removed in a future major release. ' +
+        'Please switch to promises: https://bpmn.io/l/moving-to-promises.html'
       ));
 
       var argsWithoutCallback = Array.prototype.slice.call(arguments, 0, -1);


### PR DESCRIPTION
This simplifies the warning text and corrects wrong spacing in the current version:

![image](https://user-images.githubusercontent.com/58601/81797350-f0c8e580-950e-11ea-8e81-3565bdad6096.png)
