### PR TITLE
fix(modeling): set label color on `bpmndi:BPMNLabel#color`

### DIFF
--- a/lib/features/modeling/cmd/SetColorHandler.js
+++ b/lib/features/modeling/cmd/SetColorHandler.js
@@ -63,12 +63,26 @@ SetColorHandler.prototype.postExecute = function(context) {
     // TODO @barmac: remove once we drop bpmn.io properties
     ensureLegacySupport(assignedDi);
 
-    self._commandStack.execute('element.updateProperties', {
-      element: element,
-      properties: {
-        di: assignedDi
-      }
-    });
+    if (element.labelTarget) {
+
+      // set label colors as bpmndi:BPMNLabel#color
+      self._commandStack.execute('element.updateModdleProperties', {
+        element: element,
+        moddleElement: element.di.label,
+        properties: {
+          color: di['background-color']
+        }
+      });
+    } else {
+
+      // set colors bpmndi:BPMNEdge or bpmndi:BPMNShape
+      self._commandStack.execute('element.updateProperties', {
+        element: element,
+        properties: {
+          di: assignedDi
+        }
+      });
+    }
   });
 
 };

--- a/test/spec/features/modeling/SetColor.bpmn
+++ b/test/spec/features/modeling/SetColor.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="simple" exporter="camunda modeler" exporterVersion="2.6.0" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn2:process id="Process_1" isExecutable="false">
+    <bpmn2:subProcess id="SubProcess_1" name="Sub Process 1">
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:startEvent id="StartEvent_1" name="Start Event 1">
+        <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      </bpmn2:startEvent>
+      <bpmn2:task id="Task_1" name="Task">
+        <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      </bpmn2:task>
+      <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="StartEvent_1" targetRef="Task_1"/>
+    </bpmn2:subProcess>
+    <bpmn2:endEvent id="EndEvent_1" name="End Event">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="SubProcess_1" targetRef="EndEvent_1"/>
+    <bpmn2:startEvent id="StartEvent_2" name="Start">
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" name="Flow" sourceRef="StartEvent_2" targetRef="SubProcess_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_2" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds height="300.0" width="300.0" x="300.0" y="80.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="352.0" y="242.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_Task_2" bpmnElement="Task_1">
+        <dc:Bounds height="80.0" width="100.0" x="420.0" y="220.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_StartEvent_2" targetElement="_BPMNShape_Task_2">
+        <di:waypoint xsi:type="dc:Point" x="388.0" y="260.0"/>
+        <di:waypoint xsi:type="dc:Point" x="420.0" y="260.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="650.0" y="212.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_BPMNShape_SubProcess_2" targetElement="_BPMNShape_EndEvent_2">
+        <di:waypoint xsi:type="dc:Point" x="600.0" y="230.0"/>
+        <di:waypoint xsi:type="dc:Point" x="650.0" y="230.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_11" bpmnElement="StartEvent_2">
+        <dc:Bounds height="36.0" width="36.0" x="108.0" y="212.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="0.0" width="0.0" x="126.0" y="253.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_StartEvent_11" targetElement="_BPMNShape_SubProcess_2">
+        <di:waypoint xsi:type="dc:Point" x="144.0" y="230.0"/>
+        <di:waypoint xsi:type="dc:Point" x="300.0" y="230.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="21.0" width="33.0" x="192.0" y="204.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/test/spec/features/modeling/SetColorSpec.js
+++ b/test/spec/features/modeling/SetColorSpec.js
@@ -11,9 +11,10 @@ import coreModule from 'lib/core';
 var FUCHSIA_HEX = '#ff00ff',
     YELLOW_HEX = '#ffff00';
 
+
 describe('features/modeling - set color', function() {
 
-  var diagramXML = require('../../../fixtures/bpmn/simple.bpmn');
+  var diagramXML = require('./SetColor.bpmn');
 
   beforeEach(bootstrapModeler(diagramXML, {
     modules: [
@@ -136,6 +137,46 @@ describe('features/modeling - set color', function() {
       // then
       expect(taskDi.get('border-color')).not.to.exist;
       expect(taskDi.get('background-color')).not.to.exist;
+    }));
+
+
+
+    it('setting stroke + fill color on external label', inject(function(elementRegistry, modeling) {
+
+      // given
+      var flowShape = elementRegistry.get('SequenceFlow_3'),
+          flowLabel = flowShape.label,
+          flowDi = getDi(flowShape);
+
+      // when
+      modeling.setColor(flowLabel, { stroke: 'FUCHSIA', fill: 'FUCHSIA' });
+
+      // then
+      expect(flowDi.get('border-color')).not.to.exist;
+      expect(flowDi.get('background-color')).not.to.exist;
+
+      expect(flowDi.label.get('color')).to.eql(FUCHSIA_HEX);
+    }));
+
+
+    it('unsetting stroke + fill color on external label', inject(function(elementRegistry, modeling) {
+
+      // given
+      var flowShape = elementRegistry.get('SequenceFlow_3'),
+          flowLabel = flowShape.label,
+          flowDi = getDi(flowShape);
+
+      // assume
+      modeling.setColor(flowLabel, { stroke: 'FUCHSIA', fill: 'FUCHSIA' });
+
+      // when
+      modeling.setColor(flowLabel, { stroke: undefined, fill: undefined });
+
+      // then
+      expect(flowDi.get('border-color')).not.to.exist;
+      expect(flowDi.get('background-color')).not.to.exist;
+
+      expect(flowDi.label.get('color')).not.to.exist;
     }));
 
 
@@ -637,5 +678,7 @@ describe('features/modeling - set color', function() {
         expect(sequenceFlowDi.get('stroke')).to.eql('#abcdef');
       }
     ));
+
   });
+
 });


### PR DESCRIPTION
Setting colors on external labels would not set the `bpmndi:BPMNLabel#color` property but rather serialize it illegally as `bpmndi:BPMNEdge#background-color`. This PR fixes the behavior to adopt the standards compliant serialization.

Note that we already support reading color in the correct way, cf. `BpmnRenderer`.

---

Related to https://github.com/camunda/camunda-modeler/issues/2599.