### PR TITLE
Update imports and export

### DIFF
--- a/lib/features/modeling/cmd/UpdateModdlePropertiesHandler.js
+++ b/lib/features/modeling/cmd/UpdateModdlePropertiesHandler.js
@@ -1,20 +1,21 @@
 'use strict';
 
-var reduce = require('min-dash').reduce,
-    keys = require('min-dash').keys,
-    forEach = require('min-dash').forEach,
-    is = require('../../../util/ModelUtil').is,
-    getBusinessObject = require('../../../util/ModelUtil').getBusinessObject;
+import { 
+  reduce, 
+  keys, 
+  forEach 
+} from 'min-dash';
 
+import { 
+  is, 
+  getBusinessObject 
+} from '../../../util/ModelUtil';
 
-function UpdateModdlePropertiesHandler(elementRegistry) {
+export default function UpdateModdlePropertiesHandler(elementRegistry) {
   this._elementRegistry = elementRegistry;
 }
 
 UpdateModdlePropertiesHandler.$inject = ['elementRegistry'];
-
-module.exports = UpdateModdlePropertiesHandler;
-
 
 UpdateModdlePropertiesHandler.prototype.execute = function(context) {
 


### PR DESCRIPTION
Modified to use 'export default' instead of 'module.exports' so that I don't get errors stating that there is no default export.

I was receiving an error that there was no default export. It looks like most of the other handlers use 'export default' instead of 'module.exports'
