### PR TITLE
fix(moddle-copy): primitive array copying

### DIFF
--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -234,8 +234,6 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
 
       // copying might NOT be allowed
       if (copiedProperty) {
-        copiedProperty.$parent = parent;
-
         return childProperties.concat(copiedProperty);
       }
 

--- a/test/fixtures/json/model/custom.json
+++ b/test/fixtures/json/model/custom.json
@@ -22,6 +22,11 @@
           "name": "value",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "paths",
+          "type": "String",
+          "isMany": true
         }
       ]
     },

--- a/test/spec/features/copy-paste/ModdleCopySpec.js
+++ b/test/spec/features/copy-paste/ModdleCopySpec.js
@@ -781,6 +781,40 @@ describe('features/copy-paste/ModdleCopy', function() {
 
   });
 
+
+  describe('custom', function() {
+
+    var customPackage = require('../../../fixtures/json/model/custom.json');
+
+    beforeEach(bootstrapModeler(basicXML, {
+      modules: testModules,
+      moddleExtensions: {
+        custom: customPackage
+      }
+    }));
+
+
+    it('should copy arrays of strings', inject(function(moddle, moddleCopy) {
+
+      // given
+      var paths = [ 'A', 'B', 'C' ];
+
+      var customElement = moddle.create('custom:CustomSendElement', {
+        paths: paths
+      });
+
+      // when
+      var newElement = moddleCopy.copyElement(customElement, moddle.create('custom:CustomSendElement'));
+
+      // then
+      expect(newElement.paths).to.have.length(3);
+      expect(newElement.paths).to.eql(paths);
+
+      expectNoAttrs(newElement);
+    }));
+
+  });
+
 });
 
 


### PR DESCRIPTION
Closes #1518

Issue stemmed from setting the parent here. When the array contained primitives, this led to trying to set a property on a primitive which is an exception. In general, the recursion itself handled the setting (or not) of parents depending on the array element type, so doing it here again is (unless I've missed something) redundant and in this case breaking.

Also thanks @pinussilvestrus for the test case.