### PR TITLE
style: update used colors

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -2,6 +2,13 @@
   --bjs-font-family: Arial, sans-serif;
 }
 
+.djs-container {
+  --breadcrumbs-item-color: var(--color-blue-205-100-50);
+  --breadcrumbs-arrow-color: var(--color-black);
+  --drilldown-fill-color: var(--color-white);
+  --drilldown-background-color: var(--color-blue-205-100-50);
+}
+
 .bjs-breadcrumbs {
   position: absolute;
   display: flex;
@@ -15,7 +22,7 @@
 
 .bjs-breadcrumbs li {
   display: inline-flex;
-  color: var(--blue-base-65);
+  color: var(--breadcrumbs-item-color);
   cursor: pointer;
   padding-bottom: 5px;
 }
@@ -28,7 +35,7 @@
 .bjs-breadcrumbs li:not(:first-child)::before {
   content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" /><path d="M0 0h24v24H0z" fill="none" /></svg>');
   padding: 0 8px;
-  color: black;
+  color: var(--breadcrumbs-arrow-color);
   height: 16px;
 }
 
@@ -52,6 +59,6 @@
   border-radius: 2px;
   outline: none;
 
-  fill: white;
-  background-color: var(--blue-base-65);
+  fill: var(--drilldown-fill-color);
+  background-color: var(--drilldown-background-color);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,9 +3333,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.6.3.tgz",
-      "integrity": "sha512-UJFUKOzsu8g6pKiWpZYTUstnzZxGfCrbhtX1wlpqUhUilPVFNxutSfEAs3c+c0nGqTw3O4M9XViUFoc9hNaGvw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.7.0.tgz",
+      "integrity": "sha512-nTOUotijjOaZI3xmSu26BO8bKZt39PrMz35VyEumvG+AgdkxoaPKG7iF/nE4SWRke1X2aUoyGBp1y12r5JsdoQ==",
       "requires": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.2",
     "css.escape": "^1.5.1",
-    "diagram-js": "^7.6.3",
+    "diagram-js": "^7.7.0",
     "diagram-js-direct-editing": "^1.6.3",
     "ids": "^1.0.0",
     "inherits": "^2.0.4",


### PR DESCRIPTION
Related to https://github.com/bpmn-io/diagram-js/issues/581
Requires https://github.com/bpmn-io/diagram-js/pull/583 to be merged and integrated.

This only effects the subprocess navigation features, in a minimal fashion:

_Before_
![image](https://user-images.githubusercontent.com/9433996/140276434-2b94d9f9-386a-4b70-a966-c7489ca6a37b.png)

_After_
![image](https://user-images.githubusercontent.com/9433996/140276260-9e785b61-c7f2-4568-8542-7a585a1757a6.png)

