### PR TITLE
fix(palette): activate globalConnect tool instead of toggling

### DIFF
--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -134,7 +134,7 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
       title: translate('Activate the global connect tool'),
       action: {
         click: function(event) {
-          globalConnect.toggle(event);
+          globalConnect.start(event);
         }
       }
     },

--- a/test/spec/features/palette/PaletteProviderSpec.js
+++ b/test/spec/features/palette/PaletteProviderSpec.js
@@ -88,6 +88,30 @@ describe('features/palette', function() {
 
   });
 
+
+  describe('tools', function() {
+
+    // skip on PhantomJS to prevent unwanted <forEach> behaviors
+    // cf. https://github.com/bpmn-io/diagram-js/pull/517
+    (isPhantomJS() ? it.skip : it)('should not fire <move> on globalConnect', inject(
+      function(eventBus) {
+
+        // given
+        var moveSpy = sinon.spy();
+
+        eventBus.on('global-connect.move', moveSpy);
+
+        // when
+        triggerPaletteEntry('global-connect-tool');
+
+        // then
+        expect(moveSpy).to.not.have.been.called;
+
+      }
+    ));
+
+  });
+
 });
 
 // helpers //////////
@@ -100,4 +124,8 @@ function triggerPaletteEntry(id) {
       entry.action.click(createMoveEvent(0, 0));
     }
   });
+}
+
+function isPhantomJS() {
+  return /PhantomJS/.test(window.navigator.userAgent);
 }


### PR DESCRIPTION
This prevents unwanted move events when triggered by the palette action. It fixes the issue described in #1402, when clicking the action multiple times.

![Kapture 2021-01-06 at 11 32 32](https://user-images.githubusercontent.com/9433996/103758887-2200a380-5013-11eb-8d05-d69364faccb7.gif)

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #1402

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
