### PR TITLE
Copy Root Element References on Replace

### DIFF
--- a/lib/features/modeling/behavior/BoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/BoundaryEventBehavior.js
@@ -9,11 +9,13 @@ import {
   forEach
 } from 'min-dash';
 
+var HIGH_PRIORITY = 2000;
+
 
 /**
  * BPMN specific boundary event behavior
  */
-export default function BoundaryEventBehavior(eventBus, modeling) {
+export default function BoundaryEventBehavior(eventBus, moddle, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -57,10 +59,24 @@ export default function BoundaryEventBehavior(eventBus, modeling) {
       });
     }
   });
+
+  // copy reference to root element on replace
+  eventBus.on('moddleCopy.canCopyProperty', HIGH_PRIORITY, function(context) {
+    var parent = context.parent,
+        property = context.property,
+        propertyName = context.propertyName;
+
+    var propertyDescriptor = moddle.getPropertyDescriptor(parent, propertyName);
+
+    if (propertyDescriptor && propertyDescriptor.isReference && is(property, 'bpmn:RootElement')) {
+      parent.set(propertyName, property);
+    }
+  });
 }
 
 BoundaryEventBehavior.$inject = [
   'eventBus',
+  'moddle',
   'modeling'
 ];
 

--- a/test/spec/features/modeling/behavior/BoundaryEvent.bpmn
+++ b/test/spec/features/modeling/behavior/BoundaryEvent.bpmn
@@ -1,11 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1ipuizk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1ipuizk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.7.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:eventBasedGateway id="EventBasedGateway_1" />
     <bpmn:receiveTask id="ReceiveTask_1" />
     <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ReceiveTask_1" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="BoundaryEvent_2" attachedToRef="Task_2">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_3" attachedToRef="Task_2">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" escalationRef="Escalation_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_4" attachedToRef="Task_2">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_5" attachedToRef="Task_2">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_6" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_05x99ob" messageRef="Message_1" />
+    </bpmn:boundaryEvent>
   </bpmn:process>
+  <bpmn:message id="Message_1" name="Message_1" />
+  <bpmn:escalation id="Escalation_1" name="Escalation_1" />
+  <bpmn:error id="Error_1" name="Error_1" />
+  <bpmn:signal id="Signal_1" name="Signal_1" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="EventBasedGateway_1cu8t9h_di" bpmnElement="EventBasedGateway_1">
@@ -14,11 +34,29 @@
       <bpmndi:BPMNShape id="ReceiveTask_1vk05s6_di" bpmnElement="ReceiveTask_1">
         <dc:Bounds x="300" y="103" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qf26hs_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="172" y="221" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_083btya_di" bpmnElement="Task_2">
+        <dc:Bounds x="450" y="103" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ti3ldv_di" bpmnElement="BoundaryEvent_5">
+        <dc:Bounds x="532" y="85" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yced78_di" bpmnElement="BoundaryEvent_4">
+        <dc:Bounds x="532" y="165" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1v79yci_di" bpmnElement="BoundaryEvent_3">
+        <dc:Bounds x="482" y="165" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dw2m3x_di" bpmnElement="BoundaryEvent_2">
+        <dc:Bounds x="432" y="165" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_0xg8xmx_di" bpmnElement="BoundaryEvent_1">
         <dc:Bounds x="331" y="165" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qf26hs_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
-        <dc:Bounds x="172" y="221" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_0gfnflr_di" bpmnElement="BoundaryEvent_6">
+        <dc:Bounds x="432" y="85" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
@@ -6,6 +6,8 @@ import {
 import modelingModule from 'lib/features/modeling';
 import coreModule from 'lib/core';
 
+import { is } from 'lib/util/ModelUtil';
+
 
 describe('features/modeling/behavior - boundary event', function() {
 
@@ -61,4 +63,130 @@ describe('features/modeling/behavior - boundary event', function() {
 
   });
 
+
+  describe('copy reference on replace', function() {
+
+    it('interrupting to non-interrupting', function() {
+
+      it('should copy message reference', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_2'),
+            message = getReferencedRootElement(interruptingBoundaryEvent, 'messageRef');
+
+        // assume
+        expect(is(message, 'bpmn:Message')).to.be.true;
+
+        // when
+        var nonInterruptingBoundaryEvent = bpmnReplace.replaceElement(interruptingBoundaryEvent, {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:MessageEventDefinition',
+          cancelActivity: false
+        });
+
+        // then
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
+      }));
+
+
+      it('should copy escalation reference', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_3'),
+            escalation = getReferencedRootElement(interruptingBoundaryEvent, 'escalationRef');
+
+        // assume
+        expect(is(escalation, 'bpmn:Escalation')).to.be.true;
+
+        // when
+        var nonInterruptingBoundaryEvent = bpmnReplace.replaceElement(interruptingBoundaryEvent, {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:EscalationEventDefinition',
+          cancelActivity: false
+        });
+
+        // then
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'escalationRef')).to.equal(escalation);
+      }));
+
+
+      it('should copy error reference', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_4'),
+            error = getReferencedRootElement(interruptingBoundaryEvent, 'errorRef');
+
+        // assume
+        expect(is(error, 'bpmn:Error')).to.be.true;
+
+        // when
+        var nonInterruptingBoundaryEvent = bpmnReplace.replaceElement(interruptingBoundaryEvent, {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:ErrorEventDefinition',
+          cancelActivity: false
+        });
+
+        // then
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'errorRef')).to.equal(error);
+      }));
+
+
+      it('should copy signal reference', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_5'),
+            signal = getReferencedRootElement(interruptingBoundaryEvent, 'signalRef');
+
+        // assume
+        expect(is(signal, 'bpmn:Signal')).to.be.true;
+
+        // when
+        var nonInterruptingBoundaryEvent = bpmnReplace.replaceElement(interruptingBoundaryEvent, {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:SignalEventDefinition',
+          cancelActivity: false
+        });
+
+        // then
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'signalRef')).to.equal(signal);
+      }));
+
+    });
+
+
+    it('non-interrupting to interrupting', function() {
+
+      it('should copy message reference', inject(function(bpmnReplace, elementRegistry) {
+
+        // given
+        var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_6'),
+            message = getReferencedRootElement(interruptingBoundaryEvent, 'messageRef');
+
+        // assume
+        expect(is(message, 'bpmn:Message')).to.be.true;
+
+        // when
+        var nonInterruptingBoundaryEvent = bpmnReplace.replaceElement(interruptingBoundaryEvent, {
+          type: 'bpmn:BoundaryEvent',
+          eventDefinitionType: 'bpmn:MessageEventDefinition',
+          cancelActivity: true
+        });
+
+        // then
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
+      }));
+
+    });
+
+  });
+
 });
+
+// helpers //////////
+
+function getReferencedRootElement(element, propertyName) {
+  var businessObject = element.businessObject,
+      eventDefinition = businessObject.eventDefinitions[ 0 ];
+
+  return eventDefinition.get(propertyName);
+}


### PR DESCRIPTION
When replacing an element, references to root elements (e.g. Error, Escalation, Message, Signal) will be copied if possible.

Related to camunda/camunda-modeler#2185.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
