### PR TITLE
Disallow typed start events in sub processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: disallow typed start events inside non-event based sub processes ([#831](https://github.com/bpmn-io/bpmn-js/issues/831))
+
 ## 7.2.1
 
 * `FIX`: disallow boundary events as message flow targets ([#1300](https://github.com/bpmn-io/bpmn-js/issues/1300))

--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -77,8 +77,8 @@ ReplaceMenuProvider.prototype.getEntries = function(element) {
 
   var differentType = isDifferentType(element);
 
-  // start events outside event sub processes
-  if (is(businessObject, 'bpmn:StartEvent') && !isEventSubProcess(businessObject.$parent)) {
+  // start events outside sub processes
+  if (is(businessObject, 'bpmn:StartEvent') && !is(businessObject.$parent, 'bpmn:SubProcess')) {
 
     entries = filter(replaceOptions.START_EVENT, differentType);
 
@@ -97,7 +97,6 @@ ReplaceMenuProvider.prototype.getEntries = function(element) {
 
   // start events inside event sub processes
   if (is(businessObject, 'bpmn:StartEvent') && isEventSubProcess(businessObject.$parent)) {
-
     entries = filter(replaceOptions.EVENT_SUB_PROCESS_START_EVENT, function(entry) {
 
       var target = entry.target;
@@ -110,6 +109,14 @@ ReplaceMenuProvider.prototype.getEntries = function(element) {
       return differentType(entry) || !differentType(entry) && !isInterruptingEqual;
 
     });
+
+    return this._createEntries(element, entries);
+  }
+
+  // start events inside sub processes
+  if (is(businessObject, 'bpmn:StartEvent') && !isEventSubProcess(businessObject.$parent)
+      && is(businessObject.$parent, 'bpmn:SubProcess')) {
+    entries = filter(replaceOptions.START_EVENT_SUB_PROCESS, differentType);
 
     return this._createEntries(element, entries);
   }

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -61,6 +61,33 @@ export var START_EVENT = [
   }
 ];
 
+export var START_EVENT_SUB_PROCESS = [
+  {
+    label: 'Start Event',
+    actionName: 'replace-with-none-start',
+    className: 'bpmn-icon-start-event-none',
+    target: {
+      type: 'bpmn:StartEvent'
+    }
+  },
+  {
+    label: 'Intermediate Throw Event',
+    actionName: 'replace-with-none-intermediate-throwing',
+    className: 'bpmn-icon-intermediate-event-none',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent'
+    }
+  },
+  {
+    label: 'End Event',
+    actionName: 'replace-with-none-end',
+    className: 'bpmn-icon-end-event-none',
+    target: {
+      type: 'bpmn:EndEvent'
+    }
+  }
+];
+
 export var INTERMEDIATE_EVENT = [
   {
     label: 'Start Event',

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -676,6 +676,22 @@ function canReplace(elements, target, position) {
             newElementType: 'bpmn:StartEvent'
           });
         }
+
+        // replace a typed start event by a blank interrupting start event
+        // when the target is a sub process but not an event sub process
+        if (hasOneOfEventDefinitions(element,
+          [
+            'bpmn:MessageEventDefinition',
+            'bpmn:TimerEventDefinition',
+            'bpmn:SignalEventDefinition',
+            'bpmn:ConditionalEventDefinition'
+          ]) &&
+            is(target, 'bpmn:SubProcess')) {
+          canExecute.replacements.push({
+            oldElementId: element.id,
+            newElementType: 'bpmn:StartEvent'
+          });
+        }
       }
     }
 

--- a/test/fixtures/bpmn/features/replace/01_replace.bpmn
+++ b/test/fixtures/bpmn/features/replace/01_replace.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.1.1">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="KEEP ME">
       <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
@@ -61,135 +61,155 @@
         <bpmn:messageEventDefinition />
       </bpmn:startEvent>
     </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0la1q3n" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_5">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0mynzm8" />
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess_2" />
+    <bpmn:subProcess id="EventSubProcess_2" triggeredByEvent="true" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="99" y="34" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="72" y="70" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
-        <dc:Bounds x="274" y="12" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
-        <di:waypoint x="135" y="52" />
-        <di:waypoint x="274" y="52" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="239" y="42" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
-        <dc:Bounds x="501" y="27" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="481" y="77" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
-        <di:waypoint x="374" y="52" />
-        <di:waypoint x="501" y="52" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="578" y="42" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="696" y="34" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="669" y="70" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
-        <di:waypoint x="551" y="52" />
-        <di:waypoint x="696" y="52" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="718" y="42" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
-        <dc:Bounds x="101" y="138" width="350" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Transaction_1_di" bpmnElement="Transaction_1" isExpanded="true">
-        <dc:Bounds x="490" y="138" width="350" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="StartEvent_2_di" bpmnElement="StartEvent_2">
-        <dc:Bounds x="134" y="179" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="144" y="215" width="17" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
-        <dc:Bounds x="268" y="157" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
-        <di:waypoint x="170" y="197" />
-        <di:waypoint x="268" y="197" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="174" y="187" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="SubProcessCollapsed_di" bpmnElement="SubProcessCollapsed">
-        <dc:Bounds x="103" y="367" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="AdHocSubProcessCollapsed_di" bpmnElement="AdHocSubProcessCollapsed">
-        <dc:Bounds x="235" y="367" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="AdHocSubProcessExpanded_di" bpmnElement="AdHocSubProcessExpanded" isExpanded="true">
-        <dc:Bounds x="374" y="368" width="140" height="120" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_1_di" bpmnElement="BoundaryEvent_1">
-        <dc:Bounds x="349" y="74" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="322" y="110" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_2_di" bpmnElement="BoundaryEvent_2">
-        <dc:Bounds x="262" y="74" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="235" y="110" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="IntermediateThrowEvent_1_di" bpmnElement="IntermediateThrowEvent_1">
-        <dc:Bounds x="300" y="279" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="273" y="315" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_5_di" bpmnElement="SequenceFlow_5">
-        <di:waypoint x="318" y="237" />
-        <di:waypoint x="318" y="279" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="273" y="248" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_6_di" bpmnElement="SequenceFlow_6">
-        <di:waypoint x="451" y="238" />
-        <di:waypoint x="490" y="238" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="425.5" y="228" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_7_di" bpmnElement="SequenceFlow_7">
-        <di:waypoint x="280" y="110" />
-        <di:waypoint x="280" y="138" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="233" y="114" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_8_di" bpmnElement="SequenceFlow_8">
-        <di:waypoint x="714" y="138" />
-        <di:waypoint x="714" y="70" />
+        <di:waypoint x="834" y="208" />
+        <di:waypoint x="834" y="140" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="644.5" y="94" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_7_di" bpmnElement="SequenceFlow_7">
+        <di:waypoint x="400" y="180" />
+        <di:waypoint x="400" y="208" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="233" y="114" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_6_di" bpmnElement="SequenceFlow_6">
+        <di:waypoint x="571" y="308" />
+        <di:waypoint x="610" y="308" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="425.5" y="228" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="671" y="122" />
+        <di:waypoint x="816" y="122" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="718" y="42" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="494" y="122" />
+        <di:waypoint x="621" y="122" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="578" y="42" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="255" y="122" />
+        <di:waypoint x="394" y="122" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="239" y="42" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="219" y="104" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="213" y="140" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="394" y="82" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="621" y="97" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="481" y="77" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="816" y="104" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="669" y="70" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03ri246_di" bpmnElement="StartEvent_4">
+        <dc:Bounds x="150" y="652" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03dsy11_di" bpmnElement="StartEvent_5">
+        <dc:Bounds x="882" y="652" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="221" y="208" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_5_di" bpmnElement="SequenceFlow_5">
+        <di:waypoint x="438" y="307" />
+        <di:waypoint x="438" y="349" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="273" y="248" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="290" y="267" />
+        <di:waypoint x="388" y="267" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="174" y="187" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_2_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="254" y="249" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="265" y="285" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="388" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_1_di" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="420" y="349" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="273" y="315" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Transaction_1_di" bpmnElement="Transaction_1" isExpanded="true">
+        <dc:Bounds x="610" y="208" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcessCollapsed_di" bpmnElement="SubProcessCollapsed">
+        <dc:Bounds x="223" y="437" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcessCollapsed_di" bpmnElement="AdHocSubProcessCollapsed">
+        <dc:Bounds x="355" y="437" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcessExpanded_di" bpmnElement="AdHocSubProcessExpanded" isExpanded="true">
+        <dc:Bounds x="494" y="438" width="140" height="120" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EventSubProcess_1_di" bpmnElement="EventSubProcess_1" isExpanded="true">
-        <dc:Bounds x="539" y="370" width="193" height="120" />
+        <dc:Bounds x="659" y="440" width="193" height="120" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_3_di" bpmnElement="StartEvent_3">
-        <dc:Bounds x="553" y="411" width="36" height="36" />
+        <dc:Bounds x="673" y="481" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="526" y="447" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cb78c0_di" bpmnElement="SubProcess_2" isExpanded="true">
+        <dc:Bounds x="221" y="590" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cmryx4_di" bpmnElement="EventSubProcess_2" isExpanded="true">
+        <dc:Bounds x="659" y="590" width="193" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_2_di" bpmnElement="BoundaryEvent_2">
+        <dc:Bounds x="382" y="144" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="235" y="110" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1_di" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds x="469" y="144" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="322" y="110" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -657,6 +657,24 @@ describe('features/popup-menu - replace menu provider', function() {
         })
       );
 
+      it('should contain only start event, end event and intermediate throw event inside sub process except the current one',
+        inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_2');
+
+          // when
+          openPopup(startEvent);
+
+          // then
+          expect(queryEntry('replace-with-message-start')).to.be.null;
+          expect(queryEntry('replace-with-none-end')).to.exist;
+          expect(queryEntry('replace-with-none-intermediate-throwing')).to.exist;
+
+          expect(queryEntries()).to.have.length(2);
+        })
+      );
+
 
       it('should contain all intermediate events except the current one',
         inject(function(bpmnReplace, elementRegistry) {

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -1058,6 +1058,44 @@ describe('features/replace - bpmn replace', function() {
         expect(is(newElement, 'bpmn:CallActivity')).to.be.true;
       }));
 
+    it('should drop event type from start event after moving it into sub process',
+      inject(function(bpmnReplace, elementRegistry, modeling) {
+
+        // given
+        var startEvent = elementRegistry.get('StartEvent_4'),
+            subProcess = elementRegistry.get('SubProcess_2');
+
+        // when
+        modeling.moveElements([startEvent], { x: 100, y: 0 }, subProcess);
+
+        var startEventAfter = elementRegistry.filter(function(element) {
+          return is(element, 'bpmn:StartEvent') && element.parent === subProcess;
+        })[0];
+
+        // then
+        expect(startEventAfter.businessObject.eventDefinitions).to.be.undefined;
+      })
+    );
+
+    it('should not drop event type from start event after moving it into event sub process',
+      inject(function(bpmnReplace, elementRegistry, modeling) {
+
+        // given
+        var startEvent = elementRegistry.get('StartEvent_5'),
+            subProcess = elementRegistry.get('EventSubProcess_2');
+
+        // when
+        modeling.moveElements([startEvent], { x: -100, y: 0 }, subProcess);
+
+        var startEventAfter = elementRegistry.filter(function(element) {
+          return is(element, 'bpmn:StartEvent') && element.parent === subProcess;
+        })[0];
+
+        // then
+        expect(startEventAfter.businessObject.eventDefinitions[0].$type).to.equal('bpmn:MessageEventDefinition');
+      })
+    );
+
   });
 
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #831 
Fix upstream https://github.com/camunda/camunda-modeler/issues/498

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept: See [BPMN 2.0 spec](https://www.omg.org/spec/BPMN/2.0/PDF) on page 241 `There is only one type of Start Event for Sub-Processes in BPMN (see Figure 10.82): None.`
* [ ] Corresponds to the design: extends existing concepts in bpmn-js

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
