### PR TITLE
fix(rules): allow message boundary event as message flow target

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -281,12 +281,14 @@ function isMessageFlowSource(element) {
 function isMessageFlowTarget(element) {
   return (
     is(element, 'bpmn:InteractionNode') &&
-    !is(element, 'bpmn:BoundaryEvent') &&
     !isForCompensation(element) && (
       !is(element, 'bpmn:Event') || (
         is(element, 'bpmn:CatchEvent') &&
         hasEventDefinitionOrNone(element, 'bpmn:MessageEventDefinition')
       )
+    ) && !(
+      is(element, 'bpmn:BoundaryEvent') &&
+      !hasEventDefinition(element, 'bpmn:MessageEventDefinition')
     )
   );
 }

--- a/test/spec/features/rules/BpmnRules.boundaryEvent.bpmn
+++ b/test/spec/features/rules/BpmnRules.boundaryEvent.bpmn
@@ -18,6 +18,9 @@
     <bpmn:boundaryEvent id="BoundaryEvent_on_Task" attachedToRef="Task" />
     <bpmn:startEvent id="StartEvent_None" />
     <bpmn:exclusiveGateway id="ExclusiveGateway" />
+    <bpmn:boundaryEvent id="MessageBoundaryEvent_onSubProcess" attachedToRef="SubProcess">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1owasie" />
+    </bpmn:boundaryEvent>
   </bpmn:process>
   <bpmn:process id="OtherProcess">
     <bpmn:task id="Task_in_OtherProcess" name="3" />
@@ -87,6 +90,9 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="474" y="275" width="90" height="20" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MessageBoundaryEvent_onSubProcess_di" bpmnElement="MessageBoundaryEvent_onSubProcess">
+        <dc:Bounds x="362" y="204" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -663,6 +663,17 @@ describe('features/modeling/rules - BpmnRules', function() {
     }));
 
 
+    it('connect Task_in_OtherProcess -> MessageBoundaryEvent_onSubProcess', inject(function() {
+
+      expectCanConnect('Task_in_OtherProcess', 'MessageBoundaryEvent_onSubProcess', {
+        sequenceFlow: false,
+        messageFlow: true,
+        association: false,
+        dataAssociation: false
+      });
+    }));
+
+
     it('drop BoundaryEvent -> Task', function() {
       expectCanDrop('BoundaryEvent_on_SubProcess', 'Task_in_OtherProcess', false);
     });


### PR DESCRIPTION
We accidentally removed the ability to have message boundary events as message flow target with https://github.com/bpmn-io/bpmn-js/issues/1300. This re-adds this capability but still disallows it for any other boundary event.

__Which issue does this PR address?__

Closes #1346
Related to camunda/camunda-modeler#1919

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
