### PR TITLE
chore: skip wiredeps on backport branches

### DIFF
--- a/tasks/wiredeps
+++ b/tasks/wiredeps
@@ -4,10 +4,20 @@ FEATURE_BRANCH=
 
 # https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
 
-# skip default branch and tags
-if [[ $GITHUB_REF =~ ^refs/heads/master$ ]] || [[ $GITHUB_REF =~ ^refs/tags/ ]]; then
+# skip master / backport branches and tags
+if [[ "$GITHUB_REF" =~ ^refs/heads/(master$|[0-9]+\.x) ]] || [[ "$GITHUB_REF" =~ ^refs/tags/ ]]; then
+  echo "Skip wiredeps: master/backport branch";
+
   exit 0;
 fi
+
+# skip PR builds targeting master or backport branches
+if [[ "$GITHUB_BASE_REF" =~ ^(master$|[0-9]+\.x) ]]; then
+  echo "Skip wiredeps: targets master/backport branch";
+
+  exit 0;
+fi
+
 
 # GITHUB_HEAD_REF is set for pull request
 FEATURE_BRANCH=$([ $GITHUB_HEAD_REF != "" ] && echo $GITHUB_HEAD_REF || echo "$GITHUB_REF" | cut -d"/" -f3)


### PR DESCRIPTION
This extends our wiredeps skip logic to not only match `master` branches and tags but also any backport branches `\d.x` as well as PRs that target master and backport branches.

Why: Because we want to safely backport things (and fix things) without wiredeps interferring.

---

![image](https://user-images.githubusercontent.com/58601/149391876-bbcd2167-cd74-4639-b28c-a622426e628c.png)

---

Proof it works: https://github.com/bpmn-io/bpmn-js/pull/1573.