### PR TITLE
feat(message): show label on message flow

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -64,6 +64,7 @@ var INNER_OUTER_DIST = 3;
 var DEFAULT_FILL_OPACITY = .95,
     HIGH_FILL_OPACITY = .35;
 
+var ELEMENT_LABEL_DISTANCE = 10;
 
 export default function BpmnRenderer(
     config, eventBus, styles, pathMap,
@@ -1474,7 +1475,25 @@ export default function BpmnRenderer(
           messageAttrs.stroke = 'white';
         }
 
-        drawPath(parentGfx, markerPathData, messageAttrs);
+        var message = drawPath(parentGfx, markerPathData, messageAttrs);
+
+        var labelText = semantic.messageRef.name;
+        var label = renderLabel(parentGfx, labelText, {
+          align: 'center-top',
+          fitBox: true,
+          style: {
+            fill: getStrokeColor(element, defaultStrokeColor)
+          }
+        });
+
+        var messageBounds = message.getBBox(),
+            labelBounds = label.getBBox();
+
+        var translateX = midPoint.x - labelBounds.width / 2,
+            translateY = midPoint.y + messageBounds.height / 2 + ELEMENT_LABEL_DISTANCE;
+
+        transform(label, translateX, translateY, 0);
+
       }
 
       return path;

--- a/test/fixtures/bpmn/draw/message-label.bpmn
+++ b/test/fixtures/bpmn/draw/message-label.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_139dc1y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.7.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+  <bpmn:collaboration id="Collaboration_054yewv">
+    <bpmn:participant id="Participant_11t38ov" />
+    <bpmn:participant id="Participant_19laqtw" />
+    <bpmn:messageFlow id="dataFlow" sourceRef="Participant_11t38ov" targetRef="Participant_19laqtw" messageRef="Message_0itoen0" />
+  </bpmn:collaboration>
+      <bpmn:message id="Message_0itoen0" name="Invoice" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_054yewv">
+      <bpmndi:BPMNShape id="Participant_0hyr9jn_di" bpmnElement="Participant_11t38ov" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="300" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_19laqtw_di" bpmnElement="Participant_19laqtw" isHorizontal="true">
+        <dc:Bounds x="160" y="250" width="300" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="dataFlow_di" bpmnElement="dataFlow">
+        <di:waypoint x="310" y="140" />
+        <di:waypoint x="310" y="250" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -174,6 +174,20 @@ describe('draw - bpmn renderer', function() {
   });
 
 
+  it('should render message label', function() {
+    var xml = require('../../fixtures/bpmn/draw/message-label.bpmn');
+    return bootstrapViewer(xml).call(this).then(function(result) {
+      checkErrors(result.error, result.warnings);
+      inject(function(elementRegistry) {
+
+        var dataFlow = elementRegistry.getGraphics('dataFlow');
+
+        expect(domQuery('.djs-label', dataFlow)).to.exist;
+      })();
+    });
+  });
+
+
   it('should render pools', function() {
     var xml = require('../../fixtures/bpmn/draw/pools.bpmn');
     return bootstrapViewer(xml).call(this).then(function(result) {


### PR DESCRIPTION
Shows the label for referenced messages on message flows

![image](https://user-images.githubusercontent.com/21984219/116094970-465abb80-a6a8-11eb-847b-ffb278d859f8.png)

We decided to focus on rendering the label and not make the label movable/editable at this point. The Message ref can only be added with external tools, so displaying the name is enough for now.

closes #777

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
