### PR TITLE
Port `POST_RELEASE` improvements over from `form-js` 

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -42,14 +42,14 @@ jobs:
         fi
     - name: Update integration test
       env:
-        GH_AUTH: ${{ secrets.GH_AUTH }}
+        BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: bash tasks/stages/update-integration-test
     - name: Update demo
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
-        GH_AUTH: ${{ secrets.GH_AUTH }}
+        BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
         BPMN_IO_DEMO_ENDPOINT: ${{ secrets.BPMN_IO_DEMO_ENDPOINT }}
@@ -57,14 +57,14 @@ jobs:
     - name: Update examples
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
-        GH_AUTH: ${{ secrets.GH_AUTH }}
+        BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: bash tasks/stages/update-examples
     - name: Update website
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
-        GH_AUTH: ${{ secrets.GH_AUTH }}
+        BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: bash tasks/stages/update-website

--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -19,23 +19,9 @@ jobs:
     - name: Set TAG
       run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
     - name: Wait for published
-      run: |
-        i=0
-        pkg="bpmn-js@${{ env.TAG }}"
-
-        until [ $i -gt 10 ]
-        do
-          echo "Checking for $pkg in npm registry..."
-
-          info=$(npm info $pkg)
-          if [[ "$info" != "" ]]; then
-            echo "Found."
-            break
-          fi
-
-          ((i++))
-          sleep 15s
-        done
+      env:
+        PKG: 'bpmn-js@${{ env.TAG }}'
+      run: tasks/stages/await-published
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -45,7 +45,7 @@ jobs:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-      run: bash tasks/stages/update-integration-test
+      run: tasks/stages/update-integration-test
     - name: Update demo
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
@@ -53,18 +53,18 @@ jobs:
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
         BPMN_IO_DEMO_ENDPOINT: ${{ secrets.BPMN_IO_DEMO_ENDPOINT }}
-      run: bash tasks/stages/update-demo
+      run: tasks/stages/update-demo
     - name: Update examples
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-      run: bash tasks/stages/update-examples
+      run: tasks/stages/update-examples
     - name: Update website
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-      run: bash tasks/stages/update-website
+      run: tasks/stages/update-website

--- a/tasks/stages/await-published
+++ b/tasks/stages/await-published
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s inherit_errexit nullglob
+
+i=0
+pkg="$PKG"
+until [ $i -gt 10 ]
+do
+  echo "Checking for $pkg in npm registry ($((i+1))/10)"
+  info=$(npm info $pkg)
+  if [[ "$info" != "" ]]; then
+    echo "Found."
+    break
+  fi
+
+  i=$((var+1))
+  sleep 15s
+done

--- a/tasks/stages/update-demo
+++ b/tasks/stages/update-demo
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/bin/bash
+
 
 # bumps bpmn-js and diagram-js dependencies in bpmn-io-demo
 
@@ -15,14 +16,19 @@ cd "$CLONE_DIR"
 
 npm install --save bpmn-js@latest diagram-js@latest
 
-git config user.email "$BPMN_IO_EMAIL"
-git config user.name "$BPMN_IO_USERNAME"
-git config push.default simple
+if [[ "x$SKIP_COMMIT" = "x" ]]; then
 
-git add -A
-git commit -m "deps: bump bpmn-js to $TAG"
-git tag "bpmn-js-$TAG"
-git push -q &2>/dev/null
-git push --tags -q &2>/dev/null
+  git config user.email "$BPMN_IO_EMAIL"
+  git config user.name "$BPMN_IO_USERNAME"
+  git config push.default simple
+
+  git add -A
+  git commit -m "deps: bump to bpmn-js@$TAG"
+  git tag "bpmn-js-$TAG"
+  git push -q &2>/dev/null
+  git push --tags -q &2>/dev/null
+else
+  echo "Skipping commit (SKIP_COMMIT=$SKIP_COMMIT)"
+fi
 
 cd "$PWD"

--- a/tasks/stages/update-demo
+++ b/tasks/stages/update-demo
@@ -9,7 +9,7 @@ CLONE_DIR="$WORKDIR/bpmn-io-demo"
 # create work dir
 mkdir -p "$WORKDIR"
 
-git clone --depth=1 "https://$GH_AUTH@github.com/$BPMN_IO_DEMO_ENDPOINT.git" "$CLONE_DIR"
+git clone --depth=1 "https://$BPMN_IO_TOKEN@github.com/$BPMN_IO_DEMO_ENDPOINT.git" "$CLONE_DIR"
 
 cd "$CLONE_DIR"
 

--- a/tasks/stages/update-demo
+++ b/tasks/stages/update-demo
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+shopt -s inherit_errexit nullglob
 
 # bumps bpmn-js and diagram-js dependencies in bpmn-io-demo
 

--- a/tasks/stages/update-examples
+++ b/tasks/stages/update-examples
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -eo pipefail
+shopt -s inherit_errexit nullglob
+
 # update bpmn-js version in the <bpmn-js-examples> project
 
 PWD="$(pwd)"

--- a/tasks/stages/update-examples
+++ b/tasks/stages/update-examples
@@ -9,7 +9,7 @@ EXAMPLES_DIR="$WORKDIR/bpmn-js-examples"
 # create work dir
 mkdir -p "$WORKDIR"
 
-git clone --depth=1 "https://$GH_AUTH@github.com/bpmn-io/bpmn-js-examples.git" "$EXAMPLES_DIR"
+git clone --depth=1 "https://$BPMN_IO_TOKEN@github.com/bpmn-io/bpmn-js-examples.git" "$EXAMPLES_DIR"
 
 cd "$EXAMPLES_DIR"
 

--- a/tasks/stages/update-integration-test
+++ b/tasks/stages/update-integration-test
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -eo pipefail
+shopt -s inherit_errexit nullglob
+
 # bumps bpmn-js and diagram-js dependencies in bpmn-js-integration
 
 PWD="$(pwd)"

--- a/tasks/stages/update-integration-test
+++ b/tasks/stages/update-integration-test
@@ -9,7 +9,7 @@ IT_DIR="$WORKDIR/bpmn-js-integration"
 # create work dir
 mkdir -p "$WORKDIR"
 
-git clone --depth=1 "https://$GH_AUTH@github.com/bpmn-io/bpmn-js-integration.git" "$IT_DIR"
+git clone --depth=1 "https://$BPMN_IO_TOKEN@github.com/bpmn-io/bpmn-js-integration.git" "$IT_DIR"
 
 cd "$IT_DIR"
 

--- a/tasks/stages/update-website
+++ b/tasks/stages/update-website
@@ -9,7 +9,7 @@ CLONE_DIR="$WORKDIR/bpmn.io"
 # create work dir
 mkdir -p "$WORKDIR"
 
-git clone --depth=1 "https://$GH_AUTH@github.com/bpmn-io/bpmn.io.git" "$CLONE_DIR"
+git clone --depth=1 "https://$BPMN_IO_TOKEN@github.com/bpmn-io/bpmn.io.git" "$CLONE_DIR"
 
 cd "$CLONE_DIR"
 

--- a/tasks/stages/update-website
+++ b/tasks/stages/update-website
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -eo pipefail
+shopt -s inherit_errexit nullglob
+
 # update bpmn-js version in the <bpmn.io> project
 
 PWD="$(pwd)"


### PR DESCRIPTION
We've recently added a couple of improvements to our form-js `POST_RELEASE` build (https://github.com/bpmn-io/form-js/pull/174).

This PR ports the changes over to bpmn-js:

* Error handling like GitHub actions do it
* Fixed shebang
* Fixed `await-released` stage
* Use organization managed rather than repository managed access token