### PR TITLE
Fix integration tests

### DIFF
--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -97,7 +97,7 @@ SubprocessCompatibility.prototype.createNewDiagrams = function(plane) {
     var parent = element.parent;
 
     // parent is expanded, get nearest collapsed parent
-    while (parent && !collapsedElements.includes(parent)) {
+    while (parent && collapsedElements.indexOf(parent) === -1) {
       parent = parent.$parent;
     }
 

--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -68,6 +68,11 @@ SubprocessCompatibility.prototype.createNewDiagrams = function(plane) {
 
   plane.get('planeElement').forEach(function(diElement) {
     var bo = diElement.bpmnElement;
+
+    if (!bo) {
+      return;
+    }
+
     var parent = bo.$parent;
 
     if (is(bo, 'bpmn:SubProcess') && !diElement.isExpanded) {

--- a/lib/features/modeling/behavior/ToggleCollapseConnectionBehaviour.js
+++ b/lib/features/modeling/behavior/ToggleCollapseConnectionBehaviour.js
@@ -48,7 +48,7 @@ export default function ToggleCollapseConnectionBehaviour(
 
 
     function handleConnection(c, incoming) {
-      if (allChildren.includes(c.source) && allChildren.includes(c.target)) {
+      if (allChildren.indexOf(c.source) !== -1 && allChildren.indexOf(c.target) !== -1) {
         return;
       }
 

--- a/test/spec/features/drilldown/legacy-subprocesses.bpmn
+++ b/test/spec/features/drilldown/legacy-subprocesses.bpmn
@@ -50,6 +50,9 @@
       <bpmndi:BPMNShape id="Activity_1hpaeri_di" bpmnElement="emptyProcess">
         <dc:Bounds x="960" y="50" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ignored_di">
+        <dc:Bounds x="0" y="0" width="100" height="80" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION

- Webpack polyfills `array.includes`, so our phantomJS tests are green even when they should not be. cf. https://github.com/bpmn-io/diagram-js/blob/develop/package-lock.json#L3385

- we assumed every DI has an associated a business Object. This assumption was removed.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
