### PR TITLE
Attempt to fix issue #1462 - StartEvent (non interrupting) is replaced with the plain StartEvent when element is placed on the diagram

### DIFF
--- a/lib/features/modeling/behavior/ReplaceElementBehaviour.js
+++ b/lib/features/modeling/behavior/ReplaceElementBehaviour.js
@@ -4,8 +4,7 @@ import { forEach } from 'min-dash';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { isEventSubProcess } from '../../../util/DiUtil';
-
+import { is, isEventSubProcess } from '../../../util/DiUtil';
 
 /**
  * BPMN-specific replace behavior.
@@ -30,7 +29,7 @@ export default function ReplaceElementBehaviour(
         target = context.parent,
         elements = context.elements;
 
-    var canReplace = bpmnRules.canReplace(elements, target);
+    var canReplace = is(target, 'bpmn:SubProcess') && bpmnRules.canReplace(elements, target);
 
     if (canReplace) {
       this.replaceElements(elements, canReplace.replacements);

--- a/lib/features/modeling/behavior/ReplaceElementBehaviour.js
+++ b/lib/features/modeling/behavior/ReplaceElementBehaviour.js
@@ -4,7 +4,9 @@ import { forEach } from 'min-dash';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import { is, isEventSubProcess } from '../../../util/DiUtil';
+import { isEventSubProcess } from '../../../util/DiUtil';
+import { is } from '../../../util/ModelUtil';
+
 
 /**
  * BPMN-specific replace behavior.

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -665,11 +665,13 @@ function canReplace(elements, target, position) {
 
   forEach(elements, function(element) {
 
-    if (!isEventSubProcess(target)) {
+    var elementParent = element.parent || target;
+
+    if (!isEventSubProcess(elementParent)) {
 
       if (is(element, 'bpmn:StartEvent') &&
           element.type !== 'label' &&
-          canDrop(element, target)) {
+          canDrop(element, elementParent)) {
 
         // replace a non-interrupting start event by a blank interrupting start event
         // when the target is not an event sub process
@@ -700,7 +702,7 @@ function canReplace(elements, target, position) {
             'bpmn:SignalEventDefinition',
             'bpmn:ConditionalEventDefinition'
           ]) &&
-            is(target, 'bpmn:SubProcess')) {
+            is(elementParent, 'bpmn:SubProcess')) {
           canExecute.replacements.push({
             oldElementId: element.id,
             newElementType: 'bpmn:StartEvent'

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -665,13 +665,11 @@ function canReplace(elements, target, position) {
 
   forEach(elements, function(element) {
 
-    var elementParent = element.parent || target;
-
-    if (!isEventSubProcess(elementParent)) {
+    if (!isEventSubProcess(target)) {
 
       if (is(element, 'bpmn:StartEvent') &&
           element.type !== 'label' &&
-          canDrop(element, elementParent)) {
+          canDrop(element, target)) {
 
         // replace a non-interrupting start event by a blank interrupting start event
         // when the target is not an event sub process
@@ -702,7 +700,7 @@ function canReplace(elements, target, position) {
             'bpmn:SignalEventDefinition',
             'bpmn:ConditionalEventDefinition'
           ]) &&
-            is(elementParent, 'bpmn:SubProcess')) {
+            is(target, 'bpmn:SubProcess')) {
           canExecute.replacements.push({
             oldElementId: element.id,
             newElementType: 'bpmn:StartEvent'


### PR DESCRIPTION
Attempt to fix issue #1462 - StartEvent (non interrupting) is replaced with the plain StartEvent when element is placed on the diagram.

Tests (BpmnReplacePreviewSpec) are need to be fixed and/or new tests should be added.
@barmac I'll glad if you can help with test cases.