### PR TITLE
fix(drilldown): override default padding of breadcrumb element

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -40,7 +40,10 @@
   display: none;
   flex-wrap: wrap;
   align-items: center;
-  top: 10px;
+  top: 30px;
+  left: 30px;
+  padding: 0px;
+  margin: 0px;
   font-family: var(--breadcrumbs-font-family);
   font-size: 16px;
   line-height: normal;
@@ -51,11 +54,11 @@
 }
 
 .djs-palette-shown .bjs-breadcrumbs {
-  left: 50px;
+  left: 90px;
 }
 
 .djs-palette-shown.djs-palette-two-column .bjs-breadcrumbs {
-  left: 100px;
+  left: 140px;
 }
 
 .bjs-breadcrumbs li {


### PR DESCRIPTION
Previously, the position of the breadcrumbs was determined in parts by the user agent stylesheet of the browser. With this PR, we remove padding and margin of the breadcrumbs and position it absolutely.

In the viewer, the breadcrumbs have the same distance from top and left, in the modeler it is positioned related to the Palette. The top distance stays the same in Modeler and Viewer.

Before: 

![Screenshot from 2022-02-22 14-55-44](https://user-images.githubusercontent.com/21984219/155149968-cdb7ba7c-37e2-45b1-8325-ba57c3bf3712.png)

After:

![image](https://user-images.githubusercontent.com/21984219/155150092-69a963ef-e5b3-4234-9f92-9e4da9293be8.png)


cf. https://github.com/bpmn-io/bpmn-js-examples/pull/159#discussion_r811299406