### PR TITLE
Place renderLabel* functions to the BpmnRenderer prototype #1347

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -71,14 +71,17 @@ export default function BpmnRenderer(
 
   BaseRenderer.call(this, eventBus, priority);
 
-  var defaultFillColor = config && config.defaultFillColor,
-      defaultStrokeColor = config && config.defaultStrokeColor;
+  this.textRenderer = textRenderer;
+  this.defaultFillColor = config && config.defaultFillColor;
+  this.defaultStrokeColor = config && config.defaultStrokeColor;
 
   var rendererId = RENDERER_IDS.next();
 
   var markers = {};
 
   var computeStyle = styles.computeStyle;
+
+  var self = this;
 
   function addMarker(id, options) {
     var attrs = assign({
@@ -446,75 +449,6 @@ export default function BpmnRenderer(
     return null;
   }
 
-  function renderLabel(parentGfx, label, options) {
-
-    options = assign({
-      size: {
-        width: 100
-      }
-    }, options);
-
-    var text = textRenderer.createText(label || '', options);
-
-    svgClasses(text).add('djs-label');
-
-    svgAppend(parentGfx, text);
-
-    return text;
-  }
-
-  function renderEmbeddedLabel(parentGfx, element, align) {
-    var semantic = getSemantic(element);
-
-    return renderLabel(parentGfx, semantic.name, {
-      box: element,
-      align: align,
-      padding: 5,
-      style: {
-        fill: getStrokeColor(element, defaultStrokeColor)
-      }
-    });
-  }
-
-  function renderExternalLabel(parentGfx, element) {
-
-    var box = {
-      width: 90,
-      height: 30,
-      x: element.width / 2 + element.x,
-      y: element.height / 2 + element.y
-    };
-
-    return renderLabel(parentGfx, getLabel(element), {
-      box: box,
-      fitBox: true,
-      style: assign(
-        {},
-        textRenderer.getExternalStyle(),
-        {
-          fill: getStrokeColor(element, defaultStrokeColor)
-        }
-      )
-    });
-  }
-
-  function renderLaneLabel(parentGfx, text, element) {
-    var textBox = renderLabel(parentGfx, text, {
-      box: {
-        height: 30,
-        width: element.height
-      },
-      align: 'center-middle',
-      style: {
-        fill: getStrokeColor(element, defaultStrokeColor)
-      }
-    });
-
-    var top = -1 * element.height;
-
-    transform(textBox, 0, -top, 270);
-  }
-
   function createPathFromConnection(connection) {
     var waypoints = connection.waypoints;
 
@@ -536,8 +470,8 @@ export default function BpmnRenderer(
     },
     'bpmn:StartEvent': function(parentGfx, element) {
       var attrs = {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       var semantic = getSemantic(element);
@@ -546,8 +480,8 @@ export default function BpmnRenderer(
         attrs = {
           strokeDasharray: '6',
           strokeLinecap: 'round',
-          fill: getFillColor(element, defaultFillColor),
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          fill: getFillColor(element, self.defaultFillColor),
+          stroke: getStrokeColor(element, self.defaultStrokeColor)
         };
       }
 
@@ -569,8 +503,8 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(element, defaultStrokeColor) : getFillColor(element, defaultFillColor);
-      var stroke = isThrowing ? getFillColor(element, defaultFillColor) : getStrokeColor(element, defaultStrokeColor);
+      var fill = isThrowing ? getStrokeColor(element, self.defaultStrokeColor) : getFillColor(element, self.defaultFillColor);
+      var stroke = isThrowing ? getFillColor(element, self.defaultFillColor) : getStrokeColor(element, self.defaultStrokeColor);
 
       var messagePath = drawPath(parentGfx, pathData, {
         strokeWidth: 1,
@@ -583,8 +517,8 @@ export default function BpmnRenderer(
     'bpmn:TimerEventDefinition': function(parentGfx, element) {
       var circle = drawCircle(parentGfx, element.width, element.height, 0.2 * element.height, {
         strokeWidth: 2,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var pathData = pathMap.getScaledPath('EVENT_TIMER_WH', {
@@ -601,7 +535,7 @@ export default function BpmnRenderer(
       drawPath(parentGfx, pathData, {
         strokeWidth: 2,
         strokeLinecap: 'square',
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       for (var i = 0;i < 12; i++) {
@@ -624,7 +558,7 @@ export default function BpmnRenderer(
           strokeWidth: 1,
           strokeLinecap: 'square',
           transform: 'rotate(' + (i * 30) + ',' + height + ',' + width + ')',
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          stroke: getStrokeColor(element, self.defaultStrokeColor)
         });
       }
 
@@ -642,12 +576,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:ConditionalEventDefinition': function(parentGfx, event) {
@@ -664,7 +598,7 @@ export default function BpmnRenderer(
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:LinkEventDefinition': function(parentGfx, event, isThrowing) {
@@ -679,12 +613,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:ErrorEventDefinition': function(parentGfx, event, isThrowing) {
@@ -699,12 +633,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:CancelEventDefinition': function(parentGfx, event, isThrowing) {
@@ -719,12 +653,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       var path = drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
 
       rotate(path, 45);
@@ -743,12 +677,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:SignalEventDefinition': function(parentGfx, event, isThrowing) {
@@ -763,12 +697,12 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
         fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:MultipleEventDefinition': function(parentGfx, event, isThrowing) {
@@ -783,7 +717,7 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, self.defaultStrokeColor) : 'none';
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
@@ -804,15 +738,15 @@ export default function BpmnRenderer(
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getStrokeColor(event, defaultStrokeColor),
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill: getStrokeColor(event, self.defaultStrokeColor),
+        stroke: getStrokeColor(event, self.defaultStrokeColor)
       });
     },
     'bpmn:EndEvent': function(parentGfx, element) {
       var circle = renderer('bpmn:Event')(parentGfx, element, {
         strokeWidth: 4,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       renderEventContent(element, parentGfx, true);
@@ -822,8 +756,8 @@ export default function BpmnRenderer(
     'bpmn:TerminateEventDefinition': function(parentGfx, element) {
       var circle = drawCircle(parentGfx, element.width, element.height, 8, {
         strokeWidth: 4,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return circle;
@@ -831,15 +765,15 @@ export default function BpmnRenderer(
     'bpmn:IntermediateEvent': function(parentGfx, element) {
       var outer = renderer('bpmn:Event')(parentGfx, element, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       /* inner */
       drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, {
         strokeWidth: 1,
         fill: getFillColor(element, 'none'),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       renderEventContent(element, parentGfx);
@@ -862,13 +796,13 @@ export default function BpmnRenderer(
 
     'bpmn:Task': function(parentGfx, element) {
       var attrs = {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       var rect = renderer('bpmn:Activity')(parentGfx, element, attrs);
 
-      renderEmbeddedLabel(parentGfx, element, 'center-middle');
+      self.renderEmbeddedLabel(parentGfx, element, 'center-middle');
       attachTaskMarkers(parentGfx, element);
 
       return rect;
@@ -885,8 +819,8 @@ export default function BpmnRenderer(
 
       /* service bg */ drawPath(parentGfx, pathDataBG, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var fillPathData = pathMap.getScaledPath('TASK_TYPE_SERVICE_FILL', {
@@ -898,7 +832,7 @@ export default function BpmnRenderer(
 
       /* service fill */ drawPath(parentGfx, fillPathData, {
         strokeWidth: 0,
-        fill: getFillColor(element, defaultFillColor)
+        fill: getFillColor(element, self.defaultFillColor)
       });
 
       var pathData = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
@@ -910,8 +844,8 @@ export default function BpmnRenderer(
 
       /* service */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
@@ -931,8 +865,8 @@ export default function BpmnRenderer(
 
       /* user path */ drawPath(parentGfx, pathData, {
         strokeWidth: 0.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var pathData2 = pathMap.getScaledPath('TASK_TYPE_USER_2', {
@@ -944,8 +878,8 @@ export default function BpmnRenderer(
 
       /* user2 path */ drawPath(parentGfx, pathData2, {
         strokeWidth: 0.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var pathData3 = pathMap.getScaledPath('TASK_TYPE_USER_3', {
@@ -957,8 +891,8 @@ export default function BpmnRenderer(
 
       /* user3 path */ drawPath(parentGfx, pathData3, {
         strokeWidth: 0.5,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
@@ -975,8 +909,8 @@ export default function BpmnRenderer(
 
       /* manual path */ drawPath(parentGfx, pathData, {
         strokeWidth: 0.5, // 0.25,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
@@ -997,8 +931,8 @@ export default function BpmnRenderer(
 
       /* send path */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getFillColor(element, defaultFillColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getFillColor(element, self.defaultFillColor)
       });
 
       return task;
@@ -1034,8 +968,8 @@ export default function BpmnRenderer(
 
       /* receive path */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
@@ -1052,7 +986,7 @@ export default function BpmnRenderer(
 
       /* script path */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
@@ -1071,7 +1005,7 @@ export default function BpmnRenderer(
       svgAttr(businessHeaderPath, {
         strokeWidth: 1,
         fill: getFillColor(element, '#aaaaaa'),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var headerData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_MAIN', {
@@ -1084,15 +1018,15 @@ export default function BpmnRenderer(
       var businessPath = drawPath(parentGfx, headerData);
       svgAttr(businessPath, {
         strokeWidth: 1,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return task;
     },
     'bpmn:SubProcess': function(parentGfx, element, attrs) {
       attrs = assign({
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       }, attrs);
 
       var rect = renderer('bpmn:Activity')(parentGfx, element, attrs);
@@ -1105,7 +1039,7 @@ export default function BpmnRenderer(
         });
       }
 
-      renderEmbeddedLabel(parentGfx, element, expanded ? 'center-top' : 'center-middle');
+      self.renderEmbeddedLabel(parentGfx, element, expanded ? 'center-top' : 'center-middle');
 
       if (expanded) {
         attachTaskMarkers(parentGfx, element);
@@ -1122,7 +1056,7 @@ export default function BpmnRenderer(
       var outer = renderer('bpmn:SubProcess')(parentGfx, element);
 
       var innerAttrs = styles.style([ 'no-fill', 'no-events' ], {
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       /* inner path */ drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS - 2, INNER_OUTER_DIST, innerAttrs);
@@ -1138,8 +1072,8 @@ export default function BpmnRenderer(
 
       var attrs = {
         fillOpacity: DEFAULT_FILL_OPACITY,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       var lane = renderer('bpmn:Lane')(parentGfx, element, attrs);
@@ -1151,18 +1085,18 @@ export default function BpmnRenderer(
           { x: 30, y: 0 },
           { x: 30, y: element.height }
         ], {
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          stroke: getStrokeColor(element, self.defaultStrokeColor)
         });
         var text = getSemantic(element).name;
-        renderLaneLabel(parentGfx, text, element);
+        self.renderLaneLabel(parentGfx, text, element);
       } else {
 
         // Collapsed pool draw text inline
         var text2 = getSemantic(element).name;
-        renderLabel(parentGfx, text2, {
+        self.renderLabel(parentGfx, text2, {
           box: element, align: 'center-middle',
           style: {
-            fill: getStrokeColor(element, defaultStrokeColor)
+            fill: getStrokeColor(element, self.defaultStrokeColor)
           }
         });
       }
@@ -1177,16 +1111,16 @@ export default function BpmnRenderer(
     },
     'bpmn:Lane': function(parentGfx, element, attrs) {
       var rect = drawRect(parentGfx, element.width, element.height, 0, assign({
-        fill: getFillColor(element, defaultFillColor),
+        fill: getFillColor(element, self.defaultFillColor),
         fillOpacity: HIGH_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       }, attrs));
 
       var semantic = getSemantic(element);
 
       if (semantic.$type === 'bpmn:Lane') {
         var text = semantic.name;
-        renderLaneLabel(parentGfx, text, element);
+        self.renderLaneLabel(parentGfx, text, element);
       }
 
       return rect;
@@ -1197,8 +1131,8 @@ export default function BpmnRenderer(
       /* circle path */
       drawCircle(parentGfx, element.width, element.height, element.height * 0.24, {
         strokeWidth: 2.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return diamond;
@@ -1220,8 +1154,8 @@ export default function BpmnRenderer(
       if ((getDi(element).isMarkerVisible)) {
         drawPath(parentGfx, pathData, {
           strokeWidth: 1,
-          fill: getStrokeColor(element, defaultStrokeColor),
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          fill: getStrokeColor(element, self.defaultStrokeColor),
+          stroke: getStrokeColor(element, self.defaultStrokeColor)
         });
       }
 
@@ -1243,8 +1177,8 @@ export default function BpmnRenderer(
 
       /* complex path */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return diamond;
@@ -1265,8 +1199,8 @@ export default function BpmnRenderer(
 
       /* parallel path */ drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return diamond;
@@ -1280,7 +1214,7 @@ export default function BpmnRenderer(
       /* outer circle path */ drawCircle(parentGfx, element.width, element.height, element.height * 0.20, {
         strokeWidth: 1,
         fill: 'none',
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var type = semantic.eventGatewayType;
@@ -1302,7 +1236,7 @@ export default function BpmnRenderer(
         var attrs = {
           strokeWidth: 2,
           fill: getFillColor(element, 'none'),
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          stroke: getStrokeColor(element, self.defaultStrokeColor)
         };
 
         /* event path */ drawPath(parentGfx, pathData, attrs);
@@ -1333,7 +1267,7 @@ export default function BpmnRenderer(
           svgAttr(innerCircle, {
             strokeWidth: 1,
             fill: 'none',
-            stroke: getStrokeColor(element, defaultStrokeColor)
+            stroke: getStrokeColor(element, self.defaultStrokeColor)
           });
         }
 
@@ -1345,9 +1279,9 @@ export default function BpmnRenderer(
     },
     'bpmn:Gateway': function(parentGfx, element) {
       var attrs = {
-        fill: getFillColor(element, defaultFillColor),
+        fill: getFillColor(element, self.defaultFillColor),
         fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       return drawDiamond(parentGfx, element.width, element.height, attrs);
@@ -1355,13 +1289,13 @@ export default function BpmnRenderer(
     'bpmn:SequenceFlow': function(parentGfx, element) {
       var pathData = createPathFromConnection(element);
 
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
+      var fill = getFillColor(element, self.defaultFillColor),
+          stroke = getStrokeColor(element, self.defaultStrokeColor);
 
       var attrs = {
         strokeLinejoin: 'round',
         markerEnd: marker('sequenceflow-end', fill, stroke),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       var path = drawPath(parentGfx, pathData, attrs);
@@ -1382,7 +1316,7 @@ export default function BpmnRenderer(
 
         // default marker
         if (source.default && (source.$instanceOf('bpmn:Gateway') || source.$instanceOf('bpmn:Activity')) &&
-            source.default === sequenceFlow) {
+          source.default === sequenceFlow) {
           svgAttr(path, {
             markerStart: marker('conditional-default-flow-marker', fill, stroke)
           });
@@ -1395,18 +1329,18 @@ export default function BpmnRenderer(
 
       var semantic = getSemantic(element);
 
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
+      var fill = getFillColor(element, self.defaultFillColor),
+          stroke = getStrokeColor(element, self.defaultStrokeColor);
 
       attrs = assign({
         strokeDasharray: '0.5, 5',
         strokeLinecap: 'round',
         strokeLinejoin: 'round',
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       }, attrs || {});
 
       if (semantic.associationDirection === 'One' ||
-          semantic.associationDirection === 'Both') {
+        semantic.associationDirection === 'Both') {
         attrs.markerEnd = marker('association-end', fill, stroke);
       }
 
@@ -1417,16 +1351,16 @@ export default function BpmnRenderer(
       return drawLine(parentGfx, element.waypoints, attrs);
     },
     'bpmn:DataInputAssociation': function(parentGfx, element) {
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
+      var fill = getFillColor(element, self.defaultFillColor),
+          stroke = getStrokeColor(element, self.defaultStrokeColor);
 
       return renderer('bpmn:Association')(parentGfx, element, {
         markerEnd: marker('association-end', fill, stroke)
       });
     },
     'bpmn:DataOutputAssociation': function(parentGfx, element) {
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
+      var fill = getFillColor(element, self.defaultFillColor),
+          stroke = getStrokeColor(element, self.defaultStrokeColor);
 
       return renderer('bpmn:Association')(parentGfx, element, {
         markerEnd: marker('association-end', fill, stroke)
@@ -1437,8 +1371,8 @@ export default function BpmnRenderer(
       var semantic = getSemantic(element),
           di = getDi(element);
 
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
+      var fill = getFillColor(element, self.defaultFillColor),
+          stroke = getStrokeColor(element, self.defaultStrokeColor);
 
       var pathData = createPathFromConnection(element);
 
@@ -1449,7 +1383,7 @@ export default function BpmnRenderer(
         strokeLinecap: 'round',
         strokeLinejoin: 'round',
         strokeWidth: '1.5px',
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       var path = drawPath(parentGfx, pathData, attrs);
@@ -1492,9 +1426,9 @@ export default function BpmnRenderer(
       });
 
       var elementObject = drawPath(parentGfx, pathData, {
-        fill: getFillColor(element, defaultFillColor),
+        fill: getFillColor(element, self.defaultFillColor),
         fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var semantic = getSemantic(element);
@@ -1544,9 +1478,9 @@ export default function BpmnRenderer(
 
       var elementStore = drawPath(parentGfx, DATA_STORE_PATH, {
         strokeWidth: 2,
-        fill: getFillColor(element, defaultFillColor),
+        fill: getFillColor(element, self.defaultFillColor),
         fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       return elementStore;
@@ -1558,8 +1492,8 @@ export default function BpmnRenderer(
 
       var attrs = {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       };
 
       if (!cancel) {
@@ -1588,7 +1522,7 @@ export default function BpmnRenderer(
     'bpmn:Group': function(parentGfx, element) {
 
       var group = drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
-        stroke: getStrokeColor(element, defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor),
         strokeWidth: 1,
         strokeDasharray: '8,3,1,3',
         fill: 'none',
@@ -1598,7 +1532,7 @@ export default function BpmnRenderer(
       return group;
     },
     'label': function(parentGfx, element) {
-      return renderExternalLabel(parentGfx, element);
+      return self.renderExternalLabel(parentGfx, element);
     },
     'bpmn:TextAnnotation': function(parentGfx, element) {
       var style = {
@@ -1620,16 +1554,16 @@ export default function BpmnRenderer(
       });
 
       drawPath(parentGfx, textPathData, {
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       var text = getSemantic(element).text || '';
-      renderLabel(parentGfx, text, {
+      self.renderLabel(parentGfx, text, {
         box: element,
         align: 'left-top',
         padding: 5,
         style: {
-          fill: getStrokeColor(element, defaultStrokeColor)
+          fill: getStrokeColor(element, self.defaultStrokeColor)
         }
       });
 
@@ -1649,15 +1583,15 @@ export default function BpmnRenderer(
 
       drawMarker('participant-multiplicity', parentGfx, markerPath, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     },
     'SubProcessMarker': function(parentGfx, element) {
       var markerRect = drawRect(parentGfx, 14, 14, 0, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
 
       // Process marker is placed in the middle of the box
@@ -1676,8 +1610,8 @@ export default function BpmnRenderer(
       });
 
       drawMarker('sub-process', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     },
     'ParallelMarker': function(parentGfx, element, position) {
@@ -1693,8 +1627,8 @@ export default function BpmnRenderer(
       });
 
       drawMarker('parallel', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     },
     'SequentialMarker': function(parentGfx, element, position) {
@@ -1710,8 +1644,8 @@ export default function BpmnRenderer(
       });
 
       drawMarker('sequential', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     },
     'CompensationMarker': function(parentGfx, element, position) {
@@ -1728,8 +1662,8 @@ export default function BpmnRenderer(
 
       drawMarker('compensation', parentGfx, markerMath, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     },
     'LoopMarker': function(parentGfx, element, position) {
@@ -1746,8 +1680,8 @@ export default function BpmnRenderer(
 
       drawMarker('loop', parentGfx, markerPath, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor),
+        fill: getFillColor(element, self.defaultFillColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor),
         strokeLinecap: 'round',
         strokeMiterlimit: 0.5
       });
@@ -1766,8 +1700,8 @@ export default function BpmnRenderer(
 
       drawMarker('adhoc', parentGfx, markerPath, {
         strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, self.defaultStrokeColor),
+        stroke: getStrokeColor(element, self.defaultStrokeColor)
       });
     }
   };
@@ -1847,10 +1781,8 @@ export default function BpmnRenderer(
     });
   }
 
-
   // extension API, use at your own risk
   this._drawPath = drawPath;
-
 }
 
 
@@ -1865,6 +1797,72 @@ BpmnRenderer.$inject = [
   'textRenderer'
 ];
 
+BpmnRenderer.prototype.renderLabel = function(parentGfx, label, options) {
+  options = assign({
+    size: {
+      width: 100
+    }
+  }, options);
+
+  var text = this.textRenderer.createText(label || '', options);
+
+  svgClasses(text).add('djs-label');
+
+  svgAppend(parentGfx, text);
+
+  return text;
+};
+
+BpmnRenderer.prototype.renderEmbeddedLabel = function(parentGfx, element, align) {
+  var semantic = getSemantic(element);
+
+  return this.renderLabel(parentGfx, semantic.name, {
+    box: element,
+    align: align,
+    padding: 5,
+    style: {
+      fill: getStrokeColor(element, this.defaultStrokeColor)
+    }
+  });
+};
+
+BpmnRenderer.prototype.renderExternalLabel = function(parentGfx, element) {
+  var box = {
+    width: 90,
+    height: 30,
+    x: element.width / 2 + element.x,
+    y: element.height / 2 + element.y
+  };
+
+  return this.renderLabel(parentGfx, getLabel(element), {
+    box: box,
+    fitBox: true,
+    style: assign(
+      {},
+      this.textRenderer.getExternalStyle(),
+      {
+        fill: getStrokeColor(element, this.defaultStrokeColor)
+      }
+    )
+  });
+};
+
+BpmnRenderer.prototype.renderLaneLabel = function(parentGfx, text, element) {
+  var textBox = this.renderLabel(parentGfx, text, {
+    box: {
+      height: 30,
+      width: element.height
+    },
+    align: 'center-middle',
+    style: {
+      fill: getStrokeColor(element, this.defaultStrokeColor)
+    }
+  });
+
+  var top = -1 * element.height;
+
+  transform(textBox, 0, -top, 270);
+};
 
 BpmnRenderer.prototype.canRender = function(element) {
   return is(element, 'bpmn:BaseElement');


### PR DESCRIPTION
__Which issue does this PR address?__

Issue #1347  
Let `renderLabel*` functions to be part of BpmnRenderer, so developers will be able to override them

__Acceptance Criteria__

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
