### PR TITLE
render dataAssociations on correct parent

### DIFF
--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -1,6 +1,6 @@
 
 import { asBounds, asTRBL } from 'diagram-js/lib/layout/LayoutUtil';
-import { is } from '../../util/ModelUtil';
+import { is, isAny } from '../../util/ModelUtil';
 
 var DEFAULT_POSITION = {
   x: 180,
@@ -79,7 +79,7 @@ SubprocessCompatibility.prototype.createNewDiagrams = function(plane) {
       collapsedElements.push(bo);
     }
 
-    if (is(parent, 'bpmn:SubProcess') && parent !== plane.bpmnElement) {
+    if (shouldMoveToPlane(bo, plane)) {
 
       // don't change the array while we iterate over it
       elementsToMove.push({ diElement: diElement, parent: parent });
@@ -168,7 +168,7 @@ SubprocessCompatibility.prototype.createDiagram = function(bo) {
 SubprocessCompatibility.$inject = [ 'eventBus', 'moddle' ];
 
 
-// helpers
+// helpers //////////////////////////
 
 function findRootDiagram(element) {
   if (is(element, 'bpmndi:BPMNDiagram')) {
@@ -198,4 +198,21 @@ function getPlaneBounds(plane) {
   });
 
   return asBounds(planeTrbl);
+}
+
+function shouldMoveToPlane(bo, plane) {
+  var parent = bo.$parent;
+
+  // don't move elements that are already on the plane
+  if (!is(parent, 'bpmn:SubProcess') || parent === plane.bpmnElement) {
+    return false;
+  }
+
+  // dataAssociations are children of the subprocess but rendered on process level
+  // cf. https://github.com/bpmn-io/bpmn-js/issues/1619
+  if (isAny(bo, ['bpmn:DataInputAssociation', 'bpmn:DataOutputAssociation'])) {
+    return false;
+  }
+
+  return true;
 }

--- a/lib/import/Importer.js
+++ b/lib/import/Importer.js
@@ -124,7 +124,7 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
 }
 
 /**
- * Returns all diagrams in the same hirarchy as the requested diagram.
+ * Returns all diagrams in the same hierarchy as the requested diagram.
  * Includes all parent and sub process diagrams.
  *
  * @param {Array} definitions

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -416,6 +416,18 @@ describe('features - drilldown', function() {
     }));
 
 
+    it('should import data associations on subprocess', inject(function(elementRegistry) {
+
+      // when
+      var dataInputAssociation = elementRegistry.get('DataInputAssociation_1');
+      var dataOutputAssociation = elementRegistry.get('DataOutputAssociation_1');
+
+      // then
+      expect(dataInputAssociation).to.exist;
+      expect(dataOutputAssociation).to.exist;
+    }));
+
+
     it('should move inlined elements to sensible position', inject(function(elementRegistry) {
 
       // when

--- a/test/spec/features/drilldown/legacy-subprocesses.bpmn
+++ b/test/spec/features/drilldown/legacy-subprocesses.bpmn
@@ -3,6 +3,14 @@
   <bpmn:process id="Process_0vkcvif" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" />
     <bpmn:subProcess id="inlineSubprocess">
+      <bpmn:property id="Property_0baelcu" name="__targetRef_placeholder" />
+      <bpmn:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn:sourceRef>DataObjectReference_0kmm4fv</bpmn:sourceRef>
+        <bpmn:targetRef>Property_0baelcu</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_1">
+        <bpmn:targetRef>DataObjectReference_0kmm4fv</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
       <bpmn:startEvent id="Event_0lrpy3a">
         <bpmn:outgoing>Flow_0obnxbt</bpmn:outgoing>
       </bpmn:startEvent>
@@ -18,15 +26,28 @@
       <bpmn:sequenceFlow id="Flow_1d6ajf7" sourceRef="inlineSubprocess_2" targetRef="Event_1ic2bhx" />
     </bpmn:subProcess>
     <bpmn:subProcess id="emptyProcess" />
+    <bpmn:dataObjectReference id="DataObjectReference_0kmm4fv" dataObjectRef="DataObject_0zfveu8" />
+    <bpmn:dataObject id="DataObject_0zfveu8" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0vkcvif">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="159" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_0kmm4fv_di" bpmnElement="DataObjectReference_0kmm4fv">
+        <dc:Bounds x="572" y="515" width="36" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="inlineSubprocess_di" bpmnElement="inlineSubprocess">
         <dc:Bounds x="220" y="50" width="720" height="380" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataInputAssociation_1_di" bpmnElement="DataInputAssociation_1">
+        <di:waypoint x="608" y="526" />
+        <di:waypoint x="730" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_1_di" bpmnElement="DataOutputAssociation_1">
+        <di:waypoint x="425" y="430" />
+        <di:waypoint x="572" y="527" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1d6ajf7_di" bpmnElement="Flow_1d6ajf7">
         <di:waypoint x="740" y="240" />
         <di:waypoint x="782" y="240" />


### PR DESCRIPTION
From what I got from the bpmn documentation, the Input/Output Associations are the only edge cases where the element is a child of the subprocess but rendered outside of it. Please correct me if I am missing something!

![image](https://user-images.githubusercontent.com/21984219/158623814-3c834c48-4b55-4c7f-86ab-9043da113017.png)

closes https://github.com/bpmn-io/bpmn-js/issues/1619
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
