### PR TITLE
feat(drilldown): make breadcrumbs reactive

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -11,14 +11,25 @@
 
 .bjs-breadcrumbs {
   position: absolute;
-  display: flex;
+  display: none;
   flex-wrap: wrap;
   align-items: center;
   top: 10px;
-  left: 100px;
   font-family: var(--bjs-font-family);
   font-size: 16px;
   line-height: normal;
+}
+
+.bjs-breadcrumbs-shown .bjs-breadcrumbs {
+  display: flex;
+}
+
+.djs-palette-shown .bjs-breadcrumbs {
+  left: 50px;
+}
+
+.djs-palette-shown.djs-palette-two-column .bjs-breadcrumbs {
+  left: 100px;
 }
 
 .bjs-breadcrumbs li {

--- a/lib/features/drilldown/DrilldownOverlays.js
+++ b/lib/features/drilldown/DrilldownOverlays.js
@@ -1,9 +1,11 @@
-import { domify } from 'min-dom';
+import { domify, classes } from 'min-dom';
 
 import { escapeHTML } from 'diagram-js/lib/util/EscapeUtil';
 import { getBusinessObject, is } from '../../util/ModelUtil';
 
 var ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.81801948,3.50735931 L10.4996894,9.1896894 L10.5,4 L12,4 L12,12 L4,12 L4,10.5 L9.6896894,10.4996894 L3.75735931,4.56801948 C3.46446609,4.27512627 3.46446609,3.80025253 3.75735931,3.50735931 C4.05025253,3.21446609 4.52512627,3.21446609 4.81801948,3.50735931 Z"/></svg>';
+
+var OPEN_CLASS = 'bjs-breadcrumbs-shown';
 
 /**
  * Adds Overlays that allow switching planes on collapsed subprocesses.
@@ -14,8 +16,9 @@ var ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height=
  * @param {canvas} canvas
  */
 export default function DrilldownOverlays(eventBus, elementRegistry, overlays, canvas) {
-  var breadcrumbs = domify('<ul class="bjs-breadcrumbs djs-element-hidden"></ul>');
+  var breadcrumbs = domify('<ul class="bjs-breadcrumbs"></ul>');
   var container = canvas.getContainer();
+  var containerClasses = classes(container);
   container.appendChild(breadcrumbs);
 
   function updateBreadcrumbs(plane) {
@@ -40,11 +43,9 @@ export default function DrilldownOverlays(eventBus, elementRegistry, overlays, c
 
     breadcrumbs.innerHTML = '';
 
-    if (path.length > 1) {
-      breadcrumbs.classList.remove('djs-element-hidden');
-    } else {
-      breadcrumbs.classList.add('djs-element-hidden');
-    }
+    // show breadcrumbs and expose state to .djs-container
+    var visible = path.length > 1;
+    containerClasses.toggle(OPEN_CLASS, visible);
 
     path.forEach(function(el) {
       breadcrumbs.appendChild(el);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,9 +3333,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.7.0.tgz",
-      "integrity": "sha512-nTOUotijjOaZI3xmSu26BO8bKZt39PrMz35VyEumvG+AgdkxoaPKG7iF/nE4SWRke1X2aUoyGBp1y12r5JsdoQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.8.1.tgz",
+      "integrity": "sha512-Ziy5vTmB8V/kxuhgxQXdnNxSYnqlWxFrBih37MOOglDzyQ5mBIA8tFNssp/ncHpZmhTGC8sb54lYknovzyrrzg==",
       "requires": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.2",
     "css.escape": "^1.5.1",
-    "diagram-js": "^7.7.0",
+    "diagram-js": "^7.8.1",
     "diagram-js-direct-editing": "^1.6.3",
     "ids": "^1.0.0",
     "inherits": "^2.0.4",

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -716,17 +716,18 @@ describe('Modeler', function() {
       return createModeler(xml).then(function() {
         var drilldown = container.querySelector('.bjs-drilldown');
         var breadcrumbs = container.querySelector('.bjs-breadcrumbs');
+        var djsContainer = container.querySelector('.djs-container');
 
         // assume
         expect(drilldown).to.exist;
         expect(breadcrumbs).to.exist;
-        expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.true;
+        expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.false;
 
         // when
         drilldown.click();
 
         // then
-        expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.false;
+        expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.true;
       });
 
     });

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -379,17 +379,18 @@ describe('Viewer', function() {
       return createViewer(container, Viewer, xml).then(function() {
         var drilldown = container.querySelector('.bjs-drilldown');
         var breadcrumbs = container.querySelector('.bjs-breadcrumbs');
+        var djsContainer = container.querySelector('.djs-container');
 
         // assume
         expect(drilldown).to.exist;
         expect(breadcrumbs).to.exist;
-        expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.true;
+        expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.false;
 
         // when
         drilldown.click();
 
         // then
-        expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.false;
+        expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.true;
       });
 
     });

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -5,6 +5,7 @@ import {
 import coreModule from 'lib/core';
 import DrilldownModule from 'lib/features/drilldown';
 import { bootstrapViewer } from '../../../helper';
+import { classes } from 'min-dom';
 
 describe('features - drilldown', function() {
 
@@ -64,23 +65,23 @@ describe('features - drilldown', function() {
     it('should not show breadcrumbs in root view', inject(function(canvas) {
 
       // given
-      var breadcrumbs = canvas.getContainer().querySelector('.bjs-breadcrumbs');
+      var container = canvas.getContainer();
 
       // then
-      expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.true;
+      expect(classes(container).contains('bjs-breadcrumbs-shown')).to.be.false;
     }));
 
 
     it('should show breadcrumbs in subprocess view', inject(function(canvas) {
 
       // given
-      var breadcrumbs = canvas.getContainer().querySelector('.bjs-breadcrumbs');
+      var container = canvas.getContainer();
 
       // when
       canvas.setActivePlane('collapsedProcess');
 
       // then
-      expect(breadcrumbs.classList.contains('djs-element-hidden')).to.be.false;
+      expect(classes(container).contains('bjs-breadcrumbs-shown')).to.be.true;
     }));
 
 


### PR DESCRIPTION
* react to palette state
* expose own state to djs-container

related to https://github.com/bpmn-io/diagram-js/issues/591

![recording](https://user-images.githubusercontent.com/21984219/142185365-1c1ce366-6e74-4f1a-bffc-8efe3eead2ac.gif)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
