### PR TITLE
fix(drilldown): break long breadcrumbs

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -5,6 +5,7 @@
 .bjs-breadcrumbs {
   position: absolute;
   display: flex;
+  flex-wrap: wrap;
   top: 10px;
   left: 100px;
   font-family: var(--bjs-font-family);
@@ -16,6 +17,7 @@
   display: inline-flex;
   color: var(--blue-base-65);
   cursor: pointer;
+  padding-bottom: 5px;
 }
 
 .bjs-breadcrumbs li:last-of-type {


### PR DESCRIPTION
closes #1522

![recording (43)](https://user-images.githubusercontent.com/21984219/140481237-356dd583-e4e4-40a6-aa9e-651fb068597e.gif)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
