### PR TITLE
fix(drilldown): don't reset vieport on `makeCollaboration`

### DIFF
--- a/lib/features/drilldown/DrilldownCentering.js
+++ b/lib/features/drilldown/DrilldownCentering.js
@@ -14,7 +14,9 @@ export default function DrilldownCentering(eventBus, canvas) {
   var positionMap = new Map();
 
   eventBus.on('root.set', function(event) {
+    var newRoot = event.element;
     var currentViewbox = canvas.viewbox();
+    var storedViewbox = positionMap.get(newRoot);
 
     positionMap.set(currentRoot, {
       x: currentViewbox.x,
@@ -22,8 +24,7 @@ export default function DrilldownCentering(eventBus, canvas) {
       zoom: currentViewbox.scale
     });
 
-    var newRoot = event.element;
-    var storedViewbox = positionMap.get(newRoot);
+    currentRoot = newRoot;
 
     // current root was replaced with a collaboration, we don't update the viewbox
     if (is(newRoot, 'bpmn:Collaboration') && !storedViewbox) {
@@ -45,12 +46,6 @@ export default function DrilldownCentering(eventBus, canvas) {
     if (storedViewbox.zoom !== currentViewbox.scale) {
       canvas.zoom(storedViewbox.zoom, { x: 0, y: 0 });
     }
-
-    currentRoot = newRoot;
-  });
-
-  eventBus.on('root.remove', function(event) {
-    positionMap.remove(event.element);
   });
 
   eventBus.on('diagram.clear', function() {

--- a/lib/features/drilldown/DrilldownCentering.js
+++ b/lib/features/drilldown/DrilldownCentering.js
@@ -1,3 +1,5 @@
+import { is } from '../../util/ModelUtil';
+
 /**
  * Move collapsed subprocesses into view when drilling down.
  *
@@ -21,7 +23,14 @@ export default function DrilldownCentering(eventBus, canvas) {
     });
 
     var newRoot = event.element;
-    var storedViewbox = positionMap.get(newRoot) || { x: 0, y: 0, zoom: 1 };
+    var storedViewbox = positionMap.get(newRoot);
+
+    // current root was replaced with a collaboration, we don't update the viewbox
+    if (is(newRoot, 'bpmn:Collaboration') && !storedViewbox) {
+      return;
+    }
+
+    storedViewbox = storedViewbox || { x: 0, y: 0, zoom: 1 };
 
     var dx = (currentViewbox.x - storedViewbox.x) * currentViewbox.scale,
         dy = (currentViewbox.y - storedViewbox.y) * currentViewbox.scale;

--- a/test/spec/features/drilldown/DrilldownIntegrationSpec.js
+++ b/test/spec/features/drilldown/DrilldownIntegrationSpec.js
@@ -20,7 +20,15 @@ describe('features - drilldown', function() {
 
   beforeEach(bootstrapModeler(multiLayerXML, { modules: testModules }));
 
-  describe('Navigation', function() {
+  describe('Navigation - Collaboration', function() {
+
+    var process, participant;
+
+    beforeEach(inject(function(canvas, elementFactory) {
+      process = canvas.getRootElement();
+      participant = elementFactory.createParticipantShape({ x: 100, y: 100 });
+    }));
+
 
     it('should not reset scroll on create collaboration',
       inject(function(canvas, modeling) {
@@ -31,7 +39,8 @@ describe('features - drilldown', function() {
         var zoomedAndScrolledViewbox = canvas.viewbox();
 
         // when
-        modeling.makeCollaboration();
+        modeling.createShape(participant, { x: 0, y: 0 }, process);
+
 
         // then
         expectViewbox(zoomedAndScrolledViewbox);
@@ -48,7 +57,7 @@ describe('features - drilldown', function() {
         var zoomedAndScrolledViewbox = canvas.viewbox();
 
         // when
-        modeling.makeCollaboration();
+        modeling.createShape(participant, { x: 0, y: 0 }, process);
         commandStack.undo();
 
         // then
@@ -66,7 +75,7 @@ describe('features - drilldown', function() {
         var zoomedAndScrolledViewbox = canvas.viewbox();
 
         // when
-        modeling.makeCollaboration();
+        modeling.createShape(participant, { x: 400, y: 225 }, process);
         commandStack.undo();
         commandStack.redo();
 
@@ -74,6 +83,28 @@ describe('features - drilldown', function() {
         expectViewbox(zoomedAndScrolledViewbox);
       })
     );
+
+
+    it('should remember scroll and zoom after morph', inject(function(canvas, modeling) {
+
+      // given
+      canvas.scroll({ dx: 500, dy: 500 });
+      canvas.zoom(0.5);
+      var zoomedAndScrolledViewbox = canvas.viewbox();
+
+      modeling.createShape(participant, { x: 400, y: 225 }, process);
+      var collaboration = canvas.getRootElement();
+
+      // when
+      canvas.setRootElement(canvas.findRoot('collapsedProcess_plane'));
+      canvas.setRootElement(collaboration);
+
+      // then
+      var newViewbox = canvas.viewbox();
+      expect(newViewbox.x).to.eql(zoomedAndScrolledViewbox.x);
+      expect(newViewbox.y).to.eql(zoomedAndScrolledViewbox.y);
+      expect(newViewbox.scale).to.eql(zoomedAndScrolledViewbox.scale);
+    }));
 
   });
 

--- a/test/spec/features/drilldown/DrilldownIntegrationSpec.js
+++ b/test/spec/features/drilldown/DrilldownIntegrationSpec.js
@@ -1,0 +1,94 @@
+import {
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+import DrilldownModule from 'lib/features/drilldown';
+import { bootstrapModeler, getBpmnJS } from '../../../helper';
+
+
+describe('features - drilldown', function() {
+
+  var testModules = [
+    coreModule,
+    modelingModule,
+    DrilldownModule
+  ];
+
+  var multiLayerXML = require('./nested-subprocesses.bpmn');
+
+  beforeEach(bootstrapModeler(multiLayerXML, { modules: testModules }));
+
+  describe('Navigation', function() {
+
+    it('should not reset scroll on create collaboration',
+      inject(function(canvas, modeling) {
+
+        // given
+        canvas.scroll({ dx: 500, dy: 500 });
+        canvas.zoom(0.5);
+        var zoomedAndScrolledViewbox = canvas.viewbox();
+
+        // when
+        modeling.makeCollaboration();
+
+        // then
+        expectViewbox(zoomedAndScrolledViewbox);
+      })
+    );
+
+
+    it('should not reset scroll on create collaboration - undo',
+      inject(function(canvas, modeling, commandStack) {
+
+        // given
+        canvas.scroll({ dx: 500, dy: 500 });
+        canvas.zoom(0.5);
+        var zoomedAndScrolledViewbox = canvas.viewbox();
+
+        // when
+        modeling.makeCollaboration();
+        commandStack.undo();
+
+        // then
+        expectViewbox(zoomedAndScrolledViewbox);
+      })
+    );
+
+
+    it('should not reset scroll on create collaboration - redo',
+      inject(function(canvas, modeling, commandStack) {
+
+        // given
+        canvas.scroll({ dx: 500, dy: 500 });
+        canvas.zoom(0.5);
+        var zoomedAndScrolledViewbox = canvas.viewbox();
+
+        // when
+        modeling.makeCollaboration();
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expectViewbox(zoomedAndScrolledViewbox);
+      })
+    );
+
+  });
+
+});
+
+
+// helpers //////////
+
+function expectViewbox(expectedViewbox) {
+  return getBpmnJS().invoke(function(canvas) {
+
+    var viewbox = canvas.viewbox();
+
+    expect(viewbox.x).to.eql(expectedViewbox.x);
+    expect(viewbox.y).to.eql(expectedViewbox.y);
+    expect(viewbox.scale).to.eql(expectedViewbox.scale);
+  });
+}


### PR DESCRIPTION
closes #1565

Idea here: A Collaboration is always the root, so it will have a stored Viewbox when it accessed via 'drillUp'. We can safely assume that we want to keep the viewbox otherwise.

A cleaner solution would be to introduce a `hints` Object on the `setRootElement` API and add `{keepViewbox: true}` when we replace it in:
https://github.com/bpmn-io/bpmn-js/blob/4e08a1c703e71866ef1b11d2196daa2374a618ec/lib/features/modeling/cmd/UpdateCanvasRootHandler.js#L66-L68

However, this requires some changes in diagram-js, so I decided to go for the easy fix.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
