### PR TITLE
feat(modeling): don't select start-event inside newly created sub-process

### DIFF
--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -90,7 +90,7 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
 
     create.start(event, [ subProcess, startEvent ], {
       hints: {
-        autoSelect: [ startEvent ]
+        autoSelect: [ subProcess ]
       }
     });
   }

--- a/test/spec/features/palette/PaletteProviderSpec.js
+++ b/test/spec/features/palette/PaletteProviderSpec.js
@@ -65,7 +65,7 @@ describe('features/palette', function() {
     }));
 
 
-    it('should select start event', inject(function(canvas, dragging, selection) {
+    it('should select sub-process', inject(function(canvas, dragging, selection) {
 
       // given
       var rootElement = canvas.getRootElement(),
@@ -82,8 +82,10 @@ describe('features/palette', function() {
       dragging.end();
 
       // then
-      expect(selection.get()).to.have.length(1);
-      expect(is(selection.get()[0], 'bpmn:StartEvent')).to.be.true;
+      var selected = selection.get();
+
+      expect(selected).to.have.length(1);
+      expect(is(selected[0], 'bpmn:SubProcess')).to.be.true;
     }));
 
   });


### PR DESCRIPTION
The canonical modeling operation shall not be drill down, but continue to model.

![capture 4a9kuq_optimized](https://user-images.githubusercontent.com/58601/145111664-b0265f7c-3be9-4363-854f-4b11a427e27d.gif)