### PR TITLE
fix: regenerate package-lock.json entry for diagram-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,7 +3333,9 @@
       "dev": true
     },
     "diagram-js": {
-
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.5.0.tgz",
+      "integrity": "sha512-BAs3PJhTQYd+PjehBlf+ofGwEhSjsK1ku0B3MZKWQ4c2g1graa8CXHOdSHtxWY3KTcBVfARqx0DJdFga66Lfeg==",
       "requires": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",


### PR DESCRIPTION
Apparently, https://github.com/bpmn-io/bpmn-js/commit/1bbe6fbcdcbab60050f03537fbf5f650ca2ad986 broke the package-lock.json file as it removed the version and integrity information from diagram-js entry. Cf. https://github.com/bpmn-io/bpmn-js/commit/1bbe6fbcdcbab60050f03537fbf5f650ca2ad986#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L3336-L3338 This caused some builds to fail, e.g. https://github.com/bpmn-io/bpmn-js/pull/1500/checks?check_run_id=3899722138 Basically, without this fix it's impossible to run `npm ci` in bpmn-js repo.