### PR TITLE
fix: cancel direct editing before element deletion

### DIFF
--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -25,6 +25,8 @@ import {
   isLabel
 } from '../../util/LabelUtil';
 
+var HIGH_PRIORITY = 2000;
+
 
 export default function LabelEditingProvider(
     eventBus, bpmnFactory, canvas, directEditing,
@@ -61,7 +63,7 @@ export default function LabelEditingProvider(
   eventBus.on([
     'shape.remove',
     'connection.remove'
-  ], function(event) {
+  ], HIGH_PRIORITY, function(event) {
 
     if (directEditing.isActive(event.element)) {
       directEditing.cancel();

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -205,12 +205,33 @@ describe('features - label-editing', function() {
 
 
     it('should cancel on element deletion', inject(
+      function(elementRegistry, directEditing, modeling) {
+
+        // given
+        var shape = elementRegistry.get('Task_1'),
+            task = shape.businessObject;
+
+        directEditing.activate(shape);
+
+        directEditing._textbox.content.textContent = 'FOO BAR';
+
+        // when
+        modeling.removeElements([ shape ]);
+
+        // then
+        expect(task.name).not.to.equal('FOO BAR');
+      }
+    ));
+
+
+    it('should cancel on selected element deletion', inject(
       function(elementRegistry, directEditing, selection, modeling) {
 
         // given
         var shape = elementRegistry.get('Task_1'),
             task = shape.businessObject;
 
+        selection.select(shape);
         directEditing.activate(shape);
 
         directEditing._textbox.content.textContent = 'FOO BAR';


### PR DESCRIPTION
This is take two on fixing #1664, specifically https://github.com/bpmn-io/bpmn-js/issues/1664#issuecomment-1149805611:

![capture cmVbIr_optimized](https://user-images.githubusercontent.com/58601/172610281-fdf743f4-ba13-430f-8ab5-0486d032b50a.gif)

Without this fix selection change would trigger direct editing completion before the delete listerer could cancel it.

---

Closes #1664