### PR TITLE
Use bpmn in color

### DIFF
--- a/lib/draw/BpmnRenderUtil.js
+++ b/lib/draw/BpmnRenderUtil.js
@@ -54,13 +54,24 @@ export function getSemantic(element) {
 // color access //////////////////////
 
 export function getFillColor(element, defaultColor) {
-  return getDi(element).get('bioc:fill') || defaultColor || 'white';
+  var di = getDi(element);
+
+  return di.get('color:background-color') || di.get('bioc:fill') || defaultColor || 'white';
 }
 
 export function getStrokeColor(element, defaultColor) {
-  return getDi(element).get('bioc:stroke') || defaultColor || 'black';
+  var di = getDi(element);
+
+  return di.get('color:border-color') || di.get('bioc:stroke') || defaultColor || 'black';
 }
 
+export function getLabelColor(element, defaultColor, defaultStrokeColor) {
+  var di = getDi(element),
+      label = di.get('label');
+
+  return label && label.get('color:color') || defaultColor ||
+    getStrokeColor(element, defaultStrokeColor);
+}
 
 // cropping path customizations //////////////////////
 

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -34,7 +34,8 @@ import {
   getDiamondPath,
   getRectPath,
   getFillColor,
-  getStrokeColor
+  getStrokeColor,
+  getLabelColor
 } from './BpmnRenderUtil';
 
 import {
@@ -73,7 +74,8 @@ export default function BpmnRenderer(
   BaseRenderer.call(this, eventBus, priority);
 
   var defaultFillColor = config && config.defaultFillColor,
-      defaultStrokeColor = config && config.defaultStrokeColor;
+      defaultStrokeColor = config && config.defaultStrokeColor,
+      defaultLabelColor = config && config.defaultLabelColor;
 
   var rendererId = RENDERER_IDS.next();
 
@@ -472,7 +474,7 @@ export default function BpmnRenderer(
       align: align,
       padding: 5,
       style: {
-        fill: getStrokeColor(element, defaultStrokeColor)
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
       }
     });
   }
@@ -493,7 +495,7 @@ export default function BpmnRenderer(
         {},
         textRenderer.getExternalStyle(),
         {
-          fill: getStrokeColor(element, defaultStrokeColor)
+          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
         }
       )
     });
@@ -507,7 +509,7 @@ export default function BpmnRenderer(
       },
       align: 'center-middle',
       style: {
-        fill: getStrokeColor(element, defaultStrokeColor)
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
       }
     });
 
@@ -1163,7 +1165,7 @@ export default function BpmnRenderer(
         renderLabel(parentGfx, text2, {
           box: element, align: 'center-middle',
           style: {
-            fill: getStrokeColor(element, defaultStrokeColor)
+            fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
           }
         });
       }
@@ -1482,7 +1484,7 @@ export default function BpmnRenderer(
           align: 'center-top',
           fitBox: true,
           style: {
-            fill: getStrokeColor(element, defaultStrokeColor)
+            fill: getStrokeColor(element, defaultLabelColor, defaultStrokeColor)
           }
         });
 
@@ -1648,7 +1650,7 @@ export default function BpmnRenderer(
         align: 'left-top',
         padding: 5,
         style: {
-          fill: getStrokeColor(element, defaultStrokeColor)
+          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
         }
       });
 

--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -52,10 +52,13 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
 
     descriptor.di = {};
 
-    // fill and stroke will be set to DI
+    // colors will be set to DI
     copyProperties(businessObject.di, descriptor.di, [
       'fill',
-      'stroke'
+      'stroke',
+      'background-color',
+      'border-color',
+      'color'
     ]);
 
     copyProperties(businessObject.di, descriptor, 'isExpanded');

--- a/lib/features/modeling/cmd/SetColorHandler.js
+++ b/lib/features/modeling/cmd/SetColorHandler.js
@@ -1,6 +1,8 @@
 import {
   assign,
-  forEach
+  forEach,
+  isString,
+  pick
 } from 'min-dash';
 
 
