### PR TITLE
test: add generic logging facility

### DIFF
--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -267,6 +267,31 @@ export function createViewer(container, viewerInstance, xml, diagramId) {
   });
 }
 
+function logConfigured(type, force) {
+  var url = new URL(window.location.href);
+
+  var log = ('searchParams' in url) && url.searchParams.get('log') || '';
+
+  return force || log.includes('save-xml');
+}
+
+/**
+ * Enable logging on a modeler instance.
+ *
+ * @param  {import('bpmn-js')} modeler
+ * @param  {boolean} [force=false]
+ */
+export function enableLogging(modeler, force) {
+
+  var saveXML = logConfigured('save-xml', force);
+
+  saveXML && modeler.on('commandStack.changed', function() {
+    modeler.saveXML({ format: true }).then(function(result) {
+      console.log(result.xml);
+    });
+  });
+}
+
 export function setBpmnJS(instance) {
   BPMN_JS = instance;
 }

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -13,7 +13,8 @@ import {
 import {
   setBpmnJS,
   clearBpmnJS,
-  collectTranslations
+  collectTranslations,
+  enableLogging
 } from 'test/TestHelper';
 
 import { getDi } from 'lib/util/ModelUtil';
@@ -43,13 +44,9 @@ describe('Modeler', function() {
       }
     });
 
-    singleStart && modeler.on('commandStack.changed', function() {
-      modeler.saveXML({ format: true }).then(function(result) {
-        console.log(result.xml);
-      });
-    });
-
     setBpmnJS(modeler);
+
+    enableLogging(modeler, singleStart);
 
     return modeler.importXML(xml).then(function(result) {
       return { error: null, warnings: result.warnings, modeler: modeler };


### PR DESCRIPTION
This allows us to enable different sorts of logging conveniently
via the test helper and control it via query parameters.

-----

The basic idea is that you can control via a query parameter if you'd like to log what is happening XML wise during a test run.