### PR TITLE
chore: prevent double bundling

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,7 +45,7 @@ const configs = distros.reduce(function(configs, distro) {
       },
       plugins: pgl([
         banner(output)
-      ])
+      ], 'development')
     },
     {
       input: `./lib/${input}.js`,
@@ -61,7 +61,7 @@ const configs = distros.reduce(function(configs, distro) {
             comments: /license|@preserve/
           }
         })
-      ])
+      ], 'production')
     }
   ];
 }, []);
@@ -92,10 +92,10 @@ function banner(bundleName, minified) {
   });
 }
 
-function pgl(plugins=[]) {
+function pgl(plugins=[], env='production') {
   return [
     replace({
-      'process.env.NODE_ENV': JSON.stringify('production')
+      'process.env.NODE_ENV': JSON.stringify(env)
     }),
     nodeResolve({
       mainFields: [

--- a/tasks/build-distro.js
+++ b/tasks/build-distro.js
@@ -33,23 +33,14 @@ cp('./assets/bpmn-js.css', dest + '/assets');
 
 console.log('building pre-packaged distributions');
 
-var NODE_ENV = process.env.NODE_ENV;
+try {
+  exec('rollup', [ '-c' ], {
+    stdio: 'inherit'
+  });
+} catch (e) {
+  console.error('failed to build pre-package distributions', e);
 
-[ 'production', 'development' ].forEach(function(env) {
-
-  try {
-    process.env.NODE_ENV = env;
-
-    exec('rollup', [ '-c' ], {
-      stdio: 'inherit'
-    });
-  } catch (e) {
-    console.error('failed to build pre-package distributions', e);
-
-    process.exit(1);
-  }
-
-  process.env.NODE_ENV = NODE_ENV;
-});
+  process.exit(1);
+}
 
 console.log('done.');


### PR DESCRIPTION
For a long time I was wondering why bundling got so slow, especially noticeable after `npm install`. 

With the introduction proper bundle logs (https://github.com/bpmn-io/bpmn-js/commit/3dfc1dd07e91de9575bdc6339ee76dbf614338ce) the issue got apparent: We do bundle _all_ distributions twice, in `NODE_ENV=(development,production)`.

This PR ensures we build the distribution only once:

* development is built with NODE_ENV=development
* production is built with NODE_ENV=production