### PR TITLE
fix/2042-enable-connection-start-for-textannotation

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -366,24 +366,28 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     'bpmn:FlowNode',
     'bpmn:InteractionNode',
     'bpmn:DataObjectReference',
-    'bpmn:DataStoreReference'
+    'bpmn:DataStoreReference',
+    'bpmn:TextAnnotation'
   ])) {
 
-    assign(actions, {
-      'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation'),
-
+    const actionsMenu = {
       'connect': {
         group: 'connect',
         className: 'bpmn-icon-connection-multi',
         title: translate('Connect using ' +
-                  (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
-                  'Association'),
+          (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
+          'Association'),
         action: {
           click: startConnect,
           dragstart: startConnect
         }
       }
-    });
+    };
+
+    if (!is(businessObject, 'bpmn:TextAnnotation')) actionsMenu['append.text-annotation'] = appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation');
+      
+
+    assign(actions, actionsMenu);
   }
 
   if (isAny(businessObject, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -369,7 +369,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     'bpmn:DataStoreReference',
     'bpmn:TextAnnotation'
   ])) {
-
     const actionsMenu = {
       'connect': {
         group: 'connect',
@@ -383,10 +382,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
         }
       }
     };
-
     if (!is(businessObject, 'bpmn:TextAnnotation')) actionsMenu['append.text-annotation'] = appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation');
-      
-
     assign(actions, actionsMenu);
   }
 

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -213,7 +213,8 @@ function canStartConnection(element) {
     'bpmn:InteractionNode',
     'bpmn:DataObjectReference',
     'bpmn:DataStoreReference',
-    'bpmn:Group'
+    'bpmn:Group',
+    'bpmn:TextAnnotation'
   ]);
 }
 


### PR DESCRIPTION
🔗  Issue related to 

https://github.com/camunda/camunda-modeler/issues/2042

purpose : enable connection tool for text annotation

![image](https://user-images.githubusercontent.com/45130488/113061123-e4468d80-91b1-11eb-8670-729ae4cbc3b5.png)

