### PR TITLE
fix(viewer): use active plane for svg export

### DIFF
--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -439,7 +439,7 @@ BaseViewer.prototype.saveSVG = wrapForCompatibility(function saveSVG(options) {
     try {
       var canvas = self.get('canvas');
 
-      var contentNode = canvas.getDefaultLayer(),
+      var contentNode = canvas.getActiveLayer(),
           defsNode = domQuery('defs', canvas._svg);
 
       var contents = innerSVG(contentNode),

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -1432,6 +1432,9 @@ describe('Viewer', function() {
       expect(svg.indexOf('<svg width="100%" height="100%">')).to.equal(-1);
       expect(svg.indexOf('<g class="viewport"')).to.equal(-1);
 
+      // expect svg to not be empty
+      expect(svg.indexOf('<g')).not.to.equal(-1);
+
       var parser = new DOMParser();
       var svgNode = parser.parseFromString(svg, 'image/svg+xml');
 


### PR DESCRIPTION
When exporting as SVG in bpmn-js@9.0.0-alpha.1, the file is empty.

This PR ensures that we export the currently visible layer in the SVG.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
