### PR TITLE
fix(bpmnRender): remove dataAssociation fill

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1464,8 +1464,6 @@ export default function BpmnRenderer(
           stroke = attrs.stroke || getStrokeColor(element, defaultStrokeColor);
 
       attrs = assign({
-        fill: fill,
-        stroke: stroke,
         markerEnd: marker('association-end', fill, stroke)
       }, attrs);
 
@@ -1479,8 +1477,6 @@ export default function BpmnRenderer(
 
 
       attrs = assign({
-        fill: fill,
-        stroke: stroke,
         markerEnd: marker('association-end', fill, stroke)
       }, attrs);
 


### PR DESCRIPTION
This fixes a bug introduced with https://github.com/bpmn-io/bpmn-js/pull/1515. The `fill` attribute is wrongfully set to the whole connection instead of just the marker.

![image](https://user-images.githubusercontent.com/21984219/139020274-a7fcd3d3-0526-4839-8674-be9e4d93dbb2.png)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
