### PR TITLE
deps: replace inherits with inherits-browser

### DIFF
--- a/lib/BaseModeler.js
+++ b/lib/BaseModeler.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import Ids from 'ids';
 

--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -25,7 +25,7 @@ import {
 import Diagram from 'diagram-js';
 import BpmnModdle from 'bpmn-moddle';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   importBpmnDiagram

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import BaseModeler from './BaseModeler';
 

--- a/lib/NavigatedViewer.js
+++ b/lib/NavigatedViewer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import Viewer from './Viewer';
 

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CoreModule from './core';
 import TranslateModule from 'diagram-js/lib/i18n/translate';

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   isObject,

--- a/lib/features/auto-resize/BpmnAutoResize.js
+++ b/lib/features/auto-resize/BpmnAutoResize.js
@@ -1,6 +1,6 @@
 import AutoResize from 'diagram-js/lib/features/auto-resize/AutoResize';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { is } from '../../util/ModelUtil';
 

--- a/lib/features/auto-resize/BpmnAutoResizeProvider.js
+++ b/lib/features/auto-resize/BpmnAutoResizeProvider.js
@@ -1,6 +1,6 @@
 import { is } from '../../util/ModelUtil';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { forEach } from 'min-dash';
 

--- a/lib/features/drilldown/DrilldownOverlayBehavior.js
+++ b/lib/features/drilldown/DrilldownOverlayBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 import { is } from '../../util/ModelUtil';

--- a/lib/features/editor-actions/BpmnEditorActions.js
+++ b/lib/features/editor-actions/BpmnEditorActions.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import EditorActions from 'diagram-js/lib/features/editor-actions/EditorActions';
 

--- a/lib/features/grid-snapping/behavior/LayoutConnectionBehavior.js
+++ b/lib/features/grid-snapping/behavior/LayoutConnectionBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/keyboard/BpmnKeyboardBindings.js
+++ b/lib/features/keyboard/BpmnKeyboardBindings.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import KeyboardBindings from 'diagram-js/lib/features/keyboard/KeyboardBindings';
 

--- a/lib/features/modeling/BpmnLayouter.js
+++ b/lib/features/modeling/BpmnLayouter.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   assign

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -3,7 +3,7 @@ import {
   forEach
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   remove as collectionRemove,

--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -4,7 +4,7 @@ import {
   isObject
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   getBusinessObject,

--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import BaseModeling from 'diagram-js/lib/features/modeling/Modeling';
 

--- a/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
+++ b/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   getOrientation,

--- a/lib/features/modeling/behavior/AppendBehavior.js
+++ b/lib/features/modeling/behavior/AppendBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { is } from '../../../util/ModelUtil';
 

--- a/lib/features/modeling/behavior/AssociationBehavior.js
+++ b/lib/features/modeling/behavior/AssociationBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { is } from '../../../util/ModelUtil';
 

--- a/lib/features/modeling/behavior/AttachEventBehavior.js
+++ b/lib/features/modeling/behavior/AttachEventBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/BoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/BoundaryEventBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/CreateBehavior.js
+++ b/lib/features/modeling/behavior/CreateBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { is } from '../../../util/ModelUtil';
 

--- a/lib/features/modeling/behavior/CreateDataObjectBehavior.js
+++ b/lib/features/modeling/behavior/CreateDataObjectBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/CreateParticipantBehavior.js
+++ b/lib/features/modeling/behavior/CreateParticipantBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/DataInputAssociationBehavior.js
+++ b/lib/features/modeling/behavior/DataInputAssociationBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/DataStoreBehavior.js
+++ b/lib/features/modeling/behavior/DataStoreBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/DeleteLaneBehavior.js
+++ b/lib/features/modeling/behavior/DeleteLaneBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/DetachEventBehavior.js
+++ b/lib/features/modeling/behavior/DetachEventBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/DropOnFlowBehavior.js
+++ b/lib/features/modeling/behavior/DropOnFlowBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   assign,

--- a/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
+++ b/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/IsHorizontalFix.js
+++ b/lib/features/modeling/behavior/IsHorizontalFix.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -2,7 +2,7 @@ import {
   assign
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   is,

--- a/lib/features/modeling/behavior/MessageFlowBehavior.js
+++ b/lib/features/modeling/behavior/MessageFlowBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/RemoveElementBehavior.js
+++ b/lib/features/modeling/behavior/RemoveElementBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { is } from '../../../util/ModelUtil';
 

--- a/lib/features/modeling/behavior/RemoveEmbeddedLabelBoundsBehavior.js
+++ b/lib/features/modeling/behavior/RemoveEmbeddedLabelBoundsBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/RemoveParticipantBehavior.js
+++ b/lib/features/modeling/behavior/RemoveParticipantBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
+++ b/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
@@ -4,7 +4,7 @@ import {
   matchPattern
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/ReplaceElementBehaviour.js
+++ b/lib/features/modeling/behavior/ReplaceElementBehaviour.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import { forEach } from 'min-dash';
 

--- a/lib/features/modeling/behavior/RootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/RootElementReferenceBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   find,

--- a/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessPlaneBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/ToggleCollapseConnectionBehaviour.js
+++ b/lib/features/modeling/behavior/ToggleCollapseConnectionBehaviour.js
@@ -1,5 +1,5 @@
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/ToggleElementCollapseBehaviour.js
+++ b/lib/features/modeling/behavior/ToggleElementCollapseBehaviour.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/UnclaimIdBehavior.js
+++ b/lib/features/modeling/behavior/UnclaimIdBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/UnsetDefaultFlowBehavior.js
+++ b/lib/features/modeling/behavior/UnsetDefaultFlowBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/modeling/behavior/UpdateFlowNodeRefsBehavior.js
+++ b/lib/features/modeling/behavior/UpdateFlowNodeRefsBehavior.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import OrderingProvider from 'diagram-js/lib/features/ordering/OrderingProvider';
 

--- a/lib/features/replace-preview/BpmnReplacePreview.js
+++ b/lib/features/replace-preview/BpmnReplacePreview.js
@@ -1,6 +1,6 @@
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import cssEscape from 'css.escape';
 

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -5,7 +5,7 @@ import {
   some
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   is,

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import CreateMoveSnapping from 'diagram-js/lib/features/snapping/CreateMoveSnapping';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5997,6 +5997,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "inherits-browser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
+    },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -6627,7 +6632,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "diagram-js": "^8.3.0",
     "diagram-js-direct-editing": "^1.6.3",
     "ids": "^1.0.0",
-    "inherits": "^2.0.4",
+    "inherits-browser": "0.0.1",
     "min-dash": "^3.5.2",
     "min-dom": "^3.2.0",
     "object-refs": "^0.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -97,13 +97,7 @@ function pgl(plugins=[], env='production') {
     replace({
       'process.env.NODE_ENV': JSON.stringify(env)
     }),
-    nodeResolve({
-      mainFields: [
-        'browser',
-        'module',
-        'main'
-      ]
-    }),
+    nodeResolve(),
     commonjs(),
     json(),
     ...plugins

--- a/test/config/karma.unit.js
+++ b/test/config/karma.unit.js
@@ -83,7 +83,6 @@ module.exports = function(karma) {
       resolve: {
         mainFields: [
           'dev:module',
-          'browser',
           'module',
           'main'
         ],

--- a/test/integration/custom-elements/CustomElementFactory.js
+++ b/test/integration/custom-elements/CustomElementFactory.js
@@ -2,7 +2,7 @@ import {
   assign
 } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import BpmnElementFactory from 'lib/features/modeling/ElementFactory';
 

--- a/test/integration/custom-elements/CustomRenderer.js
+++ b/test/integration/custom-elements/CustomRenderer.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
 

--- a/test/integration/custom-elements/CustomRules.js
+++ b/test/integration/custom-elements/CustomRules.js
@@ -1,6 +1,6 @@
 import { forEach } from 'min-dash';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
 

--- a/test/integration/custom-elements/CustomUpdater.js
+++ b/test/integration/custom-elements/CustomUpdater.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   is as isBpmn

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -6,7 +6,7 @@ import ViewerDefaultExport from '../../';
 
 import Viewer from 'lib/Viewer';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import {
   createViewer

--- a/test/spec/features/modeling/LoggingCroppingConnectionDocking.js
+++ b/test/spec/features/modeling/LoggingCroppingConnectionDocking.js
@@ -4,7 +4,7 @@ import {
   getOrientation
 } from 'diagram-js/lib/layout/LayoutUtil';
 
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 
 export default function LoggingCroppingConnectionDocking(injector) {

--- a/test/util/custom-rules/CustomRules.js
+++ b/test/util/custom-rules/CustomRules.js
@@ -1,4 +1,4 @@
-import inherits from 'inherits';
+import inherits from 'inherits-browser';
 
 import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
 


### PR DESCRIPTION
This increase the safety of our build; external consumers
do no longer need to account for the `browser` field to
bundle bpmn-js (or otherwise bundle a Node shim, unintentionally).

----

Related to https://github.com/bpmn-io/diagram-js/pull/639