### PR TITLE
fix(path-map): disallow nested tokens

### DIFF
--- a/lib/draw/PathMap.js
+++ b/lib/draw/PathMap.js
@@ -444,8 +444,8 @@ export default function PathMap() {
 
 // helpers //////////////////////
 
-// copied from https://github.com/adobe-webplatform/Snap.svg/blob/master/src/svg.js
-var tokenRegex = /\{([^}]+)\}/g,
+// copied and adjusted from https://github.com/adobe-webplatform/Snap.svg/blob/master/src/svg.js
+var tokenRegex = /\{([^{}]+)\}/g,
     objNotationRegex = /(?:(?:^|\.)(.+?)(?=\[|\.|$|\()|\[('|")(.+?)\2\])(\(\))?/g; // matches .xxxxx or ["xxxxx"] to run over object properties
 
 function replacer(all, key, obj) {


### PR DESCRIPTION
The previous regex is risky as it can have exponential execution time if we nest tokens, e.g. `{{{{{{{`.

Still, it's not a vulnerability as we use only hard-coded values for strings passed to `format`.