@@ -12,6 +14,24 @@ var DEFAULT_COLORS = {
 
 export default function SetColorHandler(commandStack) {
   this._commandStack = commandStack;
+
+  this._normalizeColor = function(color) {
+
+    // Remove color for falsy values.
+    if (!color) {
+      return undefined;
+    }
+
+    if (isString(color)) {
+      var hexColor = colorToHex(color);
+
+      if (hexColor) {
+        return hexColor;
+      }
+    }
+
+    throw new Error('invalid color value: ' + color);
+  };
 }
 
 SetColorHandler.$inject = [
@@ -28,21 +48,76 @@ SetColorHandler.prototype.postExecute = function(context) {
   var di = {};
 
   if ('fill' in colors) {
-    assign(di, { fill: colors.fill });
+    assign(di, {
+      'background-color': this._normalizeColor(colors.fill) });
   }
 
   if ('stroke' in colors) {
-    assign(di, { stroke: colors.stroke });
+    assign(di, {
+      'border-color': this._normalizeColor(colors.stroke) });
   }
 
   forEach(elements, function(element) {
+    var assignedDi = isConnection(element) ? pick(di, [ 'border-color' ]) : di;
+
+    // TODO @barmac: remove once we drop bpmn.io properties
+    ensureLegacySupport(assignedDi);
 
     self._commandStack.execute('element.updateProperties', {
       element: element,
       properties: {
-        di: di
+        di: assignedDi
       }
     });
   });
 
 };
+
+/**
+ * Convert color from rgb(a)/hsl to hex. Returns `null` for unknown color names and for colors
+ * with alpha less than 1.0. This depends on `<canvas>` serialization of the `context.fillStyle`.
+ * Cf. https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-fillstyle
+ *
+ * @example
+ * ```js
+ * var color = 'fuchsia';
+ * console.log(colorToHex(color));
+ * // "#ff00ff"
+ * color = 'rgba(1,2,3,0.4)';
+ * console.log(colorToHex(color));
+ * // null
+ * ```
+ *
+ * @param {string} color
+ * @returns {string|null}
+ */
+function colorToHex(color) {
+  var context = document.createElement('canvas').getContext('2d');
+
+  // (0) Start with transparent to account for browser default values.
+  context.fillStyle = 'transparent';
+
+  // (1) Assign color so that it's serialized.
+  context.fillStyle = color;
+
+  // (2) Return null for non-hex serialization result.
+  return /^#[0-9a-fA-F]{6}$/.test(context.fillStyle) ? context.fillStyle : null;
+}
+
+function isConnection(element) {
+  return !!element.waypoints;
+}
+
+/**
+ * Add legacy properties if required.
+ * @param {{ 'border-color': string?, 'background-color': string? }} di
+ */
+function ensureLegacySupport(di) {
+  if ('border-color' in di) {
+    di.stroke = di['border-color'];
+  }
+
+  if ('background-color' in di) {
+    di.fill = di['background-color'];
+  }
+}

--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -264,10 +264,13 @@ export default function BpmnReplace(
 
     newElement.di = {};
 
-    // fill and stroke will be set to DI
+    // colors will be set to DI
     copyProperties(oldBusinessObject.di, newElement.di, [
       'fill',
-      'stroke'
+      'stroke',
+      'background-color',
+      'border-color',
+      'color'
     ]);
 
     newElement = replace.replaceElement(element, newElement, hints);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,9 +2242,9 @@
       "dev": true
     },
     "bpmn-moddle": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.0.5.tgz",
-      "integrity": "sha512-3OaoEJCHQdZeRBTmBtDJebXamweW03cgA5ymOZitddMY28Vo1dOwAX/Yg2X375d2QCeC5w/j5gI8V8iVRn12fg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.1.tgz",
+      "integrity": "sha512-R3xDuTklpK2NtxVDHJiecEVJvY2hKZikXdyl7oaULHMCQPfTBdid7TU/LGUgrLjA3L3ihBN9AKPgcAQ6HoPjpA==",
       "requires": {
         "min-dash": "^3.5.2",
         "moddle": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "webpack": "^4.44.2"
   },
   "dependencies": {
-    "bpmn-moddle": "^7.0.5",
+    "bpmn-moddle": "^7.1.1",
     "css.escape": "^1.5.1",
     "diagram-js": "^7.3.0",
     "diagram-js-direct-editing": "^1.6.2",

--- a/test/spec/draw/BpmnRenderUtilSpec.js
+++ b/test/spec/draw/BpmnRenderUtilSpec.js
@@ -9,7 +9,8 @@ import {
   getDiamondPath,
   getRectPath,
   getFillColor,
-  getStrokeColor
+  getStrokeColor,
+  getLabelColor
 } from 'lib/draw/BpmnRenderUtil';
 
 
@@ -83,4 +84,10 @@ describe('BpmnRenderUtil', function() {
 
   });
 
+
+  it('should expose getLabelColor', function() {
+
+    expect(getLabelColor).to.be.a('function');
+
+  });
 });

--- a/test/spec/draw/BpmnRenderer.colors.bpmn
+++ b/test/spec/draw/BpmnRenderer.colors.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
   <bpmn:collaboration id="Collaboration_12gf8gk">
     <bpmn:participant id="Participant_11xqomt" name="Regressnahme &#10;Sachbearbeiter" processRef="Process_1" />
     <bpmn:participant id="Participant_0igvg0r" />
@@ -84,14 +84,14 @@
       <bpmndi:BPMNShape id="Task_02fdytg_di" bpmnElement="Task_02fdytg">
         <dc:Bounds x="430" y="189" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0pqo7zt_di" bpmnElement="SequenceFlow_0pqo7zt" bioc:stroke="#3399aa">
+      <bpmndi:BPMNEdge id="SequenceFlow_0pqo7zt_di" bpmnElement="SequenceFlow_0pqo7zt" color:border-color="#FB8C00" bioc:stroke="#3399aa">
         <di:waypoint x="368" y="229" />
         <di:waypoint x="430" y="229" />
-        <bpmndi:BPMNLabel>
+        <bpmndi:BPMNLabel color:color="#FB8C00">
           <dc:Bounds x="392" y="210" width="13" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Task_04aofbe_di" bpmnElement="Task_04aofbe">
+      <bpmndi:BPMNShape id="Task_04aofbe_di" bpmnElement="Task_04aofbe" color:border-color="#FB8C00">
         <dc:Bounds x="430" y="311" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1qt82pt_di" bpmnElement="SequenceFlow_1qt82pt" bioc:stroke="blue" bioc:fill="yellow">
@@ -132,7 +132,7 @@
           <dc:Bounds x="471" y="470" width="90" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="DataStoreReference_1clvrcw_di" bpmnElement="DataStoreReference_1clvrcw">
+      <bpmndi:BPMNShape id="DataStoreReference_1clvrcw_di" bpmnElement="DataStoreReference_1clvrcw" color:background-color="#FFE0B2">
         <dc:Bounds x="143" y="364" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="154" y="414" width="29" height="12" />

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -355,7 +355,7 @@ describe('draw - bpmn renderer', function() {
         expect(markers).to.have.length(7);
         expect(markers[0].id).to.match(/^sequenceflow-end-rgb_255_224_178_-rgb_251_140_0_-[A-Za-z0-9]{25}$/);
         expect(markers[1].id).to.match(/^sequenceflow-end-yellow-blue-[A-Za-z0-9]{25}$/);
-        expect(markers[2].id).to.match(/^sequenceflow-end-white-_3399aa-[A-Za-z0-9]{25}$/);
+        expect(markers[2].id).to.match(/^sequenceflow-end-white-_FB8C00-[A-Za-z0-9]{25}$/);
         expect(markers[3].id).to.match(/^sequenceflow-end-white-rgba_255_0_0_0_9_-[A-Za-z0-9]{25}$/);
         expect(markers[4].id).to.match(/^association-end-_FFE0B2-_FB8C00-[A-Za-z0-9]{25}$/);
         expect(markers[5].id).to.match(/^messageflow-end-_FFE0B2-_FB8C00-[A-Za-z0-9]{25}$/);
@@ -450,7 +450,8 @@ describe('draw - bpmn renderer', function() {
     describe('default colors', function() {
 
       var defaultFillColor = 'red',
-          defaultStrokeColor = 'lime';
+          defaultStrokeColor = 'lime',
+          defaultLabelColor = 'blue';
 
       // TODO(philippfromme): remove once we drop PhantomJS
       function expectedColors(color) {
@@ -478,7 +479,8 @@ describe('draw - bpmn renderer', function() {
       beforeEach(bootstrapViewer(xml,{
         bpmnRenderer: {
           defaultFillColor: defaultFillColor,
-          defaultStrokeColor: defaultStrokeColor
+          defaultStrokeColor: defaultStrokeColor,
+          defaultLabelColor: defaultLabelColor
         }
       }));
 
@@ -528,7 +530,7 @@ describe('draw - bpmn renderer', function() {
        * @param {string} fillColor - Fill color to expect.
        * @param {string} strokeColor - Stroke color to expect.
        */
-      function expectColors(element, gfx, fillColor, strokeColor) {
+      function expectColors(element, gfx, fillColor, strokeColor, labelColor) {
         var djsVisual = domQuery('.djs-visual', gfx);
 
         var circle, path, polygon, polyline, rect, text;
@@ -536,7 +538,7 @@ describe('draw - bpmn renderer', function() {
         if (element.labelTarget) {
           text = domQuery('text', djsVisual);
 
-          expectFillColor(text, strokeColor);
+          expectFillColor(text, labelColor);
         } else if (element.waypoints) {
           path = domQuery('path', djsVisual);
           polyline = domQuery('polyline', djsVisual);
@@ -547,13 +549,13 @@ describe('draw - bpmn renderer', function() {
 
           expectFillColor(circle, fillColor);
           expectStrokeColor(circle, strokeColor);
-        } else if (isAny(element, [ 'bpmn:Task', 'bpmn:SubProcess', 'bpmn:Particpant' ])) {
+        } else if (isAny(element, [ 'bpmn:Task', 'bpmn:SubProcess', 'bpmn:Participant' ])) {
           rect = domQuery('rect', djsVisual);
           text = domQuery('text', djsVisual);
 
           expectFillColor(rect, fillColor);
           expectStrokeColor(rect, strokeColor);
-          expectFillColor(text, strokeColor);
+          expectFillColor(text, labelColor);
         } else if (isAny(element, [ 'bpmn:Gateway' ])) {
           polygon = domQuery('polygon', djsVisual);
 
@@ -573,14 +575,12 @@ describe('draw - bpmn renderer', function() {
 
           var gfx = elementRegistry.getGraphics(element),
               di = getDi(element),
-              fillColor = di.get('bioc:fill'),
-              strokeColor = di.get('bioc:stroke');
+              fillColor = di.get('color:background-color') || di.get('bioc:fill') || defaultFillColor,
+              strokeColor = di.get('color:border-color') || di.get('bioc:stroke') || defaultStrokeColor,
+              labelDi = di.get('label'),
+              labelColor = labelDi && labelDi.get('color:color') || defaultLabelColor;
 
-          if (fillColor || strokeColor) {
-            expectColors(element, gfx, fillColor, strokeColor);
-          } else {
-            expectColors(element, gfx, defaultFillColor, defaultStrokeColor);
-          }
+          expectColors(element, gfx, fillColor, strokeColor, labelColor);
         });
       }));
 

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -354,8 +354,8 @@ describe('features/copy-paste', function() {
           // given
           var task = elementRegistry.get('Task_1'),
               rootElement = canvas.getRootElement(),
-              fill = 'red',
-              stroke = 'green';
+              fill = '#ff0000',
+              stroke = '#00ff00';
 
 
           // when
@@ -378,6 +378,10 @@ describe('features/copy-paste', function() {
 
           var taskBo = getBusinessObject(task);
 
+          expect(taskBo.di.get('background-color')).to.equal(fill);
+          expect(taskBo.di.get('border-color')).to.equal(stroke);
+
+          // TODO @barmac: remove when we drop bpmn.io properties
           expect(taskBo.di.fill).to.equal(fill);
           expect(taskBo.di.stroke).to.equal(stroke);
         })

--- a/test/spec/features/modeling/SetColorSpec.js
+++ b/test/spec/features/modeling/SetColorSpec.js
@@ -6,6 +6,8 @@ import {
 import modelingModule from 'lib/features/modeling';
 import coreModule from 'lib/core';
 
+var FUCHSIA_HEX = '#ff00ff',
+    YELLOW_HEX = '#ffff00';
 
 describe('features/modeling - set color', function() {
 
@@ -30,7 +32,7 @@ describe('features/modeling - set color', function() {
       modeling.setColor(taskShape, { fill: 'FUCHSIA' });
 
       // then
-      expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
+      expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
     }));
 
 
@@ -44,7 +46,7 @@ describe('features/modeling - set color', function() {
       modeling.setColor(taskShape);
 
       // then
-      expect(taskShape.businessObject.di.fill).not.to.exist;
+      expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
     }));
 
 
@@ -59,8 +61,8 @@ describe('features/modeling - set color', function() {
         modeling.setColor(taskShape, { fill: 'YELLOW' });
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('YELLOW');
-        expect(taskShape.businessObject.di.stroke).to.equal('YELLOW');
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(YELLOW_HEX);
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(YELLOW_HEX);
       }
     ));
 
@@ -76,8 +78,8 @@ describe('features/modeling - set color', function() {
         modeling.setColor(taskShape, { fill: undefined });
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(taskShape.businessObject.di.stroke).to.equal('YELLOW');
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(YELLOW_HEX);
       }
     ));
 
@@ -93,8 +95,8 @@ describe('features/modeling - set color', function() {
         modeling.setColor(taskShape);
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
@@ -108,8 +110,8 @@ describe('features/modeling - set color', function() {
       modeling.setColor(taskShape, { stroke: 'FUCHSIA' });
 
       // then
-      expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
-      expect(taskShape.businessObject.di.fill).not.to.exist;
+      expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
+      expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
     }));
 
 
@@ -123,8 +125,8 @@ describe('features/modeling - set color', function() {
       modeling.setColor(taskShape);
 
       // then
-      expect(taskShape.businessObject.di.stroke).not.to.exist;
-      expect(taskShape.businessObject.di.fill).not.to.exist;
+      expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
+      expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
     }));
 
 
@@ -139,10 +141,10 @@ describe('features/modeling - set color', function() {
         modeling.setColor([ taskShape, startEventShape ], { fill: 'FUCHSIA' });
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.fill).to.equal('FUCHSIA');
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
-        expect(startEventShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
@@ -159,8 +161,8 @@ describe('features/modeling - set color', function() {
         modeling.setColor([ taskShape, startEventShape ]);
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(startEventShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -179,10 +181,10 @@ describe('features/modeling - set color', function() {
         ], { stroke: 'FUCHSIA' });
 
         // then
-        expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.stroke).to.equal('FUCHSIA');
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(startEventShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -202,11 +204,53 @@ describe('features/modeling - set color', function() {
         modeling.setColor([ taskShape, startEventShape ]);
 
         // then
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
-        expect(startEventShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
+
+    it('should not set background-color on BPMNEdge', inject(function(elementRegistry, modeling) {
+
+      // given
+      var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+      // when
+      modeling.setColor(sequenceFlow, { fill: 'FUCHSIA' });
+
+      // then
+      expect(sequenceFlow.businessObject.di.get('background-color')).not.to.exist;
+    }));
+
+
+    it('should throw for an invalid color', inject(function(elementRegistry, modeling) {
+
+      // given
+      var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+      // when
+      function setColor() {
+        modeling.setColor(sequenceFlow, { fill: 'INVALID_COLOR' });
+      }
+
+      // then
+      expect(setColor).to.throw(/^invalid color value/);
+    }));
+
+
+    it('should throw for a color with alpha', inject(function(elementRegistry, modeling) {
+
+      // given
+      var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+      // when
+      function setColor() {
+        modeling.setColor(sequenceFlow, { fill: 'rgba(0, 255, 0, 0.5)' });
+      }
+
+      // then
+      expect(setColor).to.throw(/^invalid color value/);
+    }));
   });
 
 
@@ -223,7 +267,7 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -240,7 +284,7 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -256,7 +300,7 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
@@ -273,7 +317,7 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -290,8 +334,8 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(startEventShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -309,8 +353,8 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.fill).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -330,8 +374,8 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
-        expect(startEventShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
@@ -349,8 +393,8 @@ describe('features/modeling - set color', function() {
         commandStack.undo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.stroke).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -371,7 +415,7 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -389,7 +433,7 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -406,7 +450,7 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -424,7 +468,7 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
@@ -442,8 +486,8 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.fill).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.fill).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('background-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -462,8 +506,8 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.fill).not.to.exist;
-        expect(startEventShape.businessObject.di.fill).not.to.exist;
+        expect(taskShape.businessObject.di.get('background-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('background-color')).not.to.exist;
       }
     ));
 
@@ -481,8 +525,8 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).to.equal('FUCHSIA');
-        expect(startEventShape.businessObject.di.stroke).to.equal('FUCHSIA');
+        expect(taskShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
+        expect(startEventShape.businessObject.di.get('border-color')).to.equal(FUCHSIA_HEX);
       }
     ));
 
@@ -504,11 +548,48 @@ describe('features/modeling - set color', function() {
         commandStack.redo();
 
         // then
-        expect(taskShape.businessObject.di.stroke).not.to.exist;
-        expect(startEventShape.businessObject.di.stroke).not.to.exist;
+        expect(taskShape.businessObject.di.get('border-color')).not.to.exist;
+        expect(startEventShape.businessObject.di.get('border-color')).not.to.exist;
       }
     ));
 
   });
 
+
+  // TODO @barmac: remove once we drop bpmn.io properties
+  describe('legacy', function() {
+
+    it('should set both BPMN in Color and bpmn.io properties on BPMNShape', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var taskShape = elementRegistry.get('Task_1');
+
+        // when
+        modeling.setColor(taskShape, { stroke: '#abcdef', fill: '#fedcba' });
+
+        // then
+        expect(taskShape.businessObject.di.get('border-color')).to.eql('#abcdef');
+        expect(taskShape.businessObject.di.get('stroke')).to.eql('#abcdef');
+        expect(taskShape.businessObject.di.get('background-color')).to.eql('#fedcba');
+        expect(taskShape.businessObject.di.get('fill')).to.eql('#fedcba');
+      }
+    ));
+
+
+    it('should set both BPMN in Color and bpmn.io properties on BPMNEdge', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_1');
+
+        // when
+        modeling.setColor(sequenceFlow, { stroke: '#abcdef' });
+
+        // then
+        expect(sequenceFlow.businessObject.di.get('border-color')).to.eql('#abcdef');
+        expect(sequenceFlow.businessObject.di.get('stroke')).to.eql('#abcdef');
+      }
+    ));
+  });
 });

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -1631,8 +1631,8 @@ describe('features/replace - bpmn replace', function() {
       var newElementData = {
             type: 'bpmn:UserTask'
           },
-          fill = 'red',
-          stroke = 'green';
+          fill = '#ff0000',
+          stroke = '#00ff00';
 
       modeling.setColor(task, { fill: fill, stroke: stroke });
 
@@ -1642,6 +1642,10 @@ describe('features/replace - bpmn replace', function() {
       // then
       var businessObject = newElement.businessObject;
 
+      expect(businessObject.di.get('background-color')).to.equal(fill);
+      expect(businessObject.di.get('border-color')).to.equal(stroke);
+
+      // TODO @barmac: remove when we drop bpmn.io properties
       expect(businessObject.di.fill).to.equal(fill);
       expect(businessObject.di.stroke).to.equal(stroke);
     }));


### PR DESCRIPTION
Along with custom bpmn.io extension properties, `modeling#setColor` will use [BPMN in Color properties](https://github.com/bpmn-miwg/bpmn-in-color) to serialize element colors.