### PR TITLE
WIP - feat(modeling): create new planes when collapsed subprocesses are created

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -103,3 +103,11 @@
   fill: var(--drilldown-fill-color);
   background-color: var(--drilldown-background-color);
 }
+
+.bjs-drilldown-empty {
+  display: none;
+}
+
+.selected .bjs-drilldown-empty {
+  display: inherit;
+}

--- a/lib/features/auto-resize/BpmnAutoResizeProvider.js
+++ b/lib/features/auto-resize/BpmnAutoResizeProvider.js
@@ -33,6 +33,12 @@ BpmnAutoResizeProvider.$inject = [
  */
 BpmnAutoResizeProvider.prototype.canResize = function(elements, target) {
 
+  // do not resize plane elements:
+  // root elements, collapsed sub-processes
+  if (is(target.di, 'bpmndi:BPMNPlane')) {
+    return false;
+  }
+
   if (!is(target, 'bpmn:Participant') && !is(target, 'bpmn:Lane') && !(is(target, 'bpmn:SubProcess'))) {
     return false;
   }

--- a/lib/features/di-ordering/BpmnDiOrdering.js
+++ b/lib/features/di-ordering/BpmnDiOrdering.js
@@ -2,6 +2,7 @@ import { getDi } from '../../util/ModelUtil';
 
 import {
   filter,
+  forEach,
   map
 } from 'min-dash';
 
@@ -10,27 +11,32 @@ import { selfAndAllChildren } from 'diagram-js/lib/util/Elements';
 
 var HIGH_PRIORITY = 2000;
 
-export default function BpmnDiOrdering(eventBus, canvas) {
+export default function BpmnDiOrdering(eventBus, elementRegistry) {
 
   eventBus.on('saveXML.start', HIGH_PRIORITY, orderDi);
 
   function orderDi() {
-    var root = canvas.getRootElement(),
-        rootDi = getDi(root),
-        elements,
-        diElements;
-
-    elements = selfAndAllChildren([ root ], false);
-
-    // only bpmndi:Shape and bpmndi:Edge can be direct children of bpmndi:Plane
-    elements = filter(elements, function(element) {
-      return element !== root && !element.labelTarget;
+    var rootElements = elementRegistry.filter(function(element) {
+      return !element.parent;
     });
 
-    diElements = map(elements, getDi);
+    forEach(rootElements, function(root) {
+      var rootDi = getDi(root),
+          elements,
+          diElements;
 
-    rootDi.set('planeElement', diElements);
+      elements = selfAndAllChildren([ root ], false);
+
+      // only bpmndi:Shape and bpmndi:Edge can be direct children of bpmndi:Plane
+      elements = filter(elements, function(element) {
+        return element !== root && !element.labelTarget;
+      });
+
+      diElements = map(elements, getDi);
+
+      rootDi.set('planeElement', diElements);
+    });
   }
 }
 
-BpmnDiOrdering.$inject = [ 'eventBus', 'canvas' ];
+BpmnDiOrdering.$inject = [ 'eventBus', 'elementRegistry' ];

--- a/lib/features/drilldown/DrilldownBreadcrumbs.js
+++ b/lib/features/drilldown/DrilldownBreadcrumbs.js
@@ -3,8 +3,6 @@ import { domify, classes } from 'min-dom';
 import { escapeHTML } from 'diagram-js/lib/util/EscapeUtil';
 import { getBusinessObject, is } from '../../util/ModelUtil';
 
-var ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.81801948,3.50735931 L10.4996894,9.1896894 L10.5,4 L12,4 L12,12 L4,12 L4,10.5 L9.6896894,10.4996894 L3.75735931,4.56801948 C3.46446609,4.27512627 3.46446609,3.80025253 3.75735931,3.50735931 C4.05025253,3.21446609 4.52512627,3.21446609 4.81801948,3.50735931 Z"/></svg>';
-
 var OPEN_CLASS = 'bjs-breadcrumbs-shown';
 
 /**
@@ -15,7 +13,7 @@ var OPEN_CLASS = 'bjs-breadcrumbs-shown';
  * @param {overlays} overlays
  * @param {canvas} canvas
  */
-export default function DrilldownOverlays(eventBus, elementRegistry, overlays, canvas) {
+export default function DrilldownBreadcrumbs(eventBus, elementRegistry, overlays, canvas) {
   var breadcrumbs = domify('<ul class="bjs-breadcrumbs"></ul>');
   var container = canvas.getContainer();
   var containerClasses = classes(container);
@@ -58,44 +56,9 @@ export default function DrilldownOverlays(eventBus, elementRegistry, overlays, c
     updateBreadcrumbs(plane);
   });
 
-  function canDrillDown(element) {
-    return is(element, 'bpmn:SubProcess') && canvas.getPlane(element.id);
-  }
-
-  function addOverlay(element) {
-    var html = domify('<button class="bjs-drilldown">' + ARROW_DOWN_SVG + '</button>');
-
-    html.addEventListener('click', function() {
-      canvas.setActivePlane(element.id);
-    });
-
-    overlays.add(element, 'drilldown', {
-      position: {
-        bottom: -7,
-        right: -8
-      },
-      html: html
-    });
-  }
-
-  eventBus.on('import.done', function() {
-    elementRegistry.filter(canDrillDown).map(addOverlay);
-  });
-
-
-  // TODO(nikku): add dedicated overlays spec to test
-  // interaction with element creation and replace
-  eventBus.on('element.changed', function(event) {
-
-    var element = event.element;
-
-    if (canDrillDown(element)) {
-      addOverlay(element);
-    }
-  });
 }
 
-DrilldownOverlays.$inject = [ 'eventBus', 'elementRegistry', 'overlays', 'canvas' ];
+DrilldownBreadcrumbs.$inject = [ 'eventBus', 'elementRegistry', 'overlays', 'canvas' ];
 
 
 // helpers

--- a/lib/features/drilldown/DrilldownOverlayBehavior.js
+++ b/lib/features/drilldown/DrilldownOverlayBehavior.js
@@ -1,0 +1,132 @@
+import inherits from 'inherits';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import { is } from '../../util/ModelUtil';
+import { classes, domify } from 'min-dom';
+
+var LOW_PRIORITY = 250;
+var ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M4.81801948,3.50735931 L10.4996894,9.1896894 L10.5,4 L12,4 L12,12 L4,12 L4,10.5 L9.6896894,10.4996894 L3.75735931,4.56801948 C3.46446609,4.27512627 3.46446609,3.80025253 3.75735931,3.50735931 C4.05025253,3.21446609 4.52512627,3.21446609 4.81801948,3.50735931 Z"/></svg>';
+
+var EMPTY_MARKER = 'bjs-drilldown-empty';
+
+export default function DrilldownOverlayBehavior(
+    canvas, eventBus, elementRegistry, overlays
+) {
+  CommandInterceptor.call(this, eventBus);
+
+  this._canvas = canvas;
+  this._eventBus = eventBus;
+  this._elementRegistry = elementRegistry;
+  this._overlays = overlays;
+
+  var self = this;
+
+  this.executed('shape.create', LOW_PRIORITY, function(context) {
+    var shape = context.shape;
+
+    // Add overlay to the collapsed shape
+    if (self.canDrillDown(shape)) {
+      self.addOverlay(shape);
+    }
+
+    // with the first element added, we remove the overlay marker
+    // to make the drilldown button permanent
+    updateDrilldownOverlay(shape);
+  }, true);
+
+  this.reverted('shape.create', LOW_PRIORITY, function(context) {
+    updateDrilldownOverlay(context.parent);
+  }, true);
+
+  this.executed('shape.delete', LOW_PRIORITY, function(context) {
+    updateDrilldownOverlay(context.oldParent);
+  }, true);
+
+  this.reverted('shape.delete', LOW_PRIORITY, function(context) {
+    updateDrilldownOverlay(context.oldParent);
+  }, true);
+
+  // TODO(marstamm): remove overlays when expanding an element
+
+
+  eventBus.on('import.done', function() {
+    elementRegistry.filter(function(e) {
+      return self.canDrillDown(e);
+    }).map(function(el) {
+      self.addOverlay(el);
+    });
+  });
+
+  function updateDrilldownOverlay(shape) {
+    if (!shape) {
+      return;
+    }
+
+    var parentPlane = canvas.findPlane(shape);
+    if (parentPlane) {
+      self.updateOverlayVisibility(parentPlane.rootElement);
+    }
+  }
+}
+
+inherits(DrilldownOverlayBehavior, CommandInterceptor);
+
+DrilldownOverlayBehavior.prototype.canDrillDown = function(element) {
+  return is(element, 'bpmn:SubProcess') && this._canvas.getPlane(element.id);
+};
+
+/**
+ * Updates visibility of the drilldown overlay. If the plane has no elements,
+ * the drilldown will be only shown when the element is selected.
+ *
+ * @param {djs.model.Shape|djs.model.Root} element collapsed shape or root element
+ */
+DrilldownOverlayBehavior.prototype.updateOverlayVisibility = function(element) {
+  var overlays = this._overlays;
+
+  var bo = element.businessObject;
+
+  var overlay = overlays.get({ element: bo.id, type: 'drilldown' })[0];
+
+  if (!overlay) {
+    return;
+  }
+
+  var hasContent = bo && bo.flowElements && bo.flowElements.length;
+  classes(overlay.html).toggle(EMPTY_MARKER, !hasContent);
+};
+
+/**
+ * Attaches a drilldown button to the given element. We assume that the plane has
+ * the same id as the element.
+ *
+ * @param {djs.model.Shape} element collapsed shape
+ */
+DrilldownOverlayBehavior.prototype.addOverlay = function(element) {
+  var canvas = this._canvas;
+  var overlays = this._overlays;
+
+  var button = domify('<button class="bjs-drilldown">' + ARROW_DOWN_SVG + '</button>');
+
+  button.addEventListener('click', function() {
+    canvas.setActivePlane(element.id);
+  });
+
+  overlays.add(element, 'drilldown', {
+    position: {
+      bottom: -7,
+      right: -8
+    },
+    html: button
+  });
+
+  this.updateOverlayVisibility(element);
+};
+
+
+DrilldownOverlayBehavior.$inject = [
+  'canvas',
+  'eventBus',
+  'elementRegistry',
+  'overlays'
+];

--- a/lib/features/drilldown/DrilldownOverlays.js
+++ b/lib/features/drilldown/DrilldownOverlays.js
@@ -58,36 +58,40 @@ export default function DrilldownOverlays(eventBus, elementRegistry, overlays, c
     updateBreadcrumbs(plane);
   });
 
-  var createOverlay = function(element) {
+  function canDrillDown(element) {
+    return is(element, 'bpmn:SubProcess') && canvas.getPlane(element.id);
+  }
+
+  function addOverlay(element) {
     var html = domify('<button class="bjs-drilldown">' + ARROW_DOWN_SVG + '</button>');
 
     html.addEventListener('click', function() {
       canvas.setActivePlane(element.id);
     });
 
-    overlays.add(element, {
+    overlays.add(element, 'drilldown', {
       position: {
         bottom: -7,
         right: -8
       },
       html: html
     });
-  };
-
-  var addOverlays = function(elements) {
-    elements.forEach(function(element) {
-      if (is(element, 'bpmn:SubProcess')
-          && element.collapsed
-          && canvas.getPlane(element.id)) {
-        createOverlay(element);
-      }
-    });
-  };
+  }
 
   eventBus.on('import.done', function() {
-    addOverlays(elementRegistry.filter(function(el) {
-      return is(el, 'bpmn:SubProcess');
-    }));
+    elementRegistry.filter(canDrillDown).map(addOverlay);
+  });
+
+
+  // TODO(nikku): add dedicated overlays spec to test
+  // interaction with element creation and replace
+  eventBus.on('element.changed', function(event) {
+
+    var element = event.element;
+
+    if (canDrillDown(element)) {
+      addOverlay(element);
+    }
   });
 }
 

--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -83,6 +83,15 @@ SubprocessCompatibility.prototype.createNewDiagrams = function(plane) {
 
   var newDiagrams = [];
 
+  // create new planes for all collapsed subprocesses, even when they are empty
+  collapsedElements.forEach(function(element) {
+    if (!self._processToDiagramMap[element.id]) {
+      var diagram = self.createDiagram(element);
+      self._processToDiagramMap[element.id] = diagram;
+      newDiagrams.push(diagram);
+    }
+  });
+
   elementsToMove.forEach(function(element) {
     var diElement = element.diElement;
     var parent = element.parent;
@@ -98,12 +107,6 @@ SubprocessCompatibility.prototype.createNewDiagrams = function(plane) {
     }
 
     var diagram = self._processToDiagramMap[parent.id];
-    if (!diagram) {
-      diagram = self.createDiagram(parent);
-      self._processToDiagramMap[parent.id] = diagram;
-      newDiagrams.push(diagram);
-    }
-
     self.moveToDiPlane(diElement, diagram.plane);
   });
 

--- a/lib/features/drilldown/index.js
+++ b/lib/features/drilldown/index.js
@@ -1,12 +1,13 @@
 import OverlaysModule from 'diagram-js/lib/features/overlays';
 import ChangeSupportModule from 'diagram-js/lib/features/change-support';
+import PlanesModule from 'diagram-js/lib/features/planes';
 
 import DrilldownOverlays from './DrilldownOverlays';
 import DrilldownCentering from './DrilldownCentering';
 import SubprocessCompatibility from './SubprocessCompatibility';
 
 export default {
-  __depends__: [ OverlaysModule, ChangeSupportModule ],
+  __depends__: [ OverlaysModule, ChangeSupportModule, PlanesModule ],
   __init__: [ 'drilldownOverlays', 'drilldownCentering', 'subprocessCompatibility'],
   drilldownOverlays: [ 'type', DrilldownOverlays ],
   drilldownCentering: [ 'type', DrilldownCentering ],

--- a/lib/features/drilldown/index.js
+++ b/lib/features/drilldown/index.js
@@ -2,14 +2,16 @@ import OverlaysModule from 'diagram-js/lib/features/overlays';
 import ChangeSupportModule from 'diagram-js/lib/features/change-support';
 import PlanesModule from 'diagram-js/lib/features/planes';
 
-import DrilldownOverlays from './DrilldownOverlays';
+import DrilldownBreadcrumbs from './DrilldownBreadcrumbs';
 import DrilldownCentering from './DrilldownCentering';
 import SubprocessCompatibility from './SubprocessCompatibility';
+import DrilldownOverlayBehavior from './DrilldownOverlayBehavior';
 
 export default {
   __depends__: [ OverlaysModule, ChangeSupportModule, PlanesModule ],
-  __init__: [ 'drilldownOverlays', 'drilldownCentering', 'subprocessCompatibility'],
-  drilldownOverlays: [ 'type', DrilldownOverlays ],
+  __init__: [ 'drilldownBreadcrumbs', 'drilldownOverlayBehavior', 'drilldownCentering', 'subprocessCompatibility'],
+  drilldownBreadcrumbs: [ 'type', DrilldownBreadcrumbs ],
   drilldownCentering: [ 'type', DrilldownCentering ],
+  drilldownOverlayBehavior: [ 'type', DrilldownOverlayBehavior ],
   subprocessCompatibility: [ 'type', SubprocessCompatibility ]
 };

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -44,7 +44,6 @@ export default function SubProcessPlaneBehavior(
     }
 
     var businessObject = getBusinessObject(shape);
-    console.log(self);
 
     self._createNewDiagram(businessObject);
 
@@ -166,10 +165,11 @@ SubProcessPlaneBehavior.prototype._renamePlane = function(oldId, newId) {
     return;
   }
 
-  var oldPlane = canvas.getPlane(oldId);
+  var oldPlane = canvas.getPlane(oldId),
+      oldRoot = oldPlane.rootElement;
 
   canvas.removePlane(oldPlane);
-  canvas.createPlane(newId, oldPlane.rootElement);
+  canvas.createPlane(newId, oldRoot);
 };
 
 SubProcessPlaneBehavior.$inject = [

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -34,6 +34,30 @@ export default function SubProcessPlaneBehavior(
     return is(element, 'bpmn:SubProcess') && !isExpanded(element);
   }
 
+  function createPlane(context) {
+    var shape = context.shape,
+        plane = context.targetPlane,
+        rootElement = plane && plane.rootElement;
+
+    var businessObject = getBusinessObject(shape);
+
+    rootElement = self._addDiagram(rootElement || businessObject);
+    context.targetPlane = canvas.createPlane(
+      plane ||
+      { name: businessObject.id, rootElement: rootElement });
+  }
+
+  function removePlane(context) {
+    var shape = context.shape;
+
+    var businessObject = getBusinessObject(shape);
+
+    self._removeDiagram(businessObject);
+
+    context.targetPlane = canvas.removePlane(businessObject.id);
+  }
+
+
   // add plane elements for newly created sub-processes
   // this ensures we can actually drill down into the element
   this.executed('shape.create', function(context) {
@@ -43,10 +67,7 @@ export default function SubProcessPlaneBehavior(
       return;
     }
 
-    var businessObject = getBusinessObject(shape);
-
-    self._createNewDiagram(businessObject);
-
+    createPlane(context);
   }, true);
 
 
@@ -57,33 +78,49 @@ export default function SubProcessPlaneBehavior(
       return;
     }
 
-    var businessObject = getBusinessObject(shape);
-
-    self._removeDiagram(businessObject);
-
+    removePlane(context);
   }, true);
 
 
   this.executed('element.updateProperties', function(context) {
+    var shape = context.element;
+
+    if (!isCollapsedSubProcess(shape)) {
+      return;
+    }
+
     var properties = context.properties;
     var oldProperties = context.oldProperties;
 
     var oldId = oldProperties.id,
         newId = properties.id;
 
-    self._renamePlane(oldId, newId);
+    if (oldId === newId) {
+      return;
+    }
+
+    canvas.renamePlane(oldId, newId);
   }, true);
 
 
   this.reverted('element.updateProperties', function(context) {
+    var shape = context.element;
     var properties = context.properties;
     var oldProperties = context.oldProperties;
 
     var oldId = oldProperties.id,
         newId = properties.id;
 
-    self._renamePlane(newId, oldId);
 
+    if (!isCollapsedSubProcess(shape)) {
+      return;
+    }
+
+    if (oldId === newId) {
+      return;
+    }
+
+    canvas.renamePlane(newId, oldId);
   }, true);
 
 }
@@ -92,39 +129,51 @@ inherits(SubProcessPlaneBehavior, CommandInterceptor);
 
 
 /**
-* Creates a new plane element for the given sub process and
-* adds it to the canvas.
+* Adds a given diagram to the definitions and returns a .
 *
-* @param {Object} rootElement
+* @param {Object} planeElement
 */
-SubProcessPlaneBehavior.prototype._createNewDiagram = function(rootElement) {
-  var canvas = this._canvas;
-  var bpmnFactory = this._bpmnFactory;
-  var elementFactory = this._elementFactory;
+SubProcessPlaneBehavior.prototype._addDiagram = function(planeElement) {
   var bpmnjs = this._bpmnjs;
-
   var diagrams = bpmnjs.getDefinitions().diagrams;
 
+  if (!planeElement.businessObject) {
+    planeElement = this._createDiagram(planeElement);
+  }
+
+  diagrams.push(planeElement.di.$parent);
+
+  return planeElement;
+};
+
+/**
+* Creates a new plane element for the given sub process.
+*
+* @param {Object} bpmnElement
+*
+* @return {Object} new diagram element
+*/
+SubProcessPlaneBehavior.prototype._createDiagram = function(bpmnElement) {
+  var bpmnFactory = this._bpmnFactory;
+  var elementFactory = this._elementFactory;
+
   var diPlane = bpmnFactory.create('bpmndi:BPMNPlane', {
-    bpmnElement: rootElement
+    bpmnElement: bpmnElement
   });
   var diDiagram = bpmnFactory.create('bpmndi:BPMNDiagram', {
     plane: diPlane
   });
   diPlane.$parent = diDiagram;
-  diagrams.push(diDiagram);
 
   // add a virtual element (not being drawn),
   // a copy cat of our BpmnImporter code
   var planeElement = elementFactory.createRoot({
-    id: rootElement.id + '_plane',
-    type: rootElement.$type,
+    id: bpmnElement.id + '_plane',
+    type: bpmnElement.$type,
     di: diPlane,
-    businessObject: rootElement,
+    businessObject: bpmnElement,
     collapsed: true
   });
-
-  canvas.createPlane(rootElement.id, planeElement);
 
   return planeElement;
 };
@@ -136,7 +185,6 @@ SubProcessPlaneBehavior.prototype._createNewDiagram = function(rootElement) {
  * @returns {Object} removed bpmndi:BPMNDiagram
  */
 SubProcessPlaneBehavior.prototype._removeDiagram = function(rootElement) {
-  var canvas = this._canvas;
   var bpmnjs = this._bpmnjs;
 
   var diagrams = bpmnjs.getDefinitions().diagrams;
@@ -147,30 +195,9 @@ SubProcessPlaneBehavior.prototype._removeDiagram = function(rootElement) {
 
   diagrams.splice(diagrams.indexOf(removedDiagram), 1);
 
-  canvas.removePlane(rootElement.id);
-
   return removedDiagram;
 };
 
-/**
- * Renames a canvas plane.
- *
- * @param {String} oldId
- * @param {String} newId
- */
-SubProcessPlaneBehavior.prototype._renamePlane = function(oldId, newId) {
-  var canvas = this._canvas;
-
-  if (!oldId || !canvas.getPlane(oldId)) {
-    return;
-  }
-
-  var oldPlane = canvas.getPlane(oldId),
-      oldRoot = oldPlane.rootElement;
-
-  canvas.removePlane(oldPlane);
-  canvas.createPlane(newId, oldRoot);
-};
 
 SubProcessPlaneBehavior.$inject = [
   'canvas',

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -1,0 +1,185 @@
+import inherits from 'inherits';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { isExpanded } from '../../../util/DiUtil';
+import { getBusinessObject, is } from '../../../util/ModelUtil';
+
+/**
+ * Creates diPlanes and canvas planes when collapses subprocesses are created.
+ *
+ * @param {Canvas} canvas
+ * @param {EventBus} eventBus
+ * @param {Modeling} modeling
+ * @param {ElementFactory} elementFactory
+ * @param {BpmnFactory} bpmnFactory
+ * @param {Bpmnjs} bpmnjs
+ */
+export default function SubProcessPlaneBehavior(
+    canvas, eventBus, modeling,
+    elementFactory, bpmnFactory, bpmnjs) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this._canvas = canvas;
+  this._eventBus = eventBus;
+  this._modeling = modeling;
+  this._elementFactory = elementFactory;
+  this._bpmnFactory = bpmnFactory;
+  this._bpmnjs = bpmnjs;
+
+  var self = this;
+
+  function isCollapsedSubProcess(element) {
+    return is(element, 'bpmn:SubProcess') && !isExpanded(element);
+  }
+
+  // add plane elements for newly created sub-processes
+  // this ensures we can actually drill down into the element
+  this.executed('shape.create', function(context) {
+    var shape = context.shape;
+
+    if (!isCollapsedSubProcess(shape)) {
+      return;
+    }
+
+    var businessObject = getBusinessObject(shape);
+    console.log(self);
+
+    self._createNewDiagram(businessObject);
+
+  }, true);
+
+
+  this.reverted('shape.create', 500, function(context) {
+    var shape = context.shape;
+
+    if (!isCollapsedSubProcess(shape)) {
+      return;
+    }
+
+    var businessObject = getBusinessObject(shape);
+
+    self._removeDiagram(businessObject);
+
+  }, true);
+
+
+  this.executed('element.updateProperties', function(context) {
+    var properties = context.properties;
+    var oldProperties = context.oldProperties;
+
+    var oldId = oldProperties.id,
+        newId = properties.id;
+
+    self._renamePlane(oldId, newId);
+  }, true);
+
+
+  this.reverted('element.updateProperties', function(context) {
+    var properties = context.properties;
+    var oldProperties = context.oldProperties;
+
+    var oldId = oldProperties.id,
+        newId = properties.id;
+
+    self._renamePlane(newId, oldId);
+
+  }, true);
+
+}
+
+inherits(SubProcessPlaneBehavior, CommandInterceptor);
+
+
+/**
+* Creates a new plane element for the given sub process and
+* adds it to the canvas.
+*
+* @param {Object} rootElement
+*/
+SubProcessPlaneBehavior.prototype._createNewDiagram = function(rootElement) {
+  var canvas = this._canvas;
+  var bpmnFactory = this._bpmnFactory;
+  var elementFactory = this._elementFactory;
+  var bpmnjs = this._bpmnjs;
+
+  var diagrams = bpmnjs.getDefinitions().diagrams;
+
+  var diPlane = bpmnFactory.create('bpmndi:BPMNPlane', {
+    bpmnElement: rootElement
+  });
+  var diDiagram = bpmnFactory.create('bpmndi:BPMNDiagram', {
+    plane: diPlane
+  });
+  diPlane.$parent = diDiagram;
+  diagrams.push(diDiagram);
+
+  // add a virtual element (not being drawn),
+  // a copy cat of our BpmnImporter code
+  var planeElement = elementFactory.createRoot({
+    id: rootElement.id + '_plane',
+    type: rootElement.$type,
+    di: diPlane,
+    businessObject: rootElement,
+    collapsed: true
+  });
+
+  canvas.createPlane(rootElement.id, planeElement);
+
+  return planeElement;
+};
+
+/**
+ * Removes the diagram for a given root element
+ *
+ * @param {Object} rootElement
+ * @returns {Object} removed bpmndi:BPMNDiagram
+ */
+SubProcessPlaneBehavior.prototype._removeDiagram = function(rootElement) {
+  var canvas = this._canvas;
+  var bpmnjs = this._bpmnjs;
+
+  var diagrams = bpmnjs.getDefinitions().diagrams;
+
+  var removedDiagram = diagrams.find(function(diagram) {
+    return diagram.plane.bpmnElement.id === rootElement.id;
+  });
+
+  diagrams.splice(diagrams.indexOf(removedDiagram), 1);
+
+  canvas.removePlane(rootElement.id);
+
+  return removedDiagram;
+};
+
+/**
+ * Renames a canvas plane.
+ *
+ * @param {String} oldId
+ * @param {String} newId
+ */
+SubProcessPlaneBehavior.prototype._renamePlane = function(oldId, newId) {
+  var canvas = this._canvas;
+
+  if (!oldId || !canvas.getPlane(oldId)) {
+    return;
+  }
+
+  var oldPlane = canvas.getPlane(oldId);
+
+  canvas.removePlane(oldPlane);
+  canvas.createPlane(newId, oldPlane.rootElement);
+};
+
+SubProcessPlaneBehavior.$inject = [
+  'canvas',
+  'eventBus',
+  'modeling',
+  'elementFactory',
+  'bpmnFactory',
+  'bpmnjs'
+];
+
+
+

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -28,6 +28,7 @@ import ResizeLaneBehavior from './ResizeLaneBehavior';
 import RemoveElementBehavior from './RemoveElementBehavior';
 import SpaceToolBehavior from './SpaceToolBehavior';
 import SubProcessStartEventBehavior from './SubProcessStartEventBehavior';
+import SubProcessPlaneBehavior from './SubProcessPlaneBehavior';
 import ToggleElementCollapseBehaviour from './ToggleElementCollapseBehaviour';
 import UnclaimIdBehavior from './UnclaimIdBehavior';
 import UpdateFlowNodeRefsBehavior from './UpdateFlowNodeRefsBehavior';
@@ -66,6 +67,7 @@ export default {
     'toggleElementCollapseBehaviour',
     'spaceToolBehavior',
     'subProcessStartEventBehavior',
+    'subProcessPlaneBehavior',
     'unclaimIdBehavior',
     'unsetDefaultFlowBehavior',
     'updateFlowNodeRefsBehavior'
@@ -101,6 +103,7 @@ export default {
   toggleElementCollapseBehaviour : [ 'type', ToggleElementCollapseBehaviour ],
   spaceToolBehavior: [ 'type', SpaceToolBehavior ],
   subProcessStartEventBehavior: [ 'type', SubProcessStartEventBehavior ],
+  subProcessPlaneBehavior: [ 'type', SubProcessPlaneBehavior ],
   unclaimIdBehavior: [ 'type', UnclaimIdBehavior ],
   updateFlowNodeRefsBehavior: [ 'type', UpdateFlowNodeRefsBehavior ],
   unsetDefaultFlowBehavior: [ 'type', UnsetDefaultFlowBehavior ]

--- a/lib/import/BpmnImporter.js
+++ b/lib/import/BpmnImporter.js
@@ -26,6 +26,13 @@ import {
 } from './Util';
 
 
+/**
+ * @param {ModdleElement} semantic
+ * @param {ModdleElement} di
+ * @param {Object} [attrs=null]
+ *
+ * @return {Object}
+ */
 function elementData(semantic, di, attrs) {
   return assign({
     id: semantic.id,
@@ -105,13 +112,12 @@ BpmnImporter.prototype.add = function(semantic, di, parentElement) {
   // invisible root element (process, subprocess or collaboration)
   if (is(di, 'bpmndi:BPMNPlane')) {
 
-    // add a virtual element (not being drawn)
-    element = this._elementFactory.createRoot(elementData(semantic, di));
+    var attrs = is(semantic, 'bpmn:SubProcess')
+      ? { id: semantic.id + '_plane' }
+      : {};
 
-    // for subprocesses, the id is already defined on the collapsed shape
-    if (is(semantic, 'bpmn:SubProcess')) {
-      element.id = element.id + '_plane';
-    }
+    // add a virtual element (not being drawn)
+    element = this._elementFactory.createRoot(elementData(semantic, di, attrs));
 
     this._canvas.createPlane(semantic.id, element);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,9 +3333,8 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-7.8.1.tgz",
-      "integrity": "sha512-Ziy5vTmB8V/kxuhgxQXdnNxSYnqlWxFrBih37MOOglDzyQ5mBIA8tFNssp/ncHpZmhTGC8sb54lYknovzyrrzg==",
+      "version": "github:bpmn-io/diagram-js#ae86c626e7ec8ab021b5cf40f3e1a24e66365566",
+      "from": "github:bpmn-io/diagram-js#create-planes-from-descriptor",
       "requires": {
         "css.escape": "^1.5.1",
         "didi": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "bpmn-moddle": "^7.1.2",
     "css.escape": "^1.5.1",
-    "diagram-js": "^7.8.1",
+    "diagram-js": "github:bpmn-io/diagram-js#create-planes-from-descriptor",
     "diagram-js-direct-editing": "^1.6.3",
     "ids": "^1.0.0",
     "inherits": "^2.0.4",

--- a/test/fixtures/bpmn/collapsed-sub-process-legacy.bpmn
+++ b/test/fixtures/bpmn/collapsed-sub-process-legacy.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0763oqv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:subProcess id="SubProcess">
+      <bpmn:startEvent id="Event_0lrpy3a">
+        <bpmn:outgoing>Flow_0obnxbt</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0obnxbt" sourceRef="Event_0lrpy3a" targetRef="NestedSubProcess" />
+      <bpmn:endEvent id="Event_1ic2bhx">
+        <bpmn:incoming>Flow_1d6ajf7</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:subProcess id="NestedSubProcess">
+        <bpmn:incoming>Flow_0obnxbt</bpmn:incoming>
+        <bpmn:outgoing>Flow_1d6ajf7</bpmn:outgoing>
+        <bpmn:startEvent id="subprocess_startEvent" />
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_1d6ajf7" sourceRef="NestedSubProcess" targetRef="Event_1ic2bhx" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess">
+        <dc:Bounds x="250" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1d6ajf7_di" bpmnElement="Flow_1d6ajf7">
+        <di:waypoint x="740" y="240" />
+        <di:waypoint x="782" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0obnxbt_di" bpmnElement="Flow_0obnxbt">
+        <di:waypoint x="308" y="240" />
+        <di:waypoint x="350" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0lrpy3a_di" bpmnElement="Event_0lrpy3a">
+        <dc:Bounds x="272" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NestedSubProcess_di" bpmnElement="NestedSubProcess">
+        <dc:Bounds x="350" y="120" width="390" height="240" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess_startEvent_di" bpmnElement="subprocess_startEvent">
+        <dc:Bounds x="410" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ic2bhx_di" bpmnElement="Event_1ic2bhx">
+        <dc:Bounds x="782" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -710,8 +710,7 @@ describe('Modeler', function() {
 
   describe('drill down', function() {
 
-    it('should allow drill down into collapsed sub-process', function() {
-      var xml = require('../fixtures/bpmn/collapsed-sub-process.bpmn');
+    function verifyDrilldown(xml) {
 
       return createModeler(xml).then(function() {
         var drilldown = container.querySelector('.bjs-drilldown');
@@ -730,6 +729,19 @@ describe('Modeler', function() {
         expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.true;
       });
 
+    }
+
+    it('should allow drill down into collapsed sub-process', function() {
+      var xml = require('../fixtures/bpmn/collapsed-sub-process.bpmn');
+
+      return verifyDrilldown(xml);
+    });
+
+
+    it('should allow drill down into legacy collapsed sub-process', function() {
+      var xml = require('../fixtures/bpmn/collapsed-sub-process-legacy.bpmn');
+
+      return verifyDrilldown(xml);
     });
 
   });

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -372,9 +372,7 @@ describe('Viewer', function() {
 
   describe('drill down', function() {
 
-    it('should allow drill down into collapsed sub-process', function() {
-
-      var xml = require('../fixtures/bpmn/collapsed-sub-process.bpmn');
+    function verifyDrilldown(xml) {
 
       return createViewer(container, Viewer, xml).then(function() {
         var drilldown = container.querySelector('.bjs-drilldown');
@@ -393,6 +391,19 @@ describe('Viewer', function() {
         expect(djsContainer.classList.contains('bjs-breadcrumbs-shown')).to.be.true;
       });
 
+    }
+
+    it('should allow drill down into collapsed sub-process', function() {
+      var xml = require('../fixtures/bpmn/collapsed-sub-process.bpmn');
+
+      return verifyDrilldown(xml);
+    });
+
+
+    it('should allow drill down into legacy collapsed sub-process', function() {
+      var xml = require('../fixtures/bpmn/collapsed-sub-process-legacy.bpmn');
+
+      return verifyDrilldown(xml);
     });
 
   });

--- a/test/spec/features/drilldown/DrilldownOverlayBehaviorSpec.bpmn
+++ b/test/spec/features/drilldown/DrilldownOverlayBehaviorSpec.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_007va6i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.0-dev">
+  <bpmn:process id="Process_1giw3j5" isExecutable="true">
+    <bpmn:subProcess id="Subprocess_with_content">
+      <bpmn:startEvent id="StartEvent_embedded" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Subprocess_empty" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1giw3j5">
+      <bpmndi:BPMNShape id="Activity_175iapo_di" bpmnElement="Subprocess_with_content">
+        <dc:Bounds x="300" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vrbgo0_di" bpmnElement="Subprocess_empty">
+        <dc:Bounds x="140" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1widlc2">
+    <bpmndi:BPMNPlane id="BPMNPlane_0epf6vs" bpmnElement="Subprocess_with_content">
+      <bpmndi:BPMNShape id="StartEvent_embedded_di" bpmnElement="StartEvent_embedded">
+        <dc:Bounds x="132" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1res3mc">
+    <bpmndi:BPMNPlane id="BPMNPlane_0iznbzu" bpmnElement="Subprocess_empty" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/drilldown/DrilldownOverlaysBehaviorSpec.js
+++ b/test/spec/features/drilldown/DrilldownOverlaysBehaviorSpec.js
@@ -1,0 +1,265 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+import replaceModule from 'lib/features/replace';
+import drilldownModule from 'lib/features/drilldown';
+import { classes } from 'min-dom';
+
+
+describe('features/modeling/behavior - subprocess planes', function() {
+
+  var diagramXML = require('./DrilldownOverlayBehaviorSpec.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule,
+      replaceModule,
+      drilldownModule
+    ]
+  }));
+
+
+  describe('create new drilldowns', function() {
+
+    it('should create drilldown for new process',
+      inject(function(elementFactory, modeling, canvas, overlays) {
+
+        // given
+        var subProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: false
+        });
+
+        // when
+        modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+        // then
+        var elementOverlays = overlays.get({ element: subProcess });
+        expect(elementOverlays).to.not.be.empty;
+
+      })
+    );
+
+
+    it('should not create drilldown for expanded subprocess',
+      inject(function(elementFactory, modeling, canvas, overlays) {
+
+        // given
+        var subProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: true
+        });
+
+        // when
+        modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+        // then
+        var elementOverlays = overlays.get({ element: subProcess });
+        expect(elementOverlays).to.be.empty;
+      })
+    );
+
+
+    it('should undo',
+      inject(function(elementFactory, modeling, commandStack, canvas, overlays) {
+
+        // given
+        var subProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: false
+        });
+        modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+        // when
+        commandStack.undo();
+
+        // then
+        var elementOverlays = overlays.get({ element: subProcess });
+        expect(elementOverlays).to.be.empty;
+      })
+    );
+
+
+    it('should redo',
+      inject(function(elementFactory, modeling, commandStack, canvas, overlays) {
+
+        // given
+        var subProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: false
+        });
+        modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        var elementOverlays = overlays.get({ element: subProcess });
+        expect(elementOverlays).to.not.be.empty;
+      })
+    );
+
+  });
+
+
+  describe('overlay visibility', function() {
+
+    describe('empty subprocess', function() {
+
+      it('should hide drilldown', inject(function(elementRegistry, overlays) {
+
+        // given
+        var subProcess = elementRegistry.get('Subprocess_empty');
+
+        // then
+        var overlay = overlays.get({ element: subProcess })[0];
+
+        expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.true;
+      }));
+
+
+      it('should show when content is added',
+        inject(function(elementRegistry, overlays, elementFactory, modeling, canvas) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_empty');
+          var task = elementFactory.createShape({ type: 'bpmn:Task' });
+          var planeRoot = canvas.getPlane('Subprocess_empty').rootElement;
+
+          // when
+          modeling.createShape(task, { x: 300, y: 300 }, planeRoot);
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.false;
+        })
+      );
+
+
+      it('should undo',
+        inject(function(elementRegistry, overlays, elementFactory,
+            modeling, canvas, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_empty');
+          var task = elementFactory.createShape({ type: 'bpmn:Task' });
+          var planeRoot = canvas.getPlane('Subprocess_empty').rootElement;
+          modeling.createShape(task, { x: 300, y: 300 }, planeRoot);
+
+          // when
+          commandStack.undo();
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.true;
+        })
+      );
+
+
+      it('should redo',
+        inject(function(elementRegistry, overlays, elementFactory,
+            modeling, canvas, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_empty');
+          var task = elementFactory.createShape({ type: 'bpmn:Task' });
+          var planeRoot = canvas.getPlane('Subprocess_empty').rootElement;
+          modeling.createShape(task, { x: 300, y: 300 }, planeRoot);
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.false;
+        })
+      );
+
+    });
+
+
+    describe('subprocess with content', function() {
+
+      it('should show drilldown', inject(function(elementRegistry, overlays) {
+
+        // given
+        var subProcess = elementRegistry.get('Subprocess_with_content');
+
+        // then
+        var overlay = overlays.get({ element: subProcess })[0];
+
+        expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.false;
+      }));
+
+
+      it('should hide when content is removed',
+        inject(function(elementRegistry, overlays, modeling) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_with_content');
+          var startEvent = elementRegistry.get('StartEvent_embedded');
+
+          // when
+          modeling.removeShape(startEvent);
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.true;
+        })
+      );
+
+
+      it('should undo',
+        inject(function(elementRegistry, overlays, modeling, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_with_content');
+          var startEvent = elementRegistry.get('StartEvent_embedded');
+          modeling.removeShape(startEvent);
+
+          // when
+          commandStack.undo();
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.false;
+        })
+      );
+
+
+      it('should redo',
+        inject(function(elementRegistry, overlays, modeling, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('Subprocess_with_content');
+          var startEvent = elementRegistry.get('StartEvent_embedded');
+          modeling.removeShape(startEvent);
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          var overlay = overlays.get({ element: subProcess })[0];
+
+          expect(classes(overlay.html).contains('bjs-drilldown-empty')).to.be.true;
+        })
+      );
+
+    });
+
+  });
+
+});

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -195,6 +195,16 @@ describe('features - drilldown', function() {
       expect(startEvent.y).to.equal(160);
     }));
 
+
+    it('should create new planes for empty processes', inject(function(canvas) {
+
+      // when
+      var emptyPlane = canvas.getPlane('emptyProcess');
+
+      // then
+      expect(emptyPlane).to.exist;
+    }));
+
   });
 
 });

--- a/test/spec/features/drilldown/legacy-subprocesses.bpmn
+++ b/test/spec/features/drilldown/legacy-subprocesses.bpmn
@@ -17,6 +17,7 @@
       </bpmn:subProcess>
       <bpmn:sequenceFlow id="Flow_1d6ajf7" sourceRef="inlineSubprocess_2" targetRef="Event_1ic2bhx" />
     </bpmn:subProcess>
+    <bpmn:subProcess id="emptyProcess" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vkcvif">
@@ -37,14 +38,17 @@
       <bpmndi:BPMNShape id="Event_0lrpy3a_di" bpmnElement="Event_0lrpy3a">
         <dc:Bounds x="272" y="222" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ic2bhx_di" bpmnElement="Event_1ic2bhx">
+        <dc:Bounds x="782" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="inlineSubprocess_2_di" bpmnElement="inlineSubprocess_2">
         <dc:Bounds x="350" y="120" width="390" height="240" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="subprocess_startEvent_di" bpmnElement="subprocess_startEvent">
         <dc:Bounds x="410" y="222" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ic2bhx_di" bpmnElement="Event_1ic2bhx">
-        <dc:Bounds x="782" y="222" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1hpaeri_di" bpmnElement="emptyProcess">
+        <dc:Bounds x="960" y="50" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/SubProcessBehavior.planes.bpmn
+++ b/test/spec/features/modeling/behavior/SubProcessBehavior.planes.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_007va6i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.0-dev">
+  <bpmn:process id="Process_1giw3j5" isExecutable="true">
+    <bpmn:task id="Task_1" />
+    <bpmn:subProcess id="SubProcess_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1giw3j5">
+      <bpmndi:BPMNShape id="Task_07xra8r_di" bpmnElement="Task_1">
+        <dc:Bounds x="156" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_01nq2r1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="280" width="350" height="200" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
@@ -1,0 +1,197 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+import replaceModule from 'lib/features/replace';
+
+describe('features/modeling/behavior - subprocess planes', function() {
+
+  var diagramXML = require('./SubProcessBehavior.planes.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule,
+      replaceModule
+    ]
+  }));
+
+
+  describe('create', function() {
+
+    it('should create new diagram for collapsed subprocess', inject(function(elementFactory, modeling, canvas, bpmnjs) {
+
+      // given
+      var subProcess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+
+      // when
+      modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+      // then
+      var diagrams = bpmnjs.getDefinitions().diagrams;
+      expect(diagrams.length).to.equal(2);
+      expect(canvas.getPlane(subProcess.id)).to.exist;
+    }));
+
+
+    it('should not create new plane for expanded subprocess', inject(function(elementFactory, modeling, canvas, bpmnjs) {
+
+      // given
+      var subProcess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        isExpanded: true
+      });
+
+      // when
+      modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+      // then
+      var diagrams = bpmnjs.getDefinitions().diagrams;
+      expect(diagrams.length).to.equal(1);
+      expect(canvas.getPlane(subProcess.id)).to.not.exist;
+    }));
+
+
+    it('should undo', inject(function(elementFactory, modeling, commandStack, canvas, bpmnjs) {
+
+      // given
+      var subProcess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+      modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+      // when
+      commandStack.undo();
+
+      // then
+      var diagrams = bpmnjs.getDefinitions().diagrams;
+      expect(diagrams.length).to.equal(1);
+      expect(canvas.getPlane(subProcess.id)).to.not.exist;
+    }));
+
+
+    it('should redo', inject(function(elementFactory, modeling, commandStack, canvas, bpmnjs) {
+
+      // given
+      var subProcess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+      modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      var diagrams = bpmnjs.getDefinitions().diagrams;
+      expect(diagrams.length).to.equal(2);
+      expect(canvas.getPlane(subProcess.id)).to.exist;
+    }));
+
+  });
+
+
+  describe('replace', function() {
+
+    describe('task -> collapsed subprocess', function() {
+
+      it('should add new diagram for collapsed subprocess', inject(
+        function(elementRegistry, bpmnReplace, bpmnjs, canvas) {
+
+          // given
+          var task = elementRegistry.get('Task_1'),
+              collapsedSubProcess;
+
+          // when
+          collapsedSubProcess = bpmnReplace.replaceElement(task, {
+            type: 'bpmn:SubProcess',
+            isExpanded: false
+          });
+
+          // then
+          var diagrams = bpmnjs.getDefinitions().diagrams;
+          expect(diagrams.length).to.equal(2);
+          expect(canvas.getPlane(collapsedSubProcess.id)).to.exist;
+        }
+      ));
+
+
+      it('should undo', inject(
+        function(elementRegistry, bpmnReplace, bpmnjs, canvas, commandStack) {
+
+          // given
+          var task = elementRegistry.get('Task_1'),
+              collapsedSubProcess = bpmnReplace.replaceElement(task, {
+                type: 'bpmn:SubProcess',
+                isExpanded: false
+              });
+
+          // when
+          commandStack.undo();
+
+
+          // then
+          var diagrams = bpmnjs.getDefinitions().diagrams;
+          expect(diagrams.length).to.equal(1);
+          expect(canvas.getPlane(collapsedSubProcess.id)).to.not.exist;
+        }
+      ));
+
+
+      it('should redo', inject(
+        function(elementRegistry, bpmnReplace, bpmnjs, canvas, commandStack) {
+
+          // given
+          var task = elementRegistry.get('Task_1'),
+              collapsedSubProcess = bpmnReplace.replaceElement(task, {
+                type: 'bpmn:SubProcess',
+                isExpanded: false
+              });
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          var diagrams = bpmnjs.getDefinitions().diagrams;
+          expect(diagrams.length).to.equal(2);
+          expect(canvas.getPlane(collapsedSubProcess.id)).to.exist;
+        }
+      ));
+    });
+
+    describe('task -> expanded subprocess', function() {
+
+      it('should not add new diagram for collapsed subprocess', inject(
+        function(elementRegistry, bpmnReplace, bpmnjs, canvas) {
+
+          // given
+          var task = elementRegistry.get('Task_1'),
+              collapsedSubProcess;
+
+          // when
+          collapsedSubProcess = bpmnReplace.replaceElement(task, {
+            type: 'bpmn:SubProcess',
+            isExpanded: true
+          });
+
+          // then
+          var diagrams = bpmnjs.getDefinitions().diagrams;
+          expect(diagrams.length).to.equal(1);
+          expect(canvas.getPlane(collapsedSubProcess.id)).to.not.exist;
+        }
+      ));
+
+    });
+
+  });
+
+});

--- a/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
@@ -85,6 +85,7 @@ describe('features/modeling/behavior - subprocess planes', function() {
         isExpanded: false
       });
       modeling.createShape(subProcess, { x: 300, y: 300 }, canvas.getRootElement());
+      var plane = canvas.getPlane(subProcess.id);
 
       // when
       commandStack.undo();
@@ -94,6 +95,7 @@ describe('features/modeling/behavior - subprocess planes', function() {
       var diagrams = bpmnjs.getDefinitions().diagrams;
       expect(diagrams.length).to.equal(2);
       expect(canvas.getPlane(subProcess.id)).to.exist;
+      expect(canvas.getPlane(subProcess.id)).to.equal(plane);
     }));
 
   });

--- a/test/spec/features/ordering/BpmnDiOrderingSpec.js
+++ b/test/spec/features/ordering/BpmnDiOrderingSpec.js
@@ -109,6 +109,33 @@ describe('features/modeling - di ordering', function() {
         task1.id,
       ]);
     });
+
+    it('should order subprocess planes', function() {
+
+      // given
+      var canvas = getBpmnJS().get('canvas'),
+          root;
+
+      // when
+      var subProcess = add(
+        { type: 'bpmn:SubProcess', isExpanded: false, width: 300, height: 200 }, { x: 300, y: 200 }
+      );
+
+      var participant = add({ type: 'bpmn:Participant', width: 500, height: 300 }, { x: 300, y: 200 }),
+          task1 = add({ type: 'bpmn:Task' }, { x: 250, y: 200 }, subProcess.id + '_plane');
+
+      root = canvas.getRootElement();
+
+      // then
+      // subProcess id exists twice: once as collapsed shape and once as plane element
+      return expectDiOrder([
+        root.id,
+        participant.id,
+        subProcess.id,
+        subProcess.id,
+        task1.id,
+      ]);
+    });
   });
 
 

--- a/test/spec/features/replace/BpmnReplace.collapsedSubProcess.bpmn
+++ b/test/spec/features/replace/BpmnReplace.collapsedSubProcess.bpmn
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:signavio="http://www.signavio.com" id="sid-edcb32b0-ba3c-4331-9874-58685c514c55" targetNamespace="http://www.signavio.com" expressionLanguage="http://www.w3.org/TR/XPath" exporter="Signavio Process Editor, http://www.signavio.com" exporterVersion="15.4.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <error id="sid-c4218475-d7d4-4ee6-ae73-5d44c49114b8" />
+  <process id="rootProcess" name="Root" processType="None" isClosed="false" isExecutable="false">
+    <startEvent id="sid-6687E2F4-B03D-4E57-A62B-68FA642BE19C">
+      <outgoing>sid-89A3F9F2-CCC8-46C7-816B-DD8AC8A98300</outgoing>
+    </startEvent>
+    <parallelGateway id="parallelGateway" gatewayDirection="Diverging">
+      <incoming>sid-89A3F9F2-CCC8-46C7-816B-DD8AC8A98300</incoming>
+      <outgoing>sid-F06605E1-AEC1-4B39-8843-4AD3F547B557</outgoing>
+      <outgoing>sid-FC2ECAF5-771E-4ED3-BEF6-EFAB45E79500</outgoing>
+    </parallelGateway>
+    <subProcess id="collapsedProcess" name="Collapsed Process">
+      <incoming>sid-F06605E1-AEC1-4B39-8843-4AD3F547B557</incoming>
+      <outgoing>sid-31F6EC44-E44C-4121-B4FE-BD69AF208C05</outgoing>
+      <startEvent id="sid-AB14D824-C8B9-4211-B224-C5AF8CED8BBD">
+        <outgoing>sid-EB275CF2-5EF1-44FA-B41B-71EB37CC2657</outgoing>
+      </startEvent>
+      <task id="sid-9E3BA75C-29DD-4DAC-8283-8FDE4E9A6724" name="Check Items">
+        <incoming>sid-EB275CF2-5EF1-44FA-B41B-71EB37CC2657</incoming>
+        <outgoing>sid-FB543319-8DFB-4445-AAA3-720137FB230B</outgoing>
+      </task>
+      <subProcess id="expandedProcess" name="Expanded Process">
+        <extensionElements>
+          <signavio:signavioMetaData metaKey="bgcolor" metaValue="#ffffff" />
+          <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+        </extensionElements>
+        <incoming>sid-FB543319-8DFB-4445-AAA3-720137FB230B</incoming>
+        <outgoing>sid-B99D259B-1BD5-45FF-BD57-FB99C360BAC0</outgoing>
+        <startEvent id="sid-3B0273A0-FE3B-4525-9E1F-FBAE2F53C2E7">
+          <outgoing>sid-472B540C-A0CD-46F4-9640-DF692EC1BFFC</outgoing>
+        </startEvent>
+        <subProcess id="collapsedProcess_2" name="Collapsed Process 2">
+          <incoming>sid-472B540C-A0CD-46F4-9640-DF692EC1BFFC</incoming>
+          <outgoing>sid-910420B0-D11B-4F9D-B285-703D8AC0BA90</outgoing>
+          <startEvent id="sid-C67DBACD-2E96-4A69-97F0-9B04CCB255EC">
+            <outgoing>sid-A7460113-CB75-491D-817B-5E1A8C606B8C</outgoing>
+          </startEvent>
+          <task id="sid-3459D5A6-4E18-4133-8362-0418AC9CE830" name="Call External Supplier">
+            <incoming>sid-A7460113-CB75-491D-817B-5E1A8C606B8C</incoming>
+            <outgoing>sid-01982395-64E8-43EF-A6D3-CDD276C312AA</outgoing>
+          </task>
+          <endEvent id="sid-987C40F8-82D3-4637-ABCE-A85A5E2AB8A9">
+            <incoming>sid-01982395-64E8-43EF-A6D3-CDD276C312AA</incoming>
+          </endEvent>
+          <sequenceFlow id="sid-A7460113-CB75-491D-817B-5E1A8C606B8C" sourceRef="sid-C67DBACD-2E96-4A69-97F0-9B04CCB255EC" targetRef="sid-3459D5A6-4E18-4133-8362-0418AC9CE830">
+          </sequenceFlow>
+          <sequenceFlow id="sid-01982395-64E8-43EF-A6D3-CDD276C312AA" sourceRef="sid-3459D5A6-4E18-4133-8362-0418AC9CE830" targetRef="sid-987C40F8-82D3-4637-ABCE-A85A5E2AB8A9">
+          </sequenceFlow>
+        </subProcess>
+        <endEvent id="sid-17C71FEB-D00D-46D0-ACBE-BB424A3EE5A5">
+          <incoming>sid-910420B0-D11B-4F9D-B285-703D8AC0BA90</incoming>
+        </endEvent>
+        <sequenceFlow id="sid-472B540C-A0CD-46F4-9640-DF692EC1BFFC" sourceRef="sid-3B0273A0-FE3B-4525-9E1F-FBAE2F53C2E7" targetRef="collapsedProcess_2">
+        </sequenceFlow>
+        <sequenceFlow id="sid-910420B0-D11B-4F9D-B285-703D8AC0BA90" sourceRef="collapsedProcess_2" targetRef="sid-17C71FEB-D00D-46D0-ACBE-BB424A3EE5A5">
+        </sequenceFlow>
+      </subProcess>
+      <endEvent id="sid-EE9F103D-15EA-4FBB-A4DB-8B94E5F04390">
+        <incoming>sid-B99D259B-1BD5-45FF-BD57-FB99C360BAC0</incoming>
+      </endEvent>
+      <sequenceFlow id="sid-EB275CF2-5EF1-44FA-B41B-71EB37CC2657" sourceRef="sid-AB14D824-C8B9-4211-B224-C5AF8CED8BBD" targetRef="sid-9E3BA75C-29DD-4DAC-8283-8FDE4E9A6724">
+      </sequenceFlow>
+      <sequenceFlow id="sid-FB543319-8DFB-4445-AAA3-720137FB230B" sourceRef="sid-9E3BA75C-29DD-4DAC-8283-8FDE4E9A6724" targetRef="expandedProcess">
+      </sequenceFlow>
+      <sequenceFlow id="sid-B99D259B-1BD5-45FF-BD57-FB99C360BAC0" sourceRef="expandedProcess" targetRef="sid-EE9F103D-15EA-4FBB-A4DB-8B94E5F04390">
+      </sequenceFlow>
+    </subProcess>
+    <subProcess id="SubProcess_Collapsed" name="SubProcess_Collapsed">
+      <incoming>sid-FC2ECAF5-771E-4ED3-BEF6-EFAB45E79500</incoming>
+      <outgoing>sid-5B23450F-AF5E-4519-B134-32107776BD44</outgoing>
+      <startEvent id="sid-A13CFBB9-5471-4439-96FA-B65862CA7B21">
+        <outgoing>sid-E71F5783-AFE7-44ED-8A9C-378C95087448</outgoing>
+      </startEvent>
+      <userTask id="UserTask" name="UserTask">
+        <incoming>sid-E71F5783-AFE7-44ED-8A9C-378C95087448</incoming>
+        <outgoing>sid-6B9741CD-D94B-41C7-A2EA-63A4C9445E16</outgoing>
+      </userTask>
+      <subProcess id="NestedCollapsed_SubProcess" name="NestedCollapse_SubProcess">
+        <incoming>sid-6B9741CD-D94B-41C7-A2EA-63A4C9445E16</incoming>
+        <outgoing>sid-1A9DABC6-6079-4BF2-9D49-C4DC9569C519</outgoing>
+        <startEvent id="sid-2098A7EE-D7D8-405E-AF61-95BA48E891B6">
+          <outgoing>sid-E5404926-738D-4447-87FE-FC6DD1E8BEFC</outgoing>
+        </startEvent>
+        <task id="sid-E21C867A-7A56-46DD-9A1E-94C02FDB18FB" name="NestedCollapse_SubProcess">
+          <incoming>sid-E5404926-738D-4447-87FE-FC6DD1E8BEFC</incoming>
+          <outgoing>sid-FED62A8F-6C3A-4BB2-8DE9-18FB0B35B50E</outgoing>
+        </task>
+        <endEvent id="sid-DAFD7764-8FA5-417B-BB33-55E483687A7D">
+          <incoming>sid-FED62A8F-6C3A-4BB2-8DE9-18FB0B35B50E</incoming>
+        </endEvent>
+        <sequenceFlow id="sid-E5404926-738D-4447-87FE-FC6DD1E8BEFC" sourceRef="sid-2098A7EE-D7D8-405E-AF61-95BA48E891B6" targetRef="sid-E21C867A-7A56-46DD-9A1E-94C02FDB18FB">
+        </sequenceFlow>
+        <sequenceFlow id="sid-FED62A8F-6C3A-4BB2-8DE9-18FB0B35B50E" sourceRef="sid-E21C867A-7A56-46DD-9A1E-94C02FDB18FB" targetRef="sid-DAFD7764-8FA5-417B-BB33-55E483687A7D">
+        </sequenceFlow>
+      </subProcess>
+      <endEvent id="sid-345BB5A6-CE3B-4711-972A-81E47BA4B667">
+        <incoming>sid-1A9DABC6-6079-4BF2-9D49-C4DC9569C519</incoming>
+      </endEvent>
+      <sequenceFlow id="sid-E71F5783-AFE7-44ED-8A9C-378C95087448" sourceRef="sid-A13CFBB9-5471-4439-96FA-B65862CA7B21" targetRef="UserTask">
+        <extensionElements>
+          <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+        </extensionElements>
+      </sequenceFlow>
+      <sequenceFlow id="sid-6B9741CD-D94B-41C7-A2EA-63A4C9445E16" sourceRef="UserTask" targetRef="NestedCollapsed_SubProcess">
+        <extensionElements>
+          <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+        </extensionElements>
+      </sequenceFlow>
+      <sequenceFlow id="sid-1A9DABC6-6079-4BF2-9D49-C4DC9569C519" sourceRef="NestedCollapsed_SubProcess" targetRef="sid-345BB5A6-CE3B-4711-972A-81E47BA4B667">
+      </sequenceFlow>
+    </subProcess>
+    <parallelGateway id="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B" gatewayDirection="Converging">
+      <incoming>sid-5B23450F-AF5E-4519-B134-32107776BD44</incoming>
+      <incoming>sid-31F6EC44-E44C-4121-B4FE-BD69AF208C05</incoming>
+      <outgoing>sid-F7DA1903-6A1A-4858-AF4B-286A968C957F</outgoing>
+    </parallelGateway>
+    <boundaryEvent id="sid-C586DCF2-0B1B-4878-8042-F9869023F21B" attachedToRef="SubProcess_Collapsed">
+      <outgoing>sid-DCB98638-BEBD-4548-B501-F0E29AC71ED4</outgoing>
+      <errorEventDefinition id="sid-804c8ce9-8013-49e6-a6f5-bf97d24f6cf0" errorRef="sid-c4218475-d7d4-4ee6-ae73-5d44c49114b8" />
+    </boundaryEvent>
+    <endEvent id="sid-A53C38A9-456B-4AC9-9D4A-6EC9663BA77C">
+      <incoming>sid-DCB98638-BEBD-4548-B501-F0E29AC71ED4</incoming>
+    </endEvent>
+    <subProcess id="parallelGateway_withoutContent" name="Ship Items (todo)">
+      <incoming>sid-F7DA1903-6A1A-4858-AF4B-286A968C957F</incoming>
+      <outgoing>sid-3FAE72F2-4037-4CBA-8B89-01D7FC7FF3E3</outgoing>
+    </subProcess>
+    <endEvent id="sid-DA90DE99-58B0-4371-B71D-87A718ACB64D">
+      <incoming>sid-3FAE72F2-4037-4CBA-8B89-01D7FC7FF3E3</incoming>
+    </endEvent>
+    <sequenceFlow id="sid-89A3F9F2-CCC8-46C7-816B-DD8AC8A98300" sourceRef="sid-6687E2F4-B03D-4E57-A62B-68FA642BE19C" targetRef="parallelGateway">
+    </sequenceFlow>
+    <sequenceFlow id="sid-F06605E1-AEC1-4B39-8843-4AD3F547B557" sourceRef="parallelGateway" targetRef="collapsedProcess">
+    </sequenceFlow>
+    <sequenceFlow id="sid-FC2ECAF5-771E-4ED3-BEF6-EFAB45E79500" sourceRef="parallelGateway" targetRef="SubProcess_Collapsed">
+    </sequenceFlow>
+    <sequenceFlow id="sid-5B23450F-AF5E-4519-B134-32107776BD44" sourceRef="SubProcess_Collapsed" targetRef="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B">
+    </sequenceFlow>
+    <sequenceFlow id="sid-31F6EC44-E44C-4121-B4FE-BD69AF208C05" sourceRef="collapsedProcess" targetRef="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B">
+    </sequenceFlow>
+    <sequenceFlow id="sid-DCB98638-BEBD-4548-B501-F0E29AC71ED4" sourceRef="sid-C586DCF2-0B1B-4878-8042-F9869023F21B" targetRef="sid-A53C38A9-456B-4AC9-9D4A-6EC9663BA77C">
+    </sequenceFlow>
+    <sequenceFlow id="sid-F7DA1903-6A1A-4858-AF4B-286A968C957F" sourceRef="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B" targetRef="parallelGateway_withoutContent">
+    </sequenceFlow>
+    <sequenceFlow id="sid-3FAE72F2-4037-4CBA-8B89-01D7FC7FF3E3" sourceRef="parallelGateway_withoutContent" targetRef="sid-DA90DE99-58B0-4371-B71D-87A718ACB64D">
+    </sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="sid-cbeafa41-c891-415c-ab0d-3eb4a233f9ed">
+    <bpmndi:BPMNPlane id="sid-5fb4720f-4b99-4727-8770-dd4166bcd5e4" bpmnElement="rootProcess">
+      <bpmndi:BPMNEdge id="sid-3FAE72F2-4037-4CBA-8B89-01D7FC7FF3E3_gui" bpmnElement="sid-3FAE72F2-4037-4CBA-8B89-01D7FC7FF3E3">
+        <omgdi:waypoint x="675" y="215" />
+        <omgdi:waypoint x="720" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-F7DA1903-6A1A-4858-AF4B-286A968C957F_gui" bpmnElement="sid-F7DA1903-6A1A-4858-AF4B-286A968C957F">
+        <omgdi:waypoint x="530" y="215.41484716157206" />
+        <omgdi:waypoint x="575" y="215.2183406113537" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-DCB98638-BEBD-4548-B501-F0E29AC71ED4_gui" bpmnElement="sid-DCB98638-BEBD-4548-B501-F0E29AC71ED4">
+        <omgdi:waypoint x="420" y="370" />
+        <omgdi:waypoint x="420" y="427.89053746720595" />
+        <omgdi:waypoint x="515" y="428" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-31F6EC44-E44C-4121-B4FE-BD69AF208C05_gui" bpmnElement="sid-31F6EC44-E44C-4121-B4FE-BD69AF208C05">
+        <omgdi:waypoint x="445" y="110" />
+        <omgdi:waypoint x="510.5" y="110" />
+        <omgdi:waypoint x="510.5" y="195" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-5B23450F-AF5E-4519-B134-32107776BD44_gui" bpmnElement="sid-5B23450F-AF5E-4519-B134-32107776BD44">
+        <omgdi:waypoint x="445" y="315" />
+        <omgdi:waypoint x="510.5" y="315" />
+        <omgdi:waypoint x="510.5" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-FC2ECAF5-771E-4ED3-BEF6-EFAB45E79500_gui" bpmnElement="sid-FC2ECAF5-771E-4ED3-BEF6-EFAB45E79500">
+        <omgdi:waypoint x="255.5" y="235" />
+        <omgdi:waypoint x="255.5" y="315" />
+        <omgdi:waypoint x="345" y="315" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-F06605E1-AEC1-4B39-8843-4AD3F547B557_gui" bpmnElement="sid-F06605E1-AEC1-4B39-8843-4AD3F547B557">
+        <omgdi:waypoint x="255.5" y="195" />
+        <omgdi:waypoint x="255.5" y="110" />
+        <omgdi:waypoint x="345" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-89A3F9F2-CCC8-46C7-816B-DD8AC8A98300_gui" bpmnElement="sid-89A3F9F2-CCC8-46C7-816B-DD8AC8A98300">
+        <omgdi:waypoint x="190" y="215.09316770186336" />
+        <omgdi:waypoint x="235" y="215.37267080745343" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="sid-6687E2F4-B03D-4E57-A62B-68FA642BE19C_gui" bpmnElement="sid-6687E2F4-B03D-4E57-A62B-68FA642BE19C">
+        <omgdc:Bounds x="160" y="200" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallelGateway_gui" bpmnElement="parallelGateway">
+        <omgdc:Bounds x="235" y="195" width="40" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="collapsedProcess_gui" bpmnElement="collapsedProcess" isExpanded="false">
+        <omgdc:Bounds x="345" y="70" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-c53530f5-9da8-4535-ae6d-c94859ea5b93">
+          <omgdc:Bounds x="352.99214363098145" y="102" width="84.08571243286133" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ProcurePayment_gui" bpmnElement="SubProcess_Collapsed" isExpanded="false">
+        <omgdc:Bounds x="345" y="275" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-c53530f5-9da8-4535-ae6d-c94859ea5b93">
+          <omgdc:Bounds x="349.520715713501" y="307" width="91.02856826782227" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B_gui" bpmnElement="sid-7412307A-1A0F-43BA-933B-6E84157B4E5B">
+        <omgdc:Bounds x="490" y="195" width="40" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-A53C38A9-456B-4AC9-9D4A-6EC9663BA77C_gui" bpmnElement="sid-A53C38A9-456B-4AC9-9D4A-6EC9663BA77C">
+        <omgdc:Bounds x="515" y="413.89053746720595" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="parallelGateway_withoutContent_gui" bpmnElement="parallelGateway_withoutContent" isExpanded="false">
+        <omgdc:Bounds x="575" y="175" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-c53530f5-9da8-4535-ae6d-c94859ea5b93">
+          <omgdc:Bounds x="595.7207126617432" y="201" width="58.62857437133789" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-DA90DE99-58B0-4371-B71D-87A718ACB64D_gui" bpmnElement="sid-DA90DE99-58B0-4371-B71D-87A718ACB64D">
+        <omgdc:Bounds x="720" y="201" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-C586DCF2-0B1B-4878-8042-F9869023F21B_gui" bpmnElement="sid-C586DCF2-0B1B-4878-8042-F9869023F21B">
+        <omgdc:Bounds x="405" y="340" width="30" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="sid-c53530f5-9da8-4535-ae6d-c94859ea5b93">
+      <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="sid-99a6a759-9161-4f4a-a83d-9ad6b9fbdc7e">
+    <bpmndi:BPMNPlane id="sid-62501c88-ba6c-44ea-90f1-3ccf6a7cea2f" bpmnElement="collapsedProcess">
+      <bpmndi:BPMNShape id="sid-AB14D824-C8B9-4211-B224-C5AF8CED8BBD_gui" bpmnElement="sid-AB14D824-C8B9-4211-B224-C5AF8CED8BBD">
+        <omgdc:Bounds x="150" y="140" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-9E3BA75C-29DD-4DAC-8283-8FDE4E9A6724_gui" bpmnElement="sid-9E3BA75C-29DD-4DAC-8283-8FDE4E9A6724">
+        <omgdc:Bounds x="225" y="115" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-592ddc98-48fc-42b3-b7f9-1df8b6d368c5">
+          <omgdc:Bounds x="241.44285583496094" y="147" width="67.11428833007812" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-3B0273A0-FE3B-4525-9E1F-FBAE2F53C2E7_gui" bpmnElement="sid-3B0273A0-FE3B-4525-9E1F-FBAE2F53C2E7">
+        <omgdc:Bounds x="390" y="140" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="collapsedProcess_2_gui" bpmnElement="collapsedProcess_2" isExpanded="false">
+        <omgdc:Bounds x="465" y="115" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-592ddc98-48fc-42b3-b7f9-1df8b6d368c5">
+          <omgdc:Bounds x="481.4778537750244" y="141" width="67.11429214477539" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-17C71FEB-D00D-46D0-ACBE-BB424A3EE5A5_gui" bpmnElement="sid-17C71FEB-D00D-46D0-ACBE-BB424A3EE5A5">
+        <omgdc:Bounds x="610" y="141" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sid-472B540C-A0CD-46F4-9640-DF692EC1BFFC_gui" bpmnElement="sid-472B540C-A0CD-46F4-9640-DF692EC1BFFC">
+        <omgdi:waypoint x="420" y="155" />
+        <omgdi:waypoint x="465" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-910420B0-D11B-4F9D-B285-703D8AC0BA90_gui" bpmnElement="sid-910420B0-D11B-4F9D-B285-703D8AC0BA90">
+        <omgdi:waypoint x="565" y="155" />
+        <omgdi:waypoint x="610" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="expandedProcess_gui" bpmnElement="expandedProcess" isExpanded="true">
+        <omgdc:Bounds x="370" y="79" width="288" height="151" />
+        <bpmndi:BPMNLabel labelStyle="sid-592ddc98-48fc-42b3-b7f9-1df8b6d368c5">
+          <omgdc:Bounds x="378" y="89" width="65.57142639160156" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-EE9F103D-15EA-4FBB-A4DB-8B94E5F04390_gui" bpmnElement="sid-EE9F103D-15EA-4FBB-A4DB-8B94E5F04390">
+        <omgdc:Bounds x="703" y="141" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sid-EB275CF2-5EF1-44FA-B41B-71EB37CC2657_gui" bpmnElement="sid-EB275CF2-5EF1-44FA-B41B-71EB37CC2657">
+        <omgdi:waypoint x="180" y="155" />
+        <omgdi:waypoint x="225" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-FB543319-8DFB-4445-AAA3-720137FB230B_gui" bpmnElement="sid-FB543319-8DFB-4445-AAA3-720137FB230B">
+        <omgdi:waypoint x="325" y="154.89539748953976" />
+        <omgdi:waypoint x="370" y="154.80125523012552" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-B99D259B-1BD5-45FF-BD57-FB99C360BAC0_gui" bpmnElement="sid-B99D259B-1BD5-45FF-BD57-FB99C360BAC0">
+        <omgdi:waypoint x="658" y="154.85467980295567" />
+        <omgdi:waypoint x="703" y="154.9655172413793" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="sid-592ddc98-48fc-42b3-b7f9-1df8b6d368c5">
+      <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="sid-0bbc44a9-8a6a-44a1-8b61-0cf870c26fe4">
+    <bpmndi:BPMNPlane id="sid-275fa3fd-9114-4005-b305-71f6c1411c24" bpmnElement="collapsedProcess_2">
+      <bpmndi:BPMNShape id="sid-C67DBACD-2E96-4A69-97F0-9B04CCB255EC_gui" bpmnElement="sid-C67DBACD-2E96-4A69-97F0-9B04CCB255EC">
+        <omgdc:Bounds x="230" y="130" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-3459D5A6-4E18-4133-8362-0418AC9CE830_gui" bpmnElement="sid-3459D5A6-4E18-4133-8362-0418AC9CE830">
+        <omgdc:Bounds x="305" y="105" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-efc2a4e3-a5c6-411d-80d4-64f3a53bc4a4">
+          <omgdc:Bounds x="321.44285583496094" y="131" width="67.11428833007812" height="24" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-987C40F8-82D3-4637-ABCE-A85A5E2AB8A9_gui" bpmnElement="sid-987C40F8-82D3-4637-ABCE-A85A5E2AB8A9">
+        <omgdc:Bounds x="450" y="131" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sid-A7460113-CB75-491D-817B-5E1A8C606B8C_gui" bpmnElement="sid-A7460113-CB75-491D-817B-5E1A8C606B8C">
+        <omgdi:waypoint x="260" y="145" />
+        <omgdi:waypoint x="305" y="145" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-01982395-64E8-43EF-A6D3-CDD276C312AA_gui" bpmnElement="sid-01982395-64E8-43EF-A6D3-CDD276C312AA">
+        <omgdi:waypoint x="405" y="145" />
+        <omgdi:waypoint x="450" y="145" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="sid-efc2a4e3-a5c6-411d-80d4-64f3a53bc4a4">
+      <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="sid-19b0e874-234e-4bee-b83c-068fe088c591">
+    <bpmndi:BPMNPlane id="sid-89d69f37-848f-4da3-bb9a-df3a9889286d" bpmnElement="SubProcess_Collapsed">
+      <bpmndi:BPMNShape id="sid-A13CFBB9-5471-4439-96FA-B65862CA7B21_gui" bpmnElement="sid-A13CFBB9-5471-4439-96FA-B65862CA7B21">
+        <omgdc:Bounds x="190" y="170" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_gui" bpmnElement="UserTask" isExpanded="false">
+        <omgdc:Bounds x="265" y="145" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-3bb65e49-bd30-45eb-a52f-e94a5e93edbc">
+          <omgdc:Bounds x="281.09214210510254" y="177" width="67.88571548461914" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NestedCollapsed_SubProcess_gui" bpmnElement="NestedCollapsed_SubProcess" isExpanded="false">
+        <omgdc:Bounds x="410" y="145" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-3bb65e49-bd30-45eb-a52f-e94a5e93edbc">
+          <omgdc:Bounds x="424.5492877960205" y="165" width="70.9714241027832" height="36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-345BB5A6-CE3B-4711-972A-81E47BA4B667_gui" bpmnElement="sid-345BB5A6-CE3B-4711-972A-81E47BA4B667">
+        <omgdc:Bounds x="555" y="171" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sid-E71F5783-AFE7-44ED-8A9C-378C95087448_gui" bpmnElement="sid-E71F5783-AFE7-44ED-8A9C-378C95087448">
+        <omgdi:waypoint x="220" y="185" />
+        <omgdi:waypoint x="265" y="185" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-6B9741CD-D94B-41C7-A2EA-63A4C9445E16_gui" bpmnElement="sid-6B9741CD-D94B-41C7-A2EA-63A4C9445E16">
+        <omgdi:waypoint x="365" y="185" />
+        <omgdi:waypoint x="410" y="185" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-1A9DABC6-6079-4BF2-9D49-C4DC9569C519_gui" bpmnElement="sid-1A9DABC6-6079-4BF2-9D49-C4DC9569C519">
+        <omgdi:waypoint x="510" y="185" />
+        <omgdi:waypoint x="555" y="185" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="sid-3bb65e49-bd30-45eb-a52f-e94a5e93edbc">
+      <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="sid-63fc7b22-cc85-458f-aaab-e165a0e36240">
+    <bpmndi:BPMNPlane id="sid-3f3c0ecd-73e0-4a0a-b05c-0b6bd60eeeb1" bpmnElement="NestedCollapsed_SubProcess">
+      <bpmndi:BPMNShape id="sid-2098A7EE-D7D8-405E-AF61-95BA48E891B6_gui" bpmnElement="sid-2098A7EE-D7D8-405E-AF61-95BA48E891B6">
+        <omgdc:Bounds x="240" y="250" width="30" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-E21C867A-7A56-46DD-9A1E-94C02FDB18FB_gui" bpmnElement="sid-E21C867A-7A56-46DD-9A1E-94C02FDB18FB">
+        <omgdc:Bounds x="315" y="225" width="100" height="80" />
+        <bpmndi:BPMNLabel labelStyle="sid-d93ac8fb-7a66-4ace-93a6-71582a8ab1a1">
+          <omgdc:Bounds x="329.51428604125977" y="245" width="70.97142791748047" height="36" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sid-DAFD7764-8FA5-417B-BB33-55E483687A7D_gui" bpmnElement="sid-DAFD7764-8FA5-417B-BB33-55E483687A7D">
+        <omgdc:Bounds x="460" y="251" width="28" height="28" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sid-E5404926-738D-4447-87FE-FC6DD1E8BEFC_gui" bpmnElement="sid-E5404926-738D-4447-87FE-FC6DD1E8BEFC">
+        <omgdi:waypoint x="270" y="265" />
+        <omgdi:waypoint x="315" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sid-FED62A8F-6C3A-4BB2-8DE9-18FB0B35B50E_gui" bpmnElement="sid-FED62A8F-6C3A-4BB2-8DE9-18FB0B35B50E">
+        <omgdi:waypoint x="415" y="265" />
+        <omgdi:waypoint x="460" y="265" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="sid-d93ac8fb-7a66-4ace-93a6-71582a8ab1a1">
+      <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -311,6 +311,81 @@ describe('features/replace - bpmn replace', function() {
   });
 
 
+  describe('should replace in sub-process (collapsed)', function() {
+
+    var diagramXML = require('./BpmnReplace.collapsedSubProcess.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules,
+      moddleExtensions: {
+        camunda: camundaPackage
+      }
+    }));
+
+
+    beforeEach(inject(function(canvas) {
+      canvas.setActivePlane('SubProcess_Collapsed');
+    }));
+
+
+    it('task', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var task = elementRegistry.get('UserTask');
+      var newElementData = {
+        type: 'bpmn:ServiceTask'
+      };
+
+      // when
+      var newElement = bpmnReplace.replaceElement(task, newElementData);
+
+      // then
+      var businessObject = newElement.businessObject;
+
+      expect(newElement).to.exist;
+      expect(is(businessObject, 'bpmn:ServiceTask')).to.be.true;
+    }));
+
+
+    it('task with collapsed sub-process', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var task = elementRegistry.get('UserTask');
+      var newElementData = {
+        type: 'bpmn:SubProcess'
+      };
+
+      // when
+      var newElement = bpmnReplace.replaceElement(task, newElementData);
+
+      // then
+      var businessObject = newElement.businessObject;
+
+      expect(newElement).to.exist;
+      expect(is(businessObject, 'bpmn:SubProcess')).to.be.true;
+    }));
+
+
+    it('collapsed sub-process with task', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var task = elementRegistry.get('NestedCollapsed_SubProcess');
+      var newElementData = {
+        type: 'bpmn:Task'
+      };
+
+      // when
+      var newElement = bpmnReplace.replaceElement(task, newElementData);
+
+      // then
+      var businessObject = newElement.businessObject;
+
+      expect(newElement).to.exist;
+      expect(is(businessObject, 'bpmn:Task')).to.be.true;
+    }));
+  });
+
+
   describe('should replace in collaboration', function() {
 
     var diagramXML = require('./BpmnReplace.collaboration.bpmn');


### PR DESCRIPTION
**Collapsed subprocesses now always have a connected diPlane, even when it is empty**

- Create a new Plane for created processes
- attach drilldown overlay
- Update drilldown CSS according to content of the plane
- ensure this also applies to legacy processes


Depends on diagram-js update

---

Closes https://github.com/bpmn-io/bpmn-js/issues/1536