### PR TITLE
feat(modeling): do not activate direct editing on newly created group

### DIFF
--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -105,7 +105,7 @@ export default function LabelEditingProvider(
 
   function activateDirectEdit(element, force) {
     if (force ||
-        isAny(element, [ 'bpmn:Task', 'bpmn:TextAnnotation', 'bpmn:Group' ]) ||
+        isAny(element, [ 'bpmn:Task', 'bpmn:TextAnnotation' ]) ||
         isCollapsedSubProcess(element)) {
 
       directEditing.activate(element);

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -492,6 +492,7 @@ describe('features - label-editing', function() {
       canvas: { deferUpdate: false }
     }));
 
+
     it('should initialize categoryValue for empty group', inject(
       function(elementRegistry, directEditing) {
 


### PR DESCRIPTION
The first canonical operation is to resize the group to the respective size, not to assign a group label.

![capture jxOJwQ_optimized](https://user-images.githubusercontent.com/58601/145111855-cad72d7b-9c74-459f-88a8-5bce5b323608.gif)


---

Note to reviewer: In an ideal world, group creation would be implemented similar to the lasso tool. I still believe this is a substantial improvement.