### PR TITLE
test: do not double add test-container class

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -10,7 +10,7 @@ insertCSS('bpmn-embedded.css', require('bpmn-font/dist/css/bpmn-embedded.css'));
 
 insertCSS('diagram-js-testing.css',
   'body .test-container { height: auto }' +
-  'body .test-container .test-content-container { height: 90vmin; }'
+  'body .test-content-container { height: 90vh; }'
 );
 
 

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -72,10 +72,10 @@ export function bootstrapBpmnJS(BpmnJS, diagram, options, locals) {
       testContainer = TestContainer.get(this);
     } catch (e) {
       testContainer = document.createElement('div');
+      testContainer.classList.add('test-content-container');
+
       document.body.appendChild(testContainer);
     }
-
-    testContainer.classList.add('test-container');
 
     var _options = options,
         _locals = locals;


### PR DESCRIPTION
This prevents the .test-container selector to appear twice in our test
markup:

```html
<div class="test-container passed" id="camunda-properties simple should
open stuff">
  <div class="title-row">
    <a href="#camunda-properties%20simple%20should%20open%20stuff">
<h3 class="test-titel">camunda-properties simple should open
stuff</h3>
    </a>
    <div class="test-result" style="float: right;">passed</div>
  </div>
  <div class="test-content-container test-container">
    <!-- test content -->
  </div>
</div>
```

With this commit we only add the .test-content-container marker in cases
where `mocha-test-container-support` is not present upon running
`bootstrapBpmnJS`.

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
