### PR TITLE
fix(devSetup): build bpmn-moddle in context of devSetup

### DIFF
--- a/docs/project/setup.sh
+++ b/docs/project/setup.sh
@@ -26,6 +26,8 @@ echo setup bpmn-moddle
 cd $base/bpmn-moddle
 npm install
 
+npm run build
+
 
 echo setup bpmn-js
 


### PR DESCRIPTION
* This will ensure that `npm run start` actually works after executing the setup script

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
