### PR TITLE
fix(modeling): ensure plane ID change is undoable

### DIFF
--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -216,7 +216,7 @@ export default function SubProcessPlaneBehavior(
   this.reverted('element.updateProperties', function(context) {
     var shape = context.element;
 
-    if (!isCollapsedSubProcess(shape)) {
+    if (!is(shape, 'bpmn:SubProcess')) {
       return;
     }
 
@@ -227,6 +227,13 @@ export default function SubProcessPlaneBehavior(
         newId = properties.id;
 
     if (oldId === newId) {
+      return;
+    }
+
+    if (isPlane(shape)) {
+      elementRegistry.updateId(shape, toPlaneId(oldId));
+      elementRegistry.updateId(newId, oldId);
+
       return;
     }
 

--- a/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessPlaneBehaviorSpec.js
@@ -305,36 +305,118 @@ describe('features/modeling/behavior - subprocess planes', function() {
     }));
 
 
-    it('should update plane id when primary shape is changed',
-      inject(function(modeling, elementRegistry) {
+    describe('do', function() {
 
-        // given
-        var subProcess = elementRegistry.get('SubProcess_2'),
-            plane = elementRegistry.get('SubProcess_2_plane');
+      it('should update plane id when primary shape is changed',
+        inject(function(modeling, elementRegistry) {
 
-        // when
-        modeling.updateProperties(subProcess, { id: 'new_name' });
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
 
-        // then
-        expect(subProcess.id).to.equal('new_name');
-        expect(plane.id).to.equal('new_name_plane');
-      }));
+          // when
+          modeling.updateProperties(subProcess, { id: 'new_name' });
+
+          // then
+          expect(subProcess.id).to.equal('new_name');
+          expect(plane.id).to.equal('new_name_plane');
+        }));
 
 
-    it('should update primary shape id when plane is changed',
-      inject(function(modeling, elementRegistry) {
+      it('should update primary shape id when plane is changed',
+        inject(function(modeling, elementRegistry) {
 
-        // given
-        var subProcess = elementRegistry.get('SubProcess_2'),
-            plane = elementRegistry.get('SubProcess_2_plane');
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
 
-        // when
-        modeling.updateProperties(plane, { id: 'new_name' });
+          // when
+          modeling.updateProperties(plane, { id: 'new_name' });
 
-        // then
-        expect(subProcess.id).to.equal('new_name');
-        expect(plane.id).to.equal('new_name_plane');
-      }));
+          // then
+          expect(subProcess.id).to.equal('new_name');
+          expect(plane.id).to.equal('new_name_plane');
+        }));
+
+    });
+
+
+    describe('undo', function() {
+
+      it('should update plane id when primary shape is changed',
+        inject(function(modeling, elementRegistry, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
+
+          // when
+          modeling.updateProperties(subProcess, { id: 'new_name' });
+          commandStack.undo();
+
+          // then
+          expect(subProcess.id).to.equal('SubProcess_2');
+          expect(plane.id).to.equal('SubProcess_2_plane');
+        }));
+
+
+      it('should update primary shape id when plane is changed',
+        inject(function(modeling, elementRegistry, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
+
+          // when
+          modeling.updateProperties(plane, { id: 'new_name' });
+          commandStack.undo();
+
+          // then
+          expect(subProcess.id).to.equal('SubProcess_2');
+          expect(plane.id).to.equal('SubProcess_2_plane');
+        }));
+
+    });
+
+
+    describe('redo', function() {
+
+      it('should update plane id when primary shape is changed',
+        inject(function(modeling, elementRegistry, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
+
+          // when
+          modeling.updateProperties(subProcess, { id: 'new_name' });
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(subProcess.id).to.equal('new_name');
+          expect(plane.id).to.equal('new_name_plane');
+        }));
+
+
+      it('should update primary shape id when plane is changed',
+        inject(function(modeling, elementRegistry, commandStack) {
+
+          // given
+          var subProcess = elementRegistry.get('SubProcess_2'),
+              plane = elementRegistry.get('SubProcess_2_plane');
+
+          // when
+          modeling.updateProperties(plane, { id: 'new_name' });
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(subProcess.id).to.equal('new_name');
+          expect(plane.id).to.equal('new_name_plane');
+        }));
+
+    });
 
 
     it('should rerender primary shape name when plane is changed',


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/2750

We did not make sure the changes we made in https://github.com/bpmn-io/bpmn-js/pull/1582 were reversible.

Test it out with `npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#master -l bpmn-io/bpmn-js#undo-plane-id-change -c "npm run start:platform"`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
