### PR TITLE
fix(label-editing): remove label property on empty label

### DIFF
--- a/lib/features/label-editing/cmd/UpdateLabelHandler.js
+++ b/lib/features/label-editing/cmd/UpdateLabelHandler.js
@@ -44,7 +44,7 @@ export default function UpdateLabelHandler(modeling, textRenderer, bpmnFactory) 
     }
 
     if (!text && di.label) {
-      di.label = null;
+      delete di.label;
     }
   }
 

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -247,7 +247,7 @@ describe('features/modeling - update label', function() {
 
       // then
       expect(task_2.businessObject.name).to.equal('');
-      expect(task_2.di.label).not.to.exist;
+      expect(task_2.di).not.to.have.property('label');
     }));
 
   });


### PR DESCRIPTION
closes #1637

Integration-test this fix in linting:

`npx @bpmn-io/sr bpmn-io/bpmn-js-bpmnlint -l bpmn-io/bpmn-js#1637-delete-label-property `

- add label to shape
- remove label
- linting does not break

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
