### PR TITLE
Add step in setup file to run modeler in browser

### DIFF
--- a/docs/project/SETUP.md
+++ b/docs/project/SETUP.md
@@ -61,6 +61,27 @@ Execute `npm install` on each of the projects to grab their dependencies.
 Execute `npm run all` on each project. Things should be fine.
 
 
-## Setup via Script
+### Setup via Script
 
 The whole setup can be automated through setup scripts for [Linux/OS X](https://github.com/bpmn-io/bpmn-js/blob/master/docs/project/setup.sh) and [Windows](https://github.com/bpmn-io/bpmn-js/blob/master/docs/project/setup.bat).
+
+
+### Running a single modeler instance
+
+To test changes that you might have made in [bpmn-js](https://github.com/bpmn-io/bpmn-js) or in any of the libraries it depends on,
+you can run a single test that will instantiate a modeler with all the core modules.
+
+* Open the [file testing the modeler](https://github.com/bpmn-io/bpmn-js/blob/master/test/spec/ModelerSpec.js#L49)
+* Change
+    ```javascript
+    it('should import simple process', function() {
+    ```
+    to
+    ```javascript
+    it.only('should import simple process', function() {
+    ```
+    (This ensures only this single test is run)
+
+* Execute `npm run dev`
+* Open your browser to <localhost:9876/debug.html>
+* Interact with the modeler and see your changes reflected


### PR DESCRIPTION
This PR adds a section that documents how to execute a single test that allows to run an instance of the modeler in the browser.