### PR TITLE
2042 - enable connection tool for text annotation

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -362,7 +362,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
-  
   if (
     isAny(businessObject, [
       'bpmn:FlowNode',

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -370,7 +370,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
   ])) {
     assign(actions, {
           'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation'),
-
           'connect': {
             group: 'connect',
             className: 'bpmn-icon-connection-multi',
@@ -383,7 +382,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
             }
           }
         });
-      }
+    }
 
     if (is(businessObject, 'bpmn:TextAnnotation')) {
         assign(actions, {
@@ -397,7 +396,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
             }
           }
         });
-    }
   }
 
   if (isAny(businessObject, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -366,24 +366,24 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     'bpmn:FlowNode',
     'bpmn:InteractionNode',
     'bpmn:DataObjectReference',
-    'bpmn:DataStoreReference'
+    'bpmn:DataStoreReference',
+    'bpmn:TextAnnotation'
   ])) {
-
-    assign(actions, {
-      'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation'),
-
+    const actionsMenu = {
       'connect': {
         group: 'connect',
         className: 'bpmn-icon-connection-multi',
         title: translate('Connect using ' +
-                  (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
-                  'Association'),
+          (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
+          'Association'),
         action: {
           click: startConnect,
           dragstart: startConnect
         }
       }
-    });
+    };
+    if (!is(businessObject, 'bpmn:TextAnnotation')) actionsMenu['append.text-annotation'] = appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation');
+    assign(actions, actionsMenu);
   }
 
   if (isAny(businessObject, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -366,24 +366,38 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     'bpmn:FlowNode',
     'bpmn:InteractionNode',
     'bpmn:DataObjectReference',
-    'bpmn:DataStoreReference',
-    'bpmn:TextAnnotation'
+    'bpmn:DataStoreReference'
   ])) {
-    var actionsMenu = {
-      'connect': {
-        group: 'connect',
-        className: 'bpmn-icon-connection-multi',
-        title: translate('Connect using ' +
-          (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
-          'Association'),
-        action: {
-          click: startConnect,
-          dragstart: startConnect
-        }
+    assign(actions, {
+          'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation'),
+
+          'connect': {
+            group: 'connect',
+            className: 'bpmn-icon-connection-multi',
+            title: translate('Connect using ' +
+                        (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
+                        'Association'),
+            action: {
+              click: startConnect,
+              dragstart: startConnect
+            }
+          }
+        });
       }
-    };
-    if (!is(businessObject, 'bpmn:TextAnnotation')) actionsMenu['append.text-annotation'] = appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation');
-    assign(actions, actionsMenu);
+
+    if (is(businessObject, 'bpmn:TextAnnotation')) {
+        assign(actions, {
+          'connect': {
+            group: 'connect',
+            className: 'bpmn-icon-connection-multi',
+            title: translate('Connect using Association'),
+            action: {
+              click: startConnect,
+              dragstart: startConnect
+            }
+          }
+        });
+    }
   }
 
   if (isAny(businessObject, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -362,28 +362,30 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
+  
   if (
     isAny(businessObject, [
-      "bpmn:FlowNode",
-      "bpmn:InteractionNode",
-      "bpmn:DataObjectReference",
-      "bpmn:DataStoreReference",
+      'bpmn:FlowNode',
+      'bpmn:InteractionNode',
+      'bpmn:DataObjectReference',
+      'bpmn:DataStoreReference',
     ])
   ) {
     assign(actions, {
-      "append.text-annotation": appendAction(
-        "bpmn:TextAnnotation",
-        "bpmn-icon-text-annotation"
+      'append.text-annotation': appendAction(
+        'bpmn:TextAnnotation',
+        'bpmn-icon-text-annotation'
       ),
+
       connect: {
-        group: "connect",
-        className: "bpmn-icon-connection-multi",
+        group: 'connect',
+        className: 'bpmn-icon-connection-multi',
         title: translate(
-          "Connect using " +
+          'Connect using ' +
             (businessObject.isForCompensation
-              ? ""
-              : "Sequence/MessageFlow or ") +
-            "Association"
+              ? ''
+              : 'Sequence/MessageFlow or ') +
+            'Association'
         ),
         action: {
           click: startConnect,
@@ -393,12 +395,12 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
-  if (is(businessObject, "bpmn:TextAnnotation")) {
+  if (is(businessObject, 'bpmn:TextAnnotation')) {
     assign(actions, {
       connect: {
-        group: "connect",
-        className: "bpmn-icon-connection-multi",
-        title: translate("Connect using Association"),
+        group: 'connect',
+        className: 'bpmn-icon-connection-multi',
+        title: translate('Connect using Association'),
         action: {
           click: startConnect,
           dragstart: startConnect,

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -369,7 +369,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     'bpmn:DataStoreReference',
     'bpmn:TextAnnotation'
   ])) {
-    const actionsMenu = {
+    var actionsMenu = {
       'connect': {
         group: 'connect',
         className: 'bpmn-icon-connection-multi',

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -362,40 +362,49 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
-  if (isAny(businessObject, [
-    'bpmn:FlowNode',
-    'bpmn:InteractionNode',
-    'bpmn:DataObjectReference',
-    'bpmn:DataStoreReference'
-  ])) {
+  if (
+    isAny(businessObject, [
+      "bpmn:FlowNode",
+      "bpmn:InteractionNode",
+      "bpmn:DataObjectReference",
+      "bpmn:DataStoreReference",
+    ])
+  ) {
     assign(actions, {
-          'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation'),
-          'connect': {
-            group: 'connect',
-            className: 'bpmn-icon-connection-multi',
-            title: translate('Connect using ' +
-                        (businessObject.isForCompensation ? '' : 'Sequence/MessageFlow or ') +
-                        'Association'),
-            action: {
-              click: startConnect,
-              dragstart: startConnect
-            }
-          }
-        });
-    }
+      "append.text-annotation": appendAction(
+        "bpmn:TextAnnotation",
+        "bpmn-icon-text-annotation"
+      ),
+      connect: {
+        group: "connect",
+        className: "bpmn-icon-connection-multi",
+        title: translate(
+          "Connect using " +
+            (businessObject.isForCompensation
+              ? ""
+              : "Sequence/MessageFlow or ") +
+            "Association"
+        ),
+        action: {
+          click: startConnect,
+          dragstart: startConnect,
+        },
+      },
+    });
+  }
 
-    if (is(businessObject, 'bpmn:TextAnnotation')) {
-        assign(actions, {
-          'connect': {
-            group: 'connect',
-            className: 'bpmn-icon-connection-multi',
-            title: translate('Connect using Association'),
-            action: {
-              click: startConnect,
-              dragstart: startConnect
-            }
-          }
-        });
+  if (is(businessObject, "bpmn:TextAnnotation")) {
+    assign(actions, {
+      connect: {
+        group: "connect",
+        className: "bpmn-icon-connection-multi",
+        title: translate("Connect using Association"),
+        action: {
+          click: startConnect,
+          dragstart: startConnect,
+        },
+      },
+    });
   }
 
   if (isAny(businessObject, [ 'bpmn:DataObjectReference', 'bpmn:DataStoreReference' ])) {

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -213,7 +213,8 @@ function canStartConnection(element) {
     'bpmn:InteractionNode',
     'bpmn:DataObjectReference',
     'bpmn:DataStoreReference',
-    'bpmn:Group'
+    'bpmn:Group',
+    'bpmn:TextAnnotation'
   ]);
 }
 

--- a/test/spec/features/context-pad/ContextPad.activation.bpmn
+++ b/test/spec/features/context-pad/ContextPad.activation.bpmn
@@ -57,7 +57,7 @@
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
         <dc:Bounds x="40" y="410" width="190" height="110" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1" bpmnElement="TextAnnotation_1">
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
         <dc:Bounds x="760" y="120" width="100" height="30" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/context-pad/ContextPad.activation.bpmn
+++ b/test/spec/features/context-pad/ContextPad.activation.bpmn
@@ -12,6 +12,9 @@
     <bpmn2:dataObject id="DataObject_1" name="Data Object 1"/>
     <bpmn2:dataObjectReference id="DataObjectReference" dataObjectRef="DataObject_1"/>
     <bpmn2:group id="Group_1" categoryValueRef="CategoryValue_1" />
+    <bpmn2:textAnnotation id="TextAnnotation_1">
+      <bpmn2:text>simple text annotation</bpmn2:text>
+    </bpmn2:textAnnotation>
   </bpmn2:process>
   <bpmn2:category id="Category_1">
     <bpmn2:categoryValue id="CategoryValue_1" />

--- a/test/spec/features/context-pad/ContextPad.activation.bpmn
+++ b/test/spec/features/context-pad/ContextPad.activation.bpmn
@@ -57,6 +57,9 @@
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
         <dc:Bounds x="40" y="410" width="190" height="110" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="760" y="120" width="100" height="30" />
+      </bpmndi:BPMNShape
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn2:definitions>

--- a/test/spec/features/context-pad/ContextPad.activation.bpmn
+++ b/test/spec/features/context-pad/ContextPad.activation.bpmn
@@ -59,7 +59,7 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1" bpmnElement="TextAnnotation_1">
         <dc:Bounds x="760" y="120" width="100" height="30" />
-      </bpmndi:BPMNShape
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn2:definitions>

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -290,7 +290,7 @@ describe('features - context-pad', function() {
         '!replace'
       ]);
     }));
-    
+
     it('should provide text annotation entries', inject(function() {
       expectContextPadEntries('TextAnnotation_1', [
         'connect',
@@ -298,7 +298,7 @@ describe('features - context-pad', function() {
         '!replace'
       ]);
     }));
-    
+
   });
 
 

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -296,7 +296,8 @@ describe('features - context-pad', function() {
       expectContextPadEntries('TextAnnotation_1', [
         'connect',
         'delete',
-        '!replace'
+        '!replace',
+        '!append.text-annotation'
       ]);
     }));
 

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -291,7 +291,8 @@ describe('features - context-pad', function() {
       ]);
     }));
 
-    it('should provide text annotation entries', inject(function() {
+    it('should provide Text Annotation entries', inject(function() {
+
       expectContextPadEntries('TextAnnotation_1', [
         'connect',
         'delete',

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -290,7 +290,17 @@ describe('features - context-pad', function() {
         '!replace'
       ]);
     }));
+    
+    
+    it('should provide text annotation entries', inject(function() {
 
+      expectContextPadEntries('TextAnnotation_1', [
+        'connect',
+        'delete',
+        '!replace'
+      ]);
+    }));
+    
   });
 
 

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -291,9 +291,7 @@ describe('features - context-pad', function() {
       ]);
     }));
     
-    
     it('should provide text annotation entries', inject(function() {
-
       expectContextPadEntries('TextAnnotation_1', [
         'connect',
         'delete',

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -2255,7 +2255,8 @@ describe('features/modeling/rules - BpmnRules', function() {
         'bpmn:InteractionNode',
         'bpmn:DataObjectReference',
         'bpmn:DataStoreReference',
-        'bpmn:Group'
+        'bpmn:Group',
+        'bpmn:TextAnnotation'
       ];
 
       // when


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/bpmn-io/bpmn-js.svg?branch=develop)](https://travis-ci.com/bpmn-io/bpmn-js)

🔗 linked to camunda modeler issue : https://github.com/camunda/camunda-modeler/issues/2042
purpose : enable connection tool to text annotation
modified : 
- BpmnRules.js to be able start link from annotation to other component
- ContextPafProvider.js to add connectTool in the menu in addition to the remove icon

![image](https://user-images.githubusercontent.com/45130488/113093228-c861dc80-91ef-11eb-8e0c-b9fcd955a15d.png)

