### PR TITLE
test: support Promise as return value in `inject`

### DIFF
--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -226,7 +226,7 @@ export function inject(fn) {
       );
     }
 
-    BPMN_JS.invoke(fn);
+    return BPMN_JS.invoke(fn);
   };
 }
 

--- a/test/spec/helper/InjectSpec.js
+++ b/test/spec/helper/InjectSpec.js
@@ -1,0 +1,66 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import { expect } from 'chai';
+
+
+describe('helper - inject', function() {
+
+  var diagramXML = require('../../fixtures/bpmn/simple.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule
+    ]
+  }));
+
+
+  it('should work with Promise as return value', function() {
+
+    // given
+    var expected = 'resolved';
+
+    // when
+    var test = inject(function(eventBus) {
+
+      expect(eventBus).to.exist;
+
+      return Promise.resolve(expected);
+    });
+
+    // then
+    return test().then(function(result) {
+
+      expect(result).to.eql(expected);
+    });
+  });
+
+
+  it('should handle Promise rejection', function() {
+
+    // given
+    var expected = new Error('rejected');
+
+    function onResolved() {
+      throw new Error('should not resolve');
+    }
+
+    function onRejected(error) {
+      expect(error).to.eql(expected);
+    }
+
+    // when
+    var test = inject(function(eventBus) {
+      expect(eventBus).to.exist;
+
+      return Promise.reject(expected);
+    });
+
+    // then
+    return test().then(onResolved, onRejected);
+  });
+
+});


### PR DESCRIPTION
This makes sure we can create async tests. Without the `return`, a test failure would end up as an unhandled Promise rejection.

So this should work in the new setup and doesn't work currently:

```js
it('should fail', inject(async function(elementRegistry) {

  expect(elementRegistry).to.exist;

  return Promise.reject(new Error('should fail'));
}));
```
