### PR TITLE
Add StartEvent when morphing from CallActivity to expanded SubProcess

### DIFF
--- a/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
@@ -20,7 +20,7 @@ export default function SubProcessStartEventBehavior(injector, modeling) {
 
     if (
       !is(newShape, 'bpmn:SubProcess') ||
-      !is(oldShape, 'bpmn:Task') ||
+      ! (is(oldShape, 'bpmn:Task') || is(oldShape, 'bpmn:CallActivity')) ||
       !isExpanded(newShape)
     ) {
       return;

--- a/test/spec/features/modeling/behavior/SubProcessBehavior.start-event.bpmn
+++ b/test/spec/features/modeling/behavior/SubProcessBehavior.start-event.bpmn
@@ -2,12 +2,16 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_007va6i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.0-dev">
   <bpmn:process id="Process_1giw3j5" isExecutable="true">
     <bpmn:task id="Task_1" />
+    <bpmn:callActivity id="CallActivity_1" />
     <bpmn:subProcess id="SubProcess_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1giw3j5">
       <bpmndi:BPMNShape id="Task_07xra8r_di" bpmnElement="Task_1">
         <dc:Bounds x="156" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+     <bpmndi:BPMNShape id="Activity_1o55kco_di" bpmnElement="CallActivity_1" isExpanded="true">
+        <dc:Bounds x="285" y="81" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_01nq2r1_di" bpmnElement="SubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="280" width="350" height="200" />

--- a/test/spec/features/modeling/behavior/SubProcessStartEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessStartEventBehaviorSpec.js
@@ -99,6 +99,56 @@ describe('features/modeling/behavior - subprocess start event', function() {
 
     });
 
+
+    describe('call activity -> expanded subprocess', function() {
+
+      it('should add start event child to subprocess', inject(
+        function(elementRegistry, bpmnReplace) {
+
+          // given
+          var callActivity = elementRegistry.get('CallActivity_1'),
+              expandedSubProcess,
+              startEvents;
+
+          // when
+          expandedSubProcess = bpmnReplace.replaceElement(callActivity, {
+            type: 'bpmn:SubProcess',
+            isExpanded: true
+          });
+
+          // then
+          startEvents = getChildStartEvents(expandedSubProcess);
+
+          expect(startEvents).to.have.length(1);
+        }
+      ));
+
+
+      it('should wire startEvent di correctly', inject(
+        function(elementRegistry, bpmnReplace) {
+
+          // given
+          var callActivity = elementRegistry.get('CallActivity_1'),
+              expandedSubProcess,
+              startEvent,
+              startEventDi;
+
+          // when
+          expandedSubProcess = bpmnReplace.replaceElement(callActivity, {
+            type: 'bpmn:SubProcess',
+            isExpanded: true
+          });
+
+          // then
+          startEvent = getChildStartEvents(expandedSubProcess)[0];
+          startEventDi = getDi(startEvent);
+
+          expect(startEventDi.$parent).to.exist;
+        }
+      ));
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Closes #1631

This p the same behaviour as the one applied to tasks:

https://user-images.githubusercontent.com/25825387/164481553-b55c4df2-24a1-4a08-b82c-cf9602474df1.mov


