### PR TITLE
Always save xml done

### DIFF
--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -358,12 +358,12 @@ BaseViewer.prototype.saveXML = wrapForCompatibility(function saveXML(options) {
 
   var definitions = this._definitions;
 
-  return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve) {
 
     if (!definitions) {
-      var err = new Error('no definitions loaded');
-
-      return reject(err);
+      return resolve({
+        error: new Error('no definitions loaded')
+      });
     }
 
     // allow to fiddle around with definitions
@@ -375,25 +375,27 @@ BaseViewer.prototype.saveXML = wrapForCompatibility(function saveXML(options) {
 
       var xml = result.xml;
 
-      try {
-        xml = self._emit('saveXML.serialized', {
-          error: null,
-          xml: xml
-        }) || xml;
+      xml = self._emit('saveXML.serialized', {
+        xml: xml
+      }) || xml;
 
-        self._emit('saveXML.done', {
-          error: null,
-          xml: xml
-        });
-      } catch (e) {
-        console.error('error in saveXML life-cycle listener', e);
-      }
-
-      return resolve({ xml: xml });
-    }).catch(function(err) {
-
-      return reject(err);
+      return resolve({
+        xml: xml
+      });
     });
+  }).catch(function(error) {
+    return { error: error };
+  }).then(function(result) {
+
+    self._emit('saveXML.done', result);
+
+    var error = result.error;
+
+    if (error) {
+      return Promise.reject(error);
+    }
+
+    return result;
   });
 });
 

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -1302,6 +1302,44 @@ describe('Viewer', function() {
 
     });
 
+
+    it('should emit <saveXML.done> on no definitions loaded', async function() {
+
+      var viewer;
+      var events = [];
+
+      var viewer = new Viewer({
+        container: container
+      });
+
+      viewer.on([
+        'saveXML.start',
+        'saveXML.serialized',
+        'saveXML.done'
+      ], function(e) {
+
+        // log event type + event arguments
+        events.push([
+          e.type,
+          Object.keys(e).filter(function(key) {
+            return key !== 'type';
+          })
+        ]);
+      });
+
+      return viewer.saveXML().catch(function(error) {
+        events.push([ 'error' ]);
+      }).finally(function() {
+
+        // then
+        expect(events).to.eql([
+          [ 'saveXML.done', [ 'error' ] ],
+          [ 'error' ]
+        ]);
+      });
+
+    });
+
   });
 
 


### PR DESCRIPTION
This ensures we can safely listen to `saveXML.done` (`{ error, xml }`) to get notified on save errors, too.