### PR TITLE
Backport `ModelUtil#getDi` and `ModelUtil#isAny` to bpmn-js@8.x

### DIFF
--- a/lib/features/modeling/util/ModelingUtil.js
+++ b/lib/features/modeling/util/ModelingUtil.js
@@ -1,24 +1,6 @@
-import {
-  some
-} from 'min-dash';
+export { is, isAny } from '../../../util/ModelUtil';
 
-import { is } from '../../../util/ModelUtil';
-
-
-/**
- * Return true if element has any of the given types.
- *
- * @param {djs.model.Base} element
- * @param {Array<string>} types
- *
- * @return {boolean}
- */
-export function isAny(element, types) {
-  return some(types, function(t) {
-    return is(element, t);
-  });
-}
-
+import { isAny } from '../../../util/ModelUtil';
 
 /**
  * Return the parent of the element with any of the given types.

--- a/lib/util/ModelUtil.js
+++ b/lib/util/ModelUtil.js
@@ -1,3 +1,8 @@
+import {
+  some
+} from 'min-dash';
+
+
 /**
  * Is an element of the given BPMN type?
  *
@@ -12,6 +17,20 @@ export function is(element, type) {
   return bo && (typeof bo.$instanceOf === 'function') && bo.$instanceOf(type);
 }
 
+
+/**
+ * Return true if element has any of the given types.
+ *
+ * @param {djs.model.Base} element
+ * @param {Array<string>} types
+ *
+ * @return {boolean}
+ */
+export function isAny(element, types) {
+  return some(types, function(t) {
+    return is(element, t);
+  });
+}
 
 /**
  * Return the business object for a given element.

--- a/lib/util/ModelUtil.js
+++ b/lib/util/ModelUtil.js
@@ -23,3 +23,16 @@ export function is(element, type) {
 export function getBusinessObject(element) {
   return (element && element.businessObject) || element;
 }
+
+/**
+ * Return the di object for a given element.
+ *
+ * @param  {djs.model.Base} element
+ *
+ * @return {ModdleElement}
+ */
+export function getDi(element) {
+  var bo = getBusinessObject(element);
+
+  return bo && bo.di;
+}

--- a/test/spec/util/ModelUtilSpec.js
+++ b/test/spec/util/ModelUtilSpec.js
@@ -7,7 +7,8 @@ import coreModule from 'lib/core';
 import modelingModule from 'lib/features/modeling';
 
 import {
-  is
+  is,
+  getDi
 } from 'lib/util/ModelUtil';
 
 
@@ -23,50 +24,86 @@ describe('util/ModelUtil', function() {
   }));
 
 
-  it('should work with diagram element', inject(function(elementFactory) {
+  describe('#is', function() {
 
-    // given
-    var messageFlowConnection = elementFactory.createConnection({ type: 'bpmn:MessageFlow' });
+    it('should work with diagram element', inject(function(elementFactory) {
 
-    // then
-    expect(is(messageFlowConnection, 'bpmn:MessageFlow')).to.be.true;
-    expect(is(messageFlowConnection, 'bpmn:BaseElement')).to.be.true;
+      // given
+      var messageFlowConnection = elementFactory.createConnection({ type: 'bpmn:MessageFlow' });
 
-    expect(is(messageFlowConnection, 'bpmn:SequenceFlow')).to.be.false;
-    expect(is(messageFlowConnection, 'bpmn:Task')).to.be.false;
-  }));
+      // then
+      expect(is(messageFlowConnection, 'bpmn:MessageFlow')).to.be.true;
+      expect(is(messageFlowConnection, 'bpmn:BaseElement')).to.be.true;
 
-
-  it('should work with business object', inject(function(bpmnFactory) {
-
-    // given
-    var gateway = bpmnFactory.create('bpmn:Gateway');
-
-    // then
-    expect(is(gateway, 'bpmn:Gateway')).to.be.true;
-    expect(is(gateway, 'bpmn:BaseElement')).to.be.true;
-
-    expect(is(gateway, 'bpmn:SequenceFlow')).to.be.false;
-  }));
+      expect(is(messageFlowConnection, 'bpmn:SequenceFlow')).to.be.false;
+      expect(is(messageFlowConnection, 'bpmn:Task')).to.be.false;
+    }));
 
 
-  it('should work with untyped business object', inject(function() {
+    it('should work with business object', inject(function(bpmnFactory) {
 
-    // given
-    var foo = { businessObject: 'BAR' };
+      // given
+      var gateway = bpmnFactory.create('bpmn:Gateway');
 
-    // then
-    expect(is(foo, 'FOO')).to.be.false;
-  }));
+      // then
+      expect(is(gateway, 'bpmn:Gateway')).to.be.true;
+      expect(is(gateway, 'bpmn:BaseElement')).to.be.true;
+
+      expect(is(gateway, 'bpmn:SequenceFlow')).to.be.false;
+    }));
 
 
-  it('should work with untyped diagram element', inject(function() {
+    it('should work with untyped business object', inject(function() {
 
-    // given
-    var foo = { };
+      // given
+      var foo = { businessObject: 'BAR' };
 
-    // then
-    expect(is(foo, 'FOO')).to.be.false;
-  }));
+      // then
+      expect(is(foo, 'FOO')).to.be.false;
+    }));
+
+
+    it('should work with untyped diagram element', inject(function() {
+
+      // given
+      var foo = { };
+
+      // then
+      expect(is(foo, 'FOO')).to.be.false;
+    }));
+
+  });
+
+
+  describe('#getDi', function() {
+
+    it('should work with connection', inject(function(elementFactory) {
+
+      // given
+      var connection = elementFactory.createConnection({ type: 'bpmn:MessageFlow' });
+
+      // when
+      var di = getDi(connection);
+
+      // then
+      expect(di).to.exist;
+      expect(is(di, 'bpmndi:BPMNEdge')).to.be.true;
+    }));
+
+
+    it('should work with shape', inject(function(elementFactory) {
+
+      // given
+      var shape = elementFactory.createShape({ type: 'bpmn:ServiceTask' });
+
+      // when
+      var di = getDi(shape);
+
+      // then
+      expect(di).to.exist;
+      expect(is(di, 'bpmndi:BPMNShape')).to.be.true;
+    }));
+
+  });
 
 });

--- a/test/spec/util/ModelUtilSpec.js
+++ b/test/spec/util/ModelUtilSpec.js
@@ -8,6 +8,7 @@ import modelingModule from 'lib/features/modeling';
 
 import {
   is,
+  isAny,
   getDi
 } from 'lib/util/ModelUtil';
 
@@ -70,6 +71,36 @@ describe('util/ModelUtil', function() {
 
       // then
       expect(is(foo, 'FOO')).to.be.false;
+    }));
+
+  });
+
+
+  describe('isAny', function() {
+
+    it('should work on shape', inject(function(bpmnFactory, elementFactory) {
+
+      // given
+      var element = elementFactory.createShape({ type: 'bpmn:Gateway' });
+
+      // then
+      expect(isAny(element, [ 'bpmn:Gateway' ])).to.be.true;
+      expect(isAny(element, [ 'bpmn:SequenceFlow', 'bpmn:Gateway' ])).to.be.true;
+      expect(isAny(element, [ 'bpmn:BaseElement' ])).to.be.true;
+      expect(isAny(element, [ 'bpmn:SequenceFlow' ])).to.be.false;
+    }));
+
+
+    it('should work on businessObject', inject(function(bpmnFactory, elementFactory) {
+
+      // given
+      var businessObject = bpmnFactory.create('bpmn:Gateway');
+
+      // then
+      expect(isAny(businessObject, [ 'bpmn:Gateway' ])).to.be.true;
+      expect(isAny(businessObject, [ 'bpmn:SequenceFlow', 'bpmn:Gateway' ])).to.be.true;
+      expect(isAny(businessObject, [ 'bpmn:BaseElement' ])).to.be.true;
+      expect(isAny(businessObject, [ 'bpmn:SequenceFlow' ])).to.be.false;
     }));
 
   });


### PR DESCRIPTION
This backports these important APIs to bpmn-js@8 for extensions to rely upon.

Makes is easier to work with both bpmn-js@8 and bpmn-js@9.

I've seen one to many test cases failing because either of them is missing.