### PR TITLE
fix(drilldown): prevent infinite loop on root property change

### DIFF
--- a/lib/features/drilldown/DrilldownBreadcrumbs.js
+++ b/lib/features/drilldown/DrilldownBreadcrumbs.js
@@ -4,9 +4,7 @@ import { find } from 'min-dash';
 import { escapeHTML } from 'diagram-js/lib/util/EscapeUtil';
 import { getBusinessObject, is } from '../../util/ModelUtil';
 import {
-  getPlaneIdFromShape,
-  getShapeIdFromPlane,
-  isPlane
+  getPlaneIdFromShape
 } from '../../util/DrilldownUtil';
 
 var OPEN_CLASS = 'bjs-breadcrumbs-shown';

--- a/lib/features/drilldown/DrilldownBreadcrumbs.js
+++ b/lib/features/drilldown/DrilldownBreadcrumbs.js
@@ -32,7 +32,7 @@ export default function DrilldownBreadcrumbs(eventBus, elementRegistry, overlays
   eventBus.on('element.changed', function(e) {
     var shape = e.element;
 
-    if (!isPlane(shape)) {
+    if (!isPlane(shape) || !is(shape, 'bpmn:SubProcess')) {
       return;
     }
 

--- a/lib/features/drilldown/DrilldownBreadcrumbs.js
+++ b/lib/features/drilldown/DrilldownBreadcrumbs.js
@@ -28,19 +28,6 @@ export default function DrilldownBreadcrumbs(eventBus, elementRegistry, overlays
 
   var boParents = [];
 
-  // update primary shape if name or ID of the plane changes
-  eventBus.on('element.changed', function(e) {
-    var shape = e.element;
-
-    if (!isPlane(shape) || !is(shape, 'bpmn:SubProcess')) {
-      return;
-    }
-
-    var primary = elementRegistry.get(getShapeIdFromPlane(shape));
-
-    primary && eventBus.fire('element.changed', { element: primary });
-  });
-
   // update breadcrumbs if name or ID of the primary shape changes
   eventBus.on('element.changed', function(e) {
     var shape = e.element,

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -240,6 +240,27 @@ export default function SubProcessPlaneBehavior(
   }, true);
 
 
+  // ensure the collapsed shapes name is rerendered when the name is changed
+  // through the plane object
+  eventBus.on('element.changed', function(e) {
+    var plane = e.element;
+
+    if (!isPlane(plane)) {
+      return;
+    }
+
+    var collapsedShape = elementRegistry.get(getShapeIdFromPlane(plane));
+
+    // don't re-throw `element.changed` events for the process object,
+    // as no collapsed shape exists to update
+    if (!collapsedShape || collapsedShape === plane) {
+      return;
+    }
+
+    eventBus.fire('element.changed', { element: collapsedShape });
+  });
+
+
   // create/remove plane for the subprocess
   this.executed('shape.toggleCollapse', LOW_PRIORITY, function(context) {
     var shape = context.shape;

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -239,25 +239,25 @@ export default function SubProcessPlaneBehavior(
     elementRegistry.updateId(planeElement, toPlaneId(oldId));
   }, true);
 
+  // re-throw element.changed to re-render primary shape if associated plane has
+  // changed (e.g. bpmn:name property has changed)
+  eventBus.on('element.changed', function(context) {
+    var element = context.element;
 
-  // ensure the collapsed shapes name is rerendered when the name is changed
-  // through the plane object
-  eventBus.on('element.changed', function(e) {
-    var plane = e.element;
-
-    if (!isPlane(plane)) {
+    if (!isPlane(element)) {
       return;
     }
 
-    var collapsedShape = elementRegistry.get(getShapeIdFromPlane(plane));
+    var plane = element;
 
-    // don't re-throw `element.changed` events for the process object,
-    // as no collapsed shape exists to update
-    if (!collapsedShape || collapsedShape === plane) {
+    var primaryShape = elementRegistry.get(getShapeIdFromPlane(plane));
+
+    // do not re-throw if no associated primary shape (e.g. bpmn:Process)
+    if (!primaryShape || primaryShape === plane) {
       return;
     }
 
-    eventBus.fire('element.changed', { element: collapsedShape });
+    eventBus.fire('element.changed', { element: primaryShape });
   });
 
 

--- a/test/spec/features/drilldown/DrilldownIntegrationSpec.js
+++ b/test/spec/features/drilldown/DrilldownIntegrationSpec.js
@@ -151,6 +151,27 @@ describe('features - drilldown', function() {
       })
     );
 
+
+    it('should update on process name change',
+      inject(function(canvas, elementRegistry, modeling) {
+
+        // given
+        canvas.setRootElement(canvas.findRoot('collapsedProcess_2_plane'));
+        var shape = elementRegistry.get('rootProcess');
+
+        // when
+        modeling.updateProperties(shape, { name: 'new name' });
+
+        // then
+        expectBreadcrumbs([
+          'new name',
+          'Collapsed Process',
+          'Expanded Process',
+          'Collapsed Process 2'
+        ]);
+      })
+    );
+
   });
 
 });

--- a/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
@@ -336,6 +336,27 @@ describe('features/modeling/behavior - subprocess planes', function() {
         expect(plane.id).to.equal('new_name_plane');
       }));
 
+
+    it('should rerender primary shape name when plane is changed',
+      inject(function(modeling, elementRegistry, eventBus) {
+
+        // given
+        var subProcess = elementRegistry.get('SubProcess_2'),
+            plane = elementRegistry.get('SubProcess_2_plane');
+
+        var changedSpy = sinon.spy();
+
+        eventBus.on('element.changed', 5000, changedSpy);
+
+        // when
+        modeling.updateProperties(plane, { name: 'new name' });
+
+        // then
+        expect(changedSpy).to.have.been.calledTwice;
+        expect(changedSpy.secondCall.args[0].element).to.eql(subProcess);
+      })
+    );
+
   });
 
 


### PR DESCRIPTION
When changing properties of the process, we created an infinite loop because the process plane does not have another representation in the diagram.
This PR ensures we only trigger `element.changed` if it is a subprocess.

try it out with `npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#master -l bpmn-io/bpmn-js#allow-changes-to-root -c "npm run start:platform"`

related to https://github.com/bpmn-io/bpmn-js-properties-panel/issues/569

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
