### PR TITLE
fix(bpmnReplace): ensure `collapsed` is set before replacing

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -117,6 +117,10 @@ ElementFactory.prototype.createBpmnElement = function(elementType, attrs) {
     applyAttribute(di, attrs, 'isExpanded');
   }
 
+  if (is(businessObject, 'bpmn:SubProcess')) {
+    attrs.collapsed = !isExpanded(businessObject, di);
+  }
+
   if (is(businessObject, 'bpmn:ExclusiveGateway')) {
     di.isMarkerVisible = true;
   }

--- a/test/spec/features/modeling/ElementFactorySpec.js
+++ b/test/spec/features/modeling/ElementFactorySpec.js
@@ -116,6 +116,19 @@ describe('features - element factory', function() {
     }));
 
 
+    it('should add collapsed attribute to subprocess', inject(function(elementFactory) {
+
+      // when
+      var subprocess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+
+      // then
+      expect(subprocess.collapsed).to.be.true;
+    }));
+
+
     describe('integration', function() {
 
       it('should create event definition with ID', inject(function(elementFactory) {

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -1027,6 +1027,30 @@ describe('features/replace - bpmn replace', function() {
     );
 
 
+    it('should allow expanding newly created subprocess',
+      inject(function(bpmnReplace, elementFactory) {
+
+        // given
+        var collapsedProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: false
+        });
+
+        var newElementData = {
+          type: 'bpmn:SubProcess',
+          isExpanded: true
+        };
+
+        // when
+        var newElement = bpmnReplace.replaceElement(collapsedProcess, newElementData);
+
+        // then
+        expect(is(newElement, 'bpmn:SubProcess')).to.be.true;
+        expect(isExpanded(newElement)).to.be.true;
+      })
+    );
+
+
     it('should keep size when morphing ad hoc',
       inject(function(bpmnReplace, elementRegistry, modeling) {
 


### PR DESCRIPTION
With the refactoring in e1efb556f2cb7cfb92a2361b9dfa0ea96dbadebd, we broke the following scenario:

- Create a collapsed subprocess
- Try to expand it

We need to ensure the `collapsed` property is set before expanding/collapsing the shape.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
