### PR TITLE
fix(bpmnRules): disallow boundaryEvents as message flow targets

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -268,7 +268,8 @@ function isSameOrganization(a, b) {
 
 function isMessageFlowSource(element) {
   return (
-    is(element, 'bpmn:InteractionNode') && (
+    is(element, 'bpmn:InteractionNode') &&
+    !is(element, 'bpmn:BoundaryEvent') && (
       !is(element, 'bpmn:Event') || (
         is(element, 'bpmn:ThrowEvent') &&
         hasEventDefinitionOrNone(element, 'bpmn:MessageEventDefinition')
@@ -280,6 +281,7 @@ function isMessageFlowSource(element) {
 function isMessageFlowTarget(element) {
   return (
     is(element, 'bpmn:InteractionNode') &&
+    !is(element, 'bpmn:BoundaryEvent') &&
     !isForCompensation(element) && (
       !is(element, 'bpmn:Event') || (
         is(element, 'bpmn:CatchEvent') &&

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -656,7 +656,7 @@ describe('features/modeling/rules - BpmnRules', function() {
 
       expectCanConnect('Task_in_OtherProcess', 'BoundaryEvent_on_SubProcess', {
         sequenceFlow: false,
-        messageFlow: true,
+        messageFlow: false,
         association: false,
         dataAssociation: false
       });


### PR DESCRIPTION
__Which issue does this PR address?__

Closes #1300

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [x] Corresponds to the concept: _Connection to any boundary event as a message flow source or target should be forbidden by rules_

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
