### PR TITLE
fix(modeling): ensure IDs are claimed when used 

### DIFF
--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -145,6 +145,7 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
     );
 
     newDi = bpmnFactory.create(oldDi.$type);
+    newDi.bpmnElement = newBusinessObject;
 
     descriptor.di = moddleCopy.copyElement(
       oldDi,

--- a/lib/features/modeling/BpmnFactory.js
+++ b/lib/features/modeling/BpmnFactory.js
@@ -42,6 +42,10 @@ BpmnFactory.prototype._needsId = function(element) {
 };
 
 BpmnFactory.prototype._ensureId = function(element) {
+  if (element.id) {
+    this._model.ids.claim(element.id, element);
+    return;
+  }
 
   // generate semantic ids for elements
   // bpmn:SequenceFlow -> SequenceFlow_ID

--- a/lib/features/modeling/behavior/UnclaimIdBehavior.js
+++ b/lib/features/modeling/behavior/UnclaimIdBehavior.js
@@ -47,7 +47,9 @@ export default function UnclaimIdBehavior(canvas, injector, moddle, modeling) {
     var rootElement = canvas.getRootElement(),
         rootElementBo = rootElement.businessObject;
 
-    moddle.ids.unclaim(rootElementBo.id);
+    if (is(rootElement, 'bpmn:Collaboration')) {
+      moddle.ids.unclaim(rootElementBo.id);
+    }
   });
 }
 

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -463,6 +463,35 @@ describe('features/copy-paste', function() {
         }
       ));
 
+
+      it('should wire DIs correctly', inject(
+        function(canvas, copyPaste, elementRegistry) {
+
+          // given
+          var subprcoess = elementRegistry.get('SubProcess_1'),
+              rootElement = canvas.getRootElement();
+
+          copyPaste.copy(subprcoess);
+
+          // when
+          var elements = copyPaste.paste({
+            element: rootElement,
+            point: {
+              x: 300,
+              y: 300
+            }
+          });
+
+          // then
+          var subprocess = elements[0];
+          var di = subprocess.di;
+
+          expect(di).to.exist;
+          expect(di.bpmnElement).to.exist;
+          expect(di.bpmnElement).to.equal(subprocess.businessObject);
+        }
+      ));
+
     });
 
 

--- a/test/spec/features/modeling/BpmnFactorySpec.js
+++ b/test/spec/features/modeling/BpmnFactorySpec.js
@@ -116,6 +116,16 @@ describe('features - bpmn-factory', function() {
         })
       );
     });
+
+
+    it('should claim provided id', inject(function(bpmnFactory, moddle) {
+      var task = bpmnFactory.create('bpmn:Task', { id: 'foo' });
+
+      expect(task).to.exist;
+      expect(task.id).to.eql('foo');
+      expect(moddle.ids.assigned('foo')).to.exist;
+    }));
+
   });
 
 

--- a/test/spec/features/modeling/behavior/UnclaimIdBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/UnclaimIdBehaviorSpec.js
@@ -82,4 +82,21 @@ describe('features/modeling - unclaim id', function() {
     expect(moddle.ids.assigned('Collaboration_1')).to.be.false;
   }));
 
+
+  describe('morphing', function() {
+    var simpleXML = require('../../../../fixtures/bpmn/simple.bpmn');
+
+    beforeEach(bootstrapModeler(simpleXML, { modules: testModules }));
+
+    it('should keep ID of root', inject(function(moddle, modeling) {
+
+      // when
+      modeling.makeCollaboration();
+
+      // then
+      expect(moddle.ids.assigned('Process_1')).to.exist;
+    }));
+
+  });
+
 });


### PR DESCRIPTION
ID claims were not properly managed before, which lead to invalid XML exports when using copy-paste. With this PR we ensure that the claimed IDs reflect the active IDs and are not claimed again when pasting.


closes #1555