### PR TITLE
Clone on copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 10.0.0
+
+* `FEAT`: allow clipboard to be serialized ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FEAT`: allow cloning of elements ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FEAT`: copy groups in a safe manner ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FIX`: make clipboard contents immutable ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FIX`: do not alter inputs passed to `ElementFactory#create` ([#1711](https://github.com/bpmn-io/bpmn-js/pull/1711))
+* `FIX`: prevent bogus meta-data to be attached on paste ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FIX`: only claim existing IDs ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+* `FIX`: prevent double paste on label creation ([#1707](https://github.com/bpmn-io/bpmn-js/pull/1707))
+
 ## 9.3.2
 
 * `FIX`: prevent unnecessary scrollbar ([#1692](https://github.com/bpmn-io/bpmn-js/issues/1692))

--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -59,9 +59,17 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
     }
   });
 
-  var references;
+  var referencesKey = '-bpmn-js-refs';
 
-  function resolveReferences(descriptor, cache) {
+  function getReferences(cache) {
+    return (cache[referencesKey] = cache[referencesKey] || {});
+  }
+
+  function setReferences(cache, references) {
+    cache[referencesKey] = references;
+  }
+
+  function resolveReferences(descriptor, cache, references) {
     var businessObject = getBusinessObject(descriptor);
 
     // default sequence flows
@@ -81,7 +89,7 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
       getBusinessObject(descriptor).attachedToRef = getBusinessObject(cache[ descriptor.host ]);
     }
 
-    references = omit(references, reduce(references, function(array, reference, key) {
+    return omit(references, reduce(references, function(array, reference, key) {
       var element = reference.element,
           property = reference.property;
 
@@ -94,10 +102,6 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
       return array;
     }, []));
   }
-
-  eventBus.on('copyPaste.pasteElements', function() {
-    references = {};
-  });
 
   eventBus.on('copyPaste.pasteElement', function(context) {
     var cache = context.cache,
@@ -159,7 +163,10 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
         descriptor = context.descriptor;
 
     // resolve references e.g. default sequence flow
-    resolveReferences(descriptor, cache);
+    setReferences(
+      cache,
+      resolveReferences(descriptor, cache, getReferences(cache))
+    );
   });
 
 }

--- a/lib/features/copy-paste/BpmnCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCopyPaste.js
@@ -24,61 +24,38 @@ function copyProperties(source, target, properties) {
   });
 }
 
-function removeProperties(element, properties) {
-  if (!isArray(properties)) {
-    properties = [ properties ];
-  }
-
-  forEach(properties, function(property) {
-    if (element[property]) {
-      delete element[property];
-    }
-  });
-}
-
 var LOW_PRIORITY = 750;
 
 
 export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
 
+  function copy(bo, clone) {
+    var targetBo = bpmnFactory.create(bo.$type);
+
+    return moddleCopy.copyElement(bo, targetBo, null, clone);
+  }
+
   eventBus.on('copyPaste.copyElement', LOW_PRIORITY, function(context) {
     var descriptor = context.descriptor,
-        element = context.element;
+        element = context.element,
+        businessObject = getBusinessObject(element);
 
-    var businessObject = descriptor.oldBusinessObject = getBusinessObject(element);
-    var di = descriptor.oldDi = getDi(element);
-
-    descriptor.type = element.type;
-
-    copyProperties(businessObject, descriptor, 'name');
-
-    copyProperties(di, descriptor, 'isExpanded');
-
-    if (isLabel(descriptor)) {
+    // do not copy business object + di for labels;
+    // will be pulled from the referenced label target
+    if (isLabel(element)) {
       return descriptor;
     }
+
+    var businessObjectCopy = descriptor.businessObject = copy(businessObject, true);
+    var diCopy = descriptor.di = copy(getDi(element), true);
+    diCopy.bpmnElement = businessObjectCopy;
+
+    copyProperties(businessObjectCopy, descriptor, 'name');
+    copyProperties(diCopy, descriptor, 'isExpanded');
 
     // default sequence flow
     if (businessObject.default) {
       descriptor.default = businessObject.default.id;
-    }
-  });
-
-  eventBus.on('moddleCopy.canCopyProperty', function(context) {
-    var parent = context.parent,
-        property = context.property,
-        propertyName = context.propertyName,
-        bpmnProcess;
-
-    if (
-      propertyName === 'processRef' &&
-      is(parent, 'bpmn:Participant') &&
-      is(property, 'bpmn:Process')
-    ) {
-      bpmnProcess = bpmnFactory.create('bpmn:Process');
-
-      // return copy of process
-      return moddleCopy.copyElement(property, bpmnProcess);
     }
   });
 
@@ -125,11 +102,10 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
   eventBus.on('copyPaste.pasteElement', function(context) {
     var cache = context.cache,
         descriptor = context.descriptor,
-        oldBusinessObject = descriptor.oldBusinessObject,
-        oldDi = descriptor.oldDi,
-        newBusinessObject, newDi;
+        businessObject = descriptor.businessObject,
+        di = descriptor.di;
 
-    // do NOT copy business object if external label
+    // wire existing di + businessObject for external label
     if (isLabel(descriptor)) {
       descriptor.businessObject = getBusinessObject(cache[ descriptor.labelTarget ]);
       descriptor.di = getDi(cache[ descriptor.labelTarget ]);
@@ -137,30 +113,53 @@ export default function BpmnCopyPaste(bpmnFactory, eventBus, moddleCopy) {
       return;
     }
 
-    newBusinessObject = bpmnFactory.create(oldBusinessObject.$type);
+    businessObject = descriptor.businessObject = copy(businessObject);
 
-    descriptor.businessObject = moddleCopy.copyElement(
-      oldBusinessObject,
-      newBusinessObject
-    );
+    di = descriptor.di = copy(di);
+    di.bpmnElement = businessObject;
 
-    newDi = bpmnFactory.create(oldDi.$type);
-    newDi.bpmnElement = newBusinessObject;
-
-    descriptor.di = moddleCopy.copyElement(
-      oldDi,
-      newDi
-    );
-
-    // resolve references e.g. default sequence flow
-    resolveReferences(descriptor, cache);
-
-    copyProperties(descriptor, newBusinessObject, [
+    copyProperties(descriptor, businessObject, [
       'isExpanded',
       'name'
     ]);
 
-    removeProperties(descriptor, 'oldBusinessObject');
+    descriptor.type = businessObject.$type;
+  });
+
+  // copy + paste processRef with participant
+
+  eventBus.on('copyPaste.copyElement', LOW_PRIORITY, function(context) {
+    var descriptor = context.descriptor,
+        element = context.element;
+
+    if (!is(element, 'bpmn:Participant')) {
+      return;
+    }
+
+    var participantBo = getBusinessObject(element);
+
+    if (participantBo.processRef) {
+      descriptor.processRef = copy(participantBo.processRef, true);
+    }
+  });
+
+  eventBus.on('copyPaste.pasteElement', function(context) {
+    var descriptor = context.descriptor,
+        processRef = descriptor.processRef;
+
+    if (processRef) {
+      descriptor.processRef = copy(processRef);
+    }
+  });
+
+  // resolve references
+
+  eventBus.on('copyPaste.pasteElement', LOW_PRIORITY, function(context) {
+    var cache = context.cache,
+        descriptor = context.descriptor;
+
+    // resolve references e.g. default sequence flow
+    resolveReferences(descriptor, cache);
   });
 
 }

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -18,7 +18,8 @@ var DISALLOWED_PROPERTIES = [
   'flowElements',
   'lanes',
   'incoming',
-  'outgoing'
+  'outgoing',
+  'categoryValue'
 ];
 
 /**

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -165,6 +165,10 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
 
     var copiedProperty = self.copyProperty(sourceProperty, targetElement, propertyName, clone);
 
+    if (!isDefined(copiedProperty)) {
+      return;
+    }
+
     var canSetProperty = self._eventBus.fire('moddleCopy.canSetCopiedProperty', {
       parent: targetElement,
       property: copiedProperty,
@@ -175,9 +179,9 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
       return;
     }
 
-    if (isDefined(copiedProperty)) {
-      targetElement.set(propertyName, copiedProperty);
-    }
+    // TODO(nikku): unclaim old IDs if ID property is copied over
+    // this._moddle.getPropertyDescriptor(parent, propertyName)
+    targetElement.set(propertyName, copiedProperty);
   });
 
   return targetElement;

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -127,10 +127,11 @@ ModdleCopy.$inject = [
  * @param {ModdleElement} sourceElement
  * @param {ModdleElement} targetElement
  * @param {Array<string>} [propertyNames]
+ * @param {boolean} clone
  *
  * @param {ModdleElement}
  */
-ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, propertyNames) {
+ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, propertyNames, clone) {
   var self = this;
 
   if (propertyNames && !isArray(propertyNames)) {
@@ -142,7 +143,8 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
   var canCopyProperties = this._eventBus.fire('moddleCopy.canCopyProperties', {
     propertyNames: propertyNames,
     sourceElement: sourceElement,
-    targetElement: targetElement
+    targetElement: targetElement,
+    clone: clone
   });
 
   if (canCopyProperties === false) {
@@ -161,7 +163,7 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
       sourceProperty = sourceElement.get(propertyName);
     }
 
-    var copiedProperty = self.copyProperty(sourceProperty, targetElement, propertyName);
+    var copiedProperty = self.copyProperty(sourceProperty, targetElement, propertyName, clone);
 
     var canSetProperty = self._eventBus.fire('moddleCopy.canSetCopiedProperty', {
       parent: targetElement,
@@ -187,17 +189,19 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
  * @param {*} property
  * @param {ModdleElement} parent
  * @param {string} propertyName
+ * @param {boolean} clone
  *
  * @returns {*}
  */
-ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
+ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clone) {
   var self = this;
 
   // allow others to copy property
   var copiedProperty = this._eventBus.fire('moddleCopy.canCopyProperty', {
     parent: parent,
     property: property,
-    propertyName: propertyName
+    propertyName: propertyName,
+    clone: clone
   });
 
   // return if copying is NOT allowed
@@ -222,7 +226,7 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
 
   // copy id
   if (propertyDescriptor.isId) {
-    return this._copyId(property, parent);
+    return this._copyId(property, parent, clone);
   }
 
   // copy arrays
@@ -230,7 +234,7 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
     return reduce(property, function(childProperties, childProperty) {
 
       // recursion
-      copiedProperty = self.copyProperty(childProperty, parent, propertyName);
+      copiedProperty = self.copyProperty(childProperty, parent, propertyName, clone);
 
       // copying might NOT be allowed
       if (copiedProperty) {
@@ -252,7 +256,7 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
     copiedProperty.$parent = parent;
 
     // recursion
-    copiedProperty = self.copyElement(property, copiedProperty);
+    copiedProperty = self.copyElement(property, copiedProperty, null, clone);
 
     return copiedProperty;
   }
@@ -261,7 +265,11 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName) {
   return property;
 };
 
-ModdleCopy.prototype._copyId = function(id, element) {
+ModdleCopy.prototype._copyId = function(id, element, clone) {
+
+  if (clone) {
+    return id;
+  }
 
   // disallow if already taken
   if (this._moddle.ids.assigned(id)) {

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -231,7 +231,7 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clo
 
   // copy id
   if (propertyDescriptor.isId) {
-    return this._copyId(property, parent, clone);
+    return property && this._copyId(property, parent, clone);
   }
 
   // copy arrays

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -7,13 +7,8 @@ import {
 } from './LabelUtil';
 
 import {
-  getBusinessObject,
   is
 } from '../../util/ModelUtil';
-
-import {
-  createCategoryValue
-} from '../modeling/behavior/util/CategoryUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
 import { isExpanded } from '../../util/DiUtil';
@@ -397,23 +392,6 @@ LabelEditingProvider.prototype.update = function(
       width: element.width / bbox.width * bounds.width,
       height: element.height / bbox.height * bounds.height
     };
-  }
-
-  if (is(element, 'bpmn:Group')) {
-
-    var businessObject = getBusinessObject(element);
-
-    // initialize categoryValue if not existing
-    if (!businessObject.categoryValueRef) {
-
-      var rootElement = this._canvas.getRootElement(),
-          definitions = getBusinessObject(rootElement).$parent;
-
-      var categoryValue = createCategoryValue(definitions, this._bpmnFactory);
-
-      getBusinessObject(element).categoryValueRef = categoryValue;
-    }
-
   }
 
   if (isEmptyText(newLabel)) {

--- a/lib/features/modeling/behavior/BoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/BoundaryEventBehavior.js
@@ -9,13 +9,11 @@ import {
   forEach
 } from 'min-dash';
 
-var HIGH_PRIORITY = 2000;
-
 
 /**
  * BPMN specific boundary event behavior
  */
-export default function BoundaryEventBehavior(eventBus, moddle, modeling) {
+export default function BoundaryEventBehavior(eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -60,23 +58,10 @@ export default function BoundaryEventBehavior(eventBus, moddle, modeling) {
     }
   });
 
-  // copy reference to root element on replace
-  eventBus.on('moddleCopy.canCopyProperty', HIGH_PRIORITY, function(context) {
-    var parent = context.parent,
-        property = context.property,
-        propertyName = context.propertyName;
-
-    var propertyDescriptor = moddle.getPropertyDescriptor(parent, propertyName);
-
-    if (propertyDescriptor && propertyDescriptor.isReference && is(property, 'bpmn:RootElement')) {
-      parent.set(propertyName, property);
-    }
-  });
 }
 
 BoundaryEventBehavior.$inject = [
   'eventBus',
-  'moddle',
   'modeling'
 ];
 

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -3,20 +3,20 @@ import inherits from 'inherits-browser';
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import {
-  add as collectionAdd,
-  remove as collectionRemove
-} from 'diagram-js/lib/util/Collections';
-
-import {
   getBusinessObject,
   is
 } from '../../../util/ModelUtil';
 
 import {
-  createCategoryValue
+  createCategory,
+  createCategoryValue,
+  linkCategoryValue,
+  unlinkCategory,
+  unlinkCategoryValue
 } from './util/CategoryUtil';
 
-var HIGH_PRIORITY = 2000;
+
+var LOWER_PRIORITY = 770;
 
 
 /**
@@ -33,46 +33,6 @@ export default function GroupBehavior(
   injector.invoke(CommandInterceptor, this);
 
   /**
-   * Removes a referenced category value for a given group shape
-   *
-   * @param {djs.model.Shape} shape
-   */
-  function removeReferencedCategoryValue(shape) {
-
-    var businessObject = getBusinessObject(shape),
-        categoryValue = businessObject.categoryValueRef;
-
-    if (!categoryValue) {
-      return;
-    }
-
-    var category = categoryValue.$parent;
-
-    if (!categoryValue) {
-      return;
-    }
-
-    collectionRemove(category.categoryValue, categoryValue);
-
-    // cleanup category if it is empty
-    if (category && !category.categoryValue.length) {
-      removeCategory(category);
-    }
-  }
-
-  /**
-   * Removes a given category from the definitions
-   *
-   * @param {ModdleElement} category
-   */
-  function removeCategory(category) {
-
-    var definitions = bpmnjs.getDefinitions();
-
-    collectionRemove(definitions.get('rootElements'), category);
-  }
-
-  /**
    * Returns all group element in the current registry
    *
    * @return {Array<djs.model.shape>} a list of group shapes
@@ -84,105 +44,257 @@ export default function GroupBehavior(
   }
 
   /**
-   * Returns true if given categoryValue is referenced in one of the given elements
+   * Returns true if given category is referenced in one of the given elements
    *
-   * @param {Array<djs.model.shape>} elements
-   * @param {ModdleElement} categoryValue
-   * @return {boolean}
+   * @param { djs.model.Element[] } elements
+   * @param { ModdleElement } category
+   *
+   * @return { boolean }
    */
-  function isReferenced(elements, categoryValue) {
-    return elements.some(function(e) {
+  function isReferencedCategory(elements, category) {
+    return elements.some(function(element) {
+      var businessObject = getBusinessObject(element);
 
-      var businessObject = getBusinessObject(e);
+      var _category = businessObject.categoryValueRef && businessObject.categoryValueRef.$parent;
 
-      return businessObject.categoryValueRef
-        && businessObject.categoryValueRef === categoryValue;
+      return _category === category;
     });
   }
 
   /**
-   * remove referenced category + value when group was deleted
+   * Returns true if given categoryValue is referenced in one of the given elements
+   *
+   * @param { djs.model.Element[] } elements
+   * @param { ModdleElement } categoryValue
+   *
+   * @return { boolean }
    */
-  this.executed('shape.delete', function(event) {
+  function isReferencedCategoryValue(elements, categoryValue) {
+    return elements.some(function(element) {
+      var businessObject = getBusinessObject(element);
+
+      return businessObject.categoryValueRef === categoryValue;
+    });
+  }
+
+  /**
+   * Remove category value unless it is still referenced
+   *
+   * @param {ModdleElement} categoryValue
+   * @param {ModdleElement} category
+   * @param {ModdleElement} businessObject
+   */
+  function removeCategoryValue(categoryValue, category, businessObject) {
+
+    var groups = getGroupElements().filter(function(element) {
+      return element.businessObject !== businessObject;
+    });
+
+    if (category && !isReferencedCategory(groups, category)) {
+      unlinkCategory(category);
+    }
+
+    if (categoryValue && !isReferencedCategoryValue(groups, categoryValue)) {
+      unlinkCategoryValue(categoryValue);
+    }
+  }
+
+  /**
+   * Add category value
+   *
+   * @param {ModdleElement} categoryValue
+   * @param {ModdleElement} category
+   */
+  function addCategoryValue(categoryValue, category) {
+    return linkCategoryValue(categoryValue, category, bpmnjs.getDefinitions());
+  }
+
+  function setCategoryValue(element, context) {
+    var businessObject = getBusinessObject(element),
+        categoryValue = businessObject.categoryValueRef;
+
+    if (!categoryValue) {
+      categoryValue =
+      businessObject.categoryValueRef =
+      context.categoryValue = (
+        context.categoryValue || createCategoryValue(bpmnFactory)
+      );
+    }
+
+    var category = categoryValue.$parent;
+
+    if (!category) {
+      category =
+      categoryValue.$parent =
+      context.category = (
+        context.category || createCategory(bpmnFactory)
+      );
+    }
+
+    addCategoryValue(categoryValue, category, bpmnjs.getDefinitions());
+  }
+
+  function unsetCategoryValue(element, context) {
+    var category = context.category,
+        categoryValue = context.categoryValue,
+        businessObject = getBusinessObject(element);
+
+    if (categoryValue) {
+      businessObject.categoryValueRef = null;
+
+      removeCategoryValue(categoryValue, category, businessObject);
+    } else {
+      removeCategoryValue(null, businessObject.categoryValueRef.$parent, businessObject);
+    }
+  }
+
+
+  // ensure category + value exist before label editing
+
+  this.execute('label.create', function(event) {
+    var context = event.context,
+        labelTarget = context.labelTarget;
+
+    if (!is(labelTarget, 'bpmn:Group')) {
+      return;
+    }
+
+    setCategoryValue(labelTarget, context);
+  });
+
+  this.revert('label.create', function(event) {
+    var context = event.context,
+        labelTarget = context.labelTarget;
+
+    if (!is(labelTarget, 'bpmn:Group')) {
+      return;
+    }
+
+    unsetCategoryValue(labelTarget, context);
+  });
+
+
+  // remove referenced category + value when group was deleted
+
+  this.execute('shape.delete', function(event) {
 
     var context = event.context,
-        shape = context.shape;
+        shape = context.shape,
+        businessObject = getBusinessObject(shape);
 
-    if (is(shape, 'bpmn:Group')) {
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
 
-      var businessObject = getBusinessObject(shape),
-          categoryValueRef = businessObject.categoryValueRef,
-          groupElements = getGroupElements();
+    var categoryValue = context.categoryValue = businessObject.categoryValueRef,
+        category;
 
-      if (!isReferenced(groupElements, categoryValueRef)) {
-        removeReferencedCategoryValue(shape);
-      }
+    if (categoryValue) {
+      category = context.category = categoryValue.$parent;
+
+      removeCategoryValue(categoryValue, category, businessObject);
+
+      businessObject.categoryValueRef = null;
     }
   });
 
-  /**
-   * re-attach removed category
-   */
   this.reverted('shape.delete', function(event) {
 
     var context = event.context,
         shape = context.shape;
 
-    if (is(shape, 'bpmn:Group')) {
-
-      var businessObject = getBusinessObject(shape),
-          categoryValueRef = businessObject.categoryValueRef,
-          definitions = bpmnjs.getDefinitions(),
-          category = categoryValueRef ? categoryValueRef.$parent : null;
-
-      collectionAdd(category.get('categoryValue'), categoryValueRef);
-      collectionAdd(definitions.get('rootElements'), category);
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
     }
-  });
 
-  /**
-   * create new category + value when group was created
-   */
-  this.execute('shape.create', function(event) {
-    var context = event.context,
-        shape = context.shape,
+    var category = context.category,
+        categoryValue = context.categoryValue,
         businessObject = getBusinessObject(shape);
 
-    if (is(businessObject, 'bpmn:Group') && !businessObject.categoryValueRef) {
-
-      var definitions = bpmnjs.getDefinitions(),
-          categoryValue = createCategoryValue(definitions, bpmnFactory);
-
-      // link the reference to the Group
+    if (categoryValue) {
       businessObject.categoryValueRef = categoryValue;
+
+      addCategoryValue(categoryValue, category);
     }
   });
 
 
-  this.revert('shape.create', function(event) {
+  // create new category + value when group was created
+
+  this.execute('shape.create', function(event) {
+    var context = event.context,
+        shape = context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
+
+    if (getBusinessObject(shape).categoryValueRef) {
+      setCategoryValue(shape, context);
+    }
+  });
+
+  this.reverted('shape.create', function(event) {
 
     var context = event.context,
         shape = context.shape;
 
-    if (is(shape, 'bpmn:Group')) {
-      removeReferencedCategoryValue(shape);
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
 
-      delete getBusinessObject(shape).categoryValueRef;
-
+    if (getBusinessObject(shape).categoryValueRef) {
+      unsetCategoryValue(shape, context);
     }
   });
 
-  // copy bpmn:CategoryValue when copying element
-  eventBus.on('moddleCopy.canCopyProperty', HIGH_PRIORITY, function(context) {
-    var property = context.property,
-        categoryValue;
 
-    if (is(property, 'bpmn:CategoryValue')) {
-      categoryValue = createCategoryValue(bpmnjs.getDefinitions(), bpmnFactory);
+  // copy + paste categoryValueRef with group
 
-      // return copy of category
-      return moddleCopy.copyElement(property, categoryValue);
+  function copy(bo, clone) {
+    var targetBo = bpmnFactory.create(bo.$type);
+
+    return moddleCopy.copyElement(bo, targetBo, null, clone);
+  }
+
+  eventBus.on('copyPaste.copyElement', LOWER_PRIORITY, function(context) {
+    var descriptor = context.descriptor,
+        element = context.element;
+
+    if (!is(element, 'bpmn:Group')) {
+      return;
     }
+
+    var groupBo = getBusinessObject(element);
+
+    if (groupBo.categoryValueRef) {
+
+      var categoryValue = groupBo.categoryValueRef;
+
+      descriptor.categoryValue = copy(categoryValue, true);
+
+      if (categoryValue.$parent) {
+        descriptor.category = copy(categoryValue.$parent, true);
+      }
+    }
+  });
+
+  eventBus.on('copyPaste.pasteElement', LOWER_PRIORITY, function(context) {
+    var descriptor = context.descriptor,
+        businessObject = descriptor.businessObject,
+        categoryValue = descriptor.categoryValue,
+        category = descriptor.category;
+
+    if (categoryValue) {
+      categoryValue = businessObject.categoryValueRef = copy(categoryValue);
+    }
+
+    if (category) {
+      categoryValue.$parent = copy(category);
+    }
+
+    delete descriptor.category;
+    delete descriptor.categoryValue;
   });
 
 }

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -261,7 +261,7 @@ export default function GroupBehavior(
     var descriptor = context.descriptor,
         element = context.element;
 
-    if (!is(element, 'bpmn:Group')) {
+    if (!is(element, 'bpmn:Group') || element.labelTarget) {
       return;
     }
 

--- a/lib/features/modeling/behavior/RootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/RootElementReferenceBehavior.js
@@ -133,19 +133,16 @@ export default function RootElementReferenceBehavior(
         rootElement = getRootElement(businessObject);
 
     if (rootElement) {
+
+      // TODO(nikku): clone on copy
       descriptor.referencedRootElement = rootElement;
     }
   });
 
   eventBus.on('copyPaste.pasteElement', LOW_PRIORITY, function(context) {
     var descriptor = context.descriptor,
-        businessObject = descriptor.businessObject;
-
-    if (!canHaveRootElementReference(businessObject)) {
-      return;
-    }
-
-    var referencedRootElement = descriptor.referencedRootElement;
+        businessObject = descriptor.businessObject,
+        referencedRootElement = descriptor.referencedRootElement;
 
     if (!referencedRootElement) {
       return;
@@ -159,6 +156,8 @@ export default function RootElementReferenceBehavior(
     }
 
     setRootElement(businessObject, referencedRootElement);
+
+    delete descriptor.referencedRootElement;
   });
 }
 

--- a/lib/features/modeling/behavior/RootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/RootElementReferenceBehavior.js
@@ -125,7 +125,7 @@ export default function RootElementReferenceBehavior(
     var descriptor = context.descriptor,
         element = context.element;
 
-    if (!canHaveRootElementReference(element)) {
+    if (element.labelTarget || !canHaveRootElementReference(element)) {
       return;
     }
 

--- a/lib/features/modeling/behavior/util/CategoryUtil.js
+++ b/lib/features/modeling/behavior/util/CategoryUtil.js
@@ -1,30 +1,83 @@
 import {
-  add as collectionAdd
+  add as collectionAdd,
+  remove as collectionRemove
 } from 'diagram-js/lib/util/Collections';
 
-import {
-  getBusinessObject
-} from '../../../../util/ModelUtil';
 
 /**
  * Creates a new bpmn:CategoryValue inside a new bpmn:Category
  *
- * @param {ModdleElement} definitions
  * @param {BpmnFactory} bpmnFactory
  *
  * @return {ModdleElement} categoryValue.
  */
-export function createCategoryValue(definitions, bpmnFactory) {
-  var categoryValue = bpmnFactory.create('bpmn:CategoryValue'),
-      category = bpmnFactory.create('bpmn:Category', {
-        categoryValue: [ categoryValue ]
-      });
+export function createCategory(bpmnFactory) {
+  return bpmnFactory.create('bpmn:Category');
+}
 
-  // add to correct place
+/**
+ * Creates a new bpmn:CategoryValue inside a new bpmn:Category
+ *
+ * @param {BpmnFactory} bpmnFactory
+ *
+ * @return {ModdleElement} categoryValue.
+ */
+export function createCategoryValue(bpmnFactory) {
+  return bpmnFactory.create('bpmn:CategoryValue');
+}
+
+/**
+ * Adds category value to definitions
+ *
+ * @param {ModdleElement} categoryValue
+ * @param {ModdleElement} category
+ * @param {ModdleElement} definitions
+ *
+ * @return {ModdleElement} categoryValue
+ */
+export function linkCategoryValue(categoryValue, category, definitions) {
+  collectionAdd(category.get('categoryValue'), categoryValue);
+  categoryValue.$parent = category;
+
   collectionAdd(definitions.get('rootElements'), category);
-  getBusinessObject(category).$parent = definitions;
-  getBusinessObject(categoryValue).$parent = category;
+  category.$parent = definitions;
 
   return categoryValue;
+}
 
+/**
+ * Unlink category value from parent
+ *
+ * @param {ModdleElement} categoryValue
+ *
+ * @return {ModdleElement} categoryValue
+ */
+export function unlinkCategoryValue(categoryValue) {
+  var category = categoryValue.$parent;
+
+  if (category) {
+    collectionRemove(category.get('categoryValue'), categoryValue);
+    categoryValue.$parent = null;
+  }
+
+  return categoryValue;
+}
+
+/**
+ * Unlink category from parent
+ *
+ * @param {ModdleElement} category
+ * @param {ModdleElement} definitions
+ *
+ * @return {ModdleElement} categoryValue
+ */
+export function unlinkCategory(category) {
+  var definitions = category.$parent;
+
+  if (definitions) {
+    collectionRemove(definitions.get('rootElements'), category);
+    category.$parent = null;
+  }
+
+  return category;
 }

--- a/lib/features/modeling/cmd/UpdateModdlePropertiesHandler.js
+++ b/lib/features/modeling/cmd/UpdateModdlePropertiesHandler.js
@@ -25,6 +25,9 @@ UpdateModdlePropertiesHandler.prototype.execute = function(context) {
     throw new Error('<moddleElement> required');
   }
 
+  // TODO(nikku): we need to ensure that ID properties
+  // are properly registered / unregistered via
+  // this._moddle.ids.assigned(id)
   var changed = context.changed || this.getVisualReferences(moddleElement).concat(element);
   var oldProperties = context.oldProperties || getModdleProperties(moddleElement, keys(properties));
 

--- a/test/spec/Modeler.copy-paste.complex.bpmn
+++ b/test/spec/Modeler.copy-paste.complex.bpmn
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0ykgsoo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:error id="Error_1" name="SomeError" errorCode="100" />
+  <bpmn:collaboration id="Collaboration">
+    <bpmn:participant id="P1" name="P1" processRef="Process_1" />
+    <bpmn:participant id="P2" name="P2" processRef="Process_2" />
+    <bpmn:messageFlow id="MessageFlow" name="MessageFlow" sourceRef="Activity_1" targetRef="Start" />
+    <bpmn:group id="Group_With_Name" categoryValueRef="CategoryValue_1" />
+    <bpmn:group id="Group_No_Name" />
+    <bpmn:textAnnotation id="Text_Annotation">
+      <bpmn:text>Text_Annotation</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association" sourceRef="P1" targetRef="Text_Annotation" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Start" name="Start" camunda:initiator="walt">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Say_Hello" name="Say_Hello">
+      <bpmn:extensionElements>
+        <camunda:executionListener expression="foo()" event="start" />
+        <camunda:inputOutput>
+          <camunda:inputParameter name="name">${ foobar }</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_1">
+        <bpmn:targetRef>DataStoreReference</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+    </bpmn:task>
+    <bpmn:endEvent id="End" name="End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start" targetRef="Say_Hello" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Say_Hello" targetRef="End" />
+    <bpmn:dataStoreReference id="DataStoreReference" name="DataStoreReference" />
+    <bpmn:boundaryEvent id="Say_Hello_Error" name="Say_Hello_Error" attachedToRef="Say_Hello">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0hmbmox" errorRef="Error_1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Say_Hello_Escalation" name="Say_Hello_Escalation" cancelActivity="false" attachedToRef="Say_Hello">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" escalationRef="Escalation_1" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:process id="Process_2" name="Process_2" isExecutable="false">
+    <bpmn:task id="Activity_1">
+      <bpmn:dataOutputAssociation id="DataOutputAssociation">
+        <bpmn:targetRef>DataObjectReference</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+    </bpmn:task>
+    <bpmn:dataObjectReference id="DataObjectReference" dataObjectRef="DataObject" />
+    <bpmn:dataObject id="DataObject" />
+    <bpmn:subProcess id="Collapsed_Sub" name="Collapsed_Sub">
+      <bpmn:subProcess id="Sub_Process_Expanded_Nested" name="Sub_Process_Expanded_Nested" default="FlowDefault">
+        <bpmn:incoming>Flow_3</bpmn:incoming>
+        <bpmn:outgoing>FlowDefault</bpmn:outgoing>
+        <bpmn:outgoing>FlowConditional</bpmn:outgoing>
+        <bpmn:startEvent id="Event_4">
+          <bpmn:outgoing>Flow_7</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:task id="Activity_4">
+          <bpmn:incoming>Flow_7</bpmn:incoming>
+          <bpmn:outgoing>Flow_8</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_7" sourceRef="Event_4" targetRef="Activity_4" />
+        <bpmn:endEvent id="Event_5">
+          <bpmn:incoming>Flow_8</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_8" sourceRef="Activity_4" targetRef="Event_5" />
+      </bpmn:subProcess>
+      <bpmn:startEvent id="Event_2">
+        <bpmn:outgoing>Flow_3</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_3" sourceRef="Event_2" targetRef="Sub_Process_Expanded_Nested" />
+      <bpmn:exclusiveGateway id="Gateway_1">
+        <bpmn:incoming>FlowDefault</bpmn:incoming>
+        <bpmn:outgoing>Flow_4</bpmn:outgoing>
+        <bpmn:outgoing>Flow_6</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:sequenceFlow id="FlowDefault" name="FlowDefault" sourceRef="Sub_Process_Expanded_Nested" targetRef="Gateway_1" />
+      <bpmn:task id="Activity_5">
+        <bpmn:incoming>Flow_4</bpmn:incoming>
+        <bpmn:outgoing>Flow_5</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_4" sourceRef="Gateway_1" targetRef="Activity_5">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">foo()</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="Event_3">
+        <bpmn:incoming>Flow_5</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_5" sourceRef="Activity_5" targetRef="Event_3" />
+      <bpmn:task id="Activity_2">
+        <bpmn:incoming>Flow_6</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_6" sourceRef="Gateway_1" targetRef="Activity_2">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">bar()</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:task id="Activity_6">
+        <bpmn:incoming>FlowConditional</bpmn:incoming>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="FlowConditional" name="FlowConditional" sourceRef="Sub_Process_Expanded_Nested" targetRef="Activity_6">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">waat()</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:textAnnotation id="TextAnnotation_2">
+        <bpmn:text>Conditions, Default Flow and friends</bpmn:text>
+      </bpmn:textAnnotation>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Boundary_No_Message" name="Boundary_No_Message" cancelActivity="false" attachedToRef="Activity_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0n2euac" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:category id="Category_1">
+    <bpmn:categoryValue id="CategoryValue_1" value="Group_With_Name" />
+  </bpmn:category>
+  <bpmn:escalation id="Escalation_1" name="Escalation" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration">
+      <bpmndi:BPMNShape id="P1_di" bpmnElement="P1" isHorizontal="true">
+        <dc:Bounds x="160" y="170" width="530" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="500" y="307" />
+        <di:waypoint x="562" y="307" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="345" y="307" />
+        <di:waypoint x="400" y="307" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Start_di" bpmnElement="Start">
+        <dc:Bounds x="309" y="289" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="315" y="265" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Say_Hello_di" bpmnElement="Say_Hello">
+        <dc:Bounds x="400" y="267" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_di" bpmnElement="End">
+        <dc:Bounds x="562" y="289" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="570" y="332" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_di" bpmnElement="DataStoreReference">
+        <dc:Bounds x="555" y="185" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="540" y="242" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r07nr0_di" bpmnElement="Say_Hello_Error">
+        <dc:Bounds x="442" y="329" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="420" y="372" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Say_Hello_Escalation_di" bpmnElement="Say_Hello_Escalation">
+        <dc:Bounds x="422" y="249" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="395" y="219" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="P2_di" bpmnElement="P2" isHorizontal="true">
+        <dc:Bounds x="160" y="570" width="530" height="190" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1_di" bpmnElement="Activity_1">
+        <dc:Bounds x="290" y="610" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_di" bpmnElement="DataObjectReference">
+        <dc:Bounds x="482" y="665" width="36" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Collapsed_Sub_di" bpmnElement="Collapsed_Sub">
+        <dc:Bounds x="560" y="610" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Boundary_No_Message_di" bpmnElement="Boundary_No_Message">
+        <dc:Bounds x="332" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="306" y="715" width="89" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_With_Name_di" bpmnElement="Group_With_Name">
+        <dc:Bounds x="270" y="520" width="270" height="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="367" y="527" width="79" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_No_Name_di" bpmnElement="Group_No_Name">
+        <dc:Bounds x="720" y="210" width="230" height="180" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="792" y="217" width="87" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Text_Annotation_di" bpmnElement="Text_Annotation">
+        <dc:Bounds x="680" y="80" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_1_di" bpmnElement="DataOutputAssociation_1">
+        <di:waypoint x="499" y="272" />
+        <di:waypoint x="555" y="233" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_di" bpmnElement="DataOutputAssociation">
+        <di:waypoint x="390" y="663" />
+        <di:waypoint x="482" y="686" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_di" bpmnElement="Association">
+        <di:waypoint x="616" y="170" />
+        <di:waypoint x="707" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="MessageFlow_di" bpmnElement="MessageFlow">
+        <di:waypoint x="327" y="610" />
+        <di:waypoint x="327" y="325" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="309" y="465" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0xhesl2">
+    <bpmndi:BPMNPlane id="BPMNPlane_Collapsed_Sub" bpmnElement="Collapsed_Sub">
+      <bpmndi:BPMNEdge id="FlowConditional_di" bpmnElement="FlowConditional">
+        <di:waypoint x="670" y="250" />
+        <di:waypoint x="730" y="250" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="661" y="232" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_6_di" bpmnElement="Flow_6">
+        <di:waypoint x="475" y="445" />
+        <di:waypoint x="475" y="530" />
+        <di:waypoint x="550" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_5_di" bpmnElement="Flow_5">
+        <di:waypoint x="650" y="420" />
+        <di:waypoint x="702" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="500" y="420" />
+        <di:waypoint x="550" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="FlowDefault_di" bpmnElement="FlowDefault">
+        <di:waypoint x="475" y="350" />
+        <di:waypoint x="475" y="395" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="461" y="370" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="198" y="250" />
+        <di:waypoint x="300" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Sub_Process_Expanded_Nested_di" bpmnElement="Sub_Process_Expanded_Nested" isExpanded="true">
+        <dc:Bounds x="300" y="150" width="370" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_8_di" bpmnElement="Flow_8">
+        <di:waypoint x="530" y="250" />
+        <di:waypoint x="592" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_7_di" bpmnElement="Flow_7">
+        <di:waypoint x="376" y="250" />
+        <di:waypoint x="430" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_4_di" bpmnElement="Event_4">
+        <dc:Bounds x="340" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_4_di" bpmnElement="Activity_4">
+        <dc:Bounds x="430" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_5_di" bpmnElement="Event_5">
+        <dc:Bounds x="592" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_2_di" bpmnElement="Event_2">
+        <dc:Bounds x="162" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="450" y="395" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_5_di" bpmnElement="Activity_5">
+        <dc:Bounds x="550" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_3_di" bpmnElement="Event_3">
+        <dc:Bounds x="702" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_2_di" bpmnElement="Activity_2">
+        <dc:Bounds x="550" y="490" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_6_di" bpmnElement="Activity_6">
+        <dc:Bounds x="730" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_2_di" bpmnElement="TextAnnotation_2">
+        <dc:Bounds x="590" y="50" width="100.00000762939453" height="55.000003814697266" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/Modeler.copy-paste.empty.bpmn
+++ b/test/spec/Modeler.copy-paste.empty.bpmn
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_Other" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="Process_1" isExecutable="true" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -2,6 +2,8 @@ import Modeler from 'lib/Modeler';
 import Viewer from 'lib/Viewer';
 import NavigatedViewer from 'lib/NavigatedViewer';
 
+import { isAny } from 'lib/util/ModelUtil';
+
 import Clipboard from 'diagram-js/lib/features/clipboard/Clipboard';
 
 import TestContainer from 'mocha-test-container-support';
@@ -16,6 +18,11 @@ import {
   collectTranslations,
   enableLogging
 } from 'test/TestHelper';
+
+import {
+  pick,
+  find
+} from 'min-dash';
 
 import { getDi } from 'lib/util/ModelUtil';
 
@@ -708,6 +715,133 @@ describe('Modeler', function() {
 
     });
 
+
+    it('should copy + paste via serialized tree', function() {
+
+      var aXML = require('./Modeler.copy-paste.complex.bpmn');
+      var bXML = require('./Modeler.copy-paste.empty.bpmn');
+
+      m2 = new Modeler({
+        container: container
+      });
+
+      m1 = new Modeler({
+        container: container
+      });
+
+      return Promise.all([
+        m1.importXML(aXML),
+        m2.importXML(bXML)
+      ]).then(function() {
+
+        // given
+        // copy all from m1
+        var serializedTree = m1.invoke(function(clipboard, editorActions) {
+          editorActions.trigger('selectElements');
+
+          editorActions.trigger('copy');
+
+          return JSON.stringify(clipboard.get());
+        });
+
+        // assume
+        expect(serializedTree).to.exist;
+
+        // TODO(nikku): needed for our canvas utilities to work
+        setBpmnJS(m2);
+
+        m2.invoke(function(
+            moddle, clipboard, dragging,
+            editorActions, elementRegistry,
+            bpmnjs) {
+
+          var definitions = bpmnjs.getDefinitions();
+          var processElement = elementRegistry.get('Process_1');
+
+          // when
+          // deserialize tree
+          var tree = JSON.parse(serializedTree, createReviver(moddle));
+
+          // set to clipboard
+          clipboard.set(tree);
+
+          // paste all to m2
+          editorActions.trigger('paste');
+          dragging.move(createCanvasEvent({ x: 150, y: 150 }));
+          dragging.move(createCanvasEvent({ x: 170, y: 150 }));
+          dragging.hover({ element: processElement });
+
+          dragging.end();
+
+          // then
+          // elements exist with original IDs
+          var expectedIds = [
+            'P1',
+            'P2',
+            'DataStoreReference',
+            'DataObjectReference',
+            'DataOutputAssociation',
+            'Say_Hello_Error',
+            'Group_No_Name',
+            'Group_With_Name',
+            'Collapsed_Sub',
+            'Sub_Process_Expanded_Nested',
+            'FlowDefault',
+            'FlowConditional',
+            'Text_Annotation',
+            'Association'
+          ];
+
+          expectedIds.forEach(function(id) {
+            expect(elementRegistry.get(id), 'element <' + id + '>').to.exist;
+          });
+
+          // global elements exist
+          var expectedGlobals = [
+            [ 'Error_1', { name: 'SomeError', errorCode: '100' } ],
+            [ 'Escalation_1', { name: 'Escalation' } ],
+            [ 'Category_1', { } ]
+          ];
+
+          var globals = [
+            'bpmn:Error',
+            'bpmn:Category',
+            'bpmn:Escalation',
+            'bpmn:Signal',
+            'bpmn:Message'
+          ];
+
+          var globalElements = definitions.get('rootElements').filter(function(element) {
+            return isAny(element, globals);
+          });
+
+          // expect <expectedGlobals>
+          expect(globalElements).to.have.length(expectedGlobals.length);
+
+          expectedGlobals.forEach(function(expected) {
+            var id = expected[0];
+            var attrs = expected[1];
+
+            var actualGlobal = find(globalElements, function(el) {
+              return el.id === id;
+            });
+
+            expect(actualGlobal, 'global <' + id + '>').to.exist;
+
+            var actualAttrs = pick(actualGlobal, Object.keys(attrs));
+
+            expect(actualAttrs, 'global <' + id + '> attrs').to.eql(attrs);
+          });
+
+        });
+
+      });
+
+    });
+
+
+    it.skip('should copy + delete + paste');
+
   });
 
 
@@ -787,3 +921,59 @@ describe('Modeler', function() {
   });
 
 });
+
+
+// helpers //////////////
+
+
+/**
+ * A factory function that returns a reviver to be
+ * used with JSON#parse to reinstantiate moddle instances.
+ *
+ * @param { Moddle } moddle
+ *
+ * @return { (key: string, object: any) => any|null }
+ */
+function createReviver(moddle) {
+
+  var elCache = {};
+
+  /**
+   * The actual reviewer that creates model instances
+   * for elements with a $type attribute.
+   *
+   * Elements with ids will be re-used, if already
+   * created.
+   *
+   * @param {string} key
+   * @param {any} object
+   *
+   * @return {any|null} actual element
+   */
+  return function(key, object) {
+
+    if (typeof object === 'object' && typeof object.$type === 'string') {
+
+      var objectId = object.id;
+
+      if (objectId && elCache[objectId]) {
+        return elCache[objectId];
+      }
+
+      var type = object.$type;
+      var attrs = Object.assign({}, object);
+
+      delete attrs.$type;
+
+      var newEl = moddle.create(type, attrs);
+
+      if (objectId) {
+        elCache[objectId] = newEl;
+      }
+
+      return newEl;
+    }
+
+    return object;
+  };
+}

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -140,9 +140,7 @@ describe('features/copy-paste', function() {
 
           // then
           expect(attachedBoundaryEvent.businessObject.attachedToRef).to.eql(task.businessObject);
-
           expect(attachedBoundaryEvent.host).to.be.eql(task);
-
           expect(attachedBoundaryEvent.type).to.eql('bpmn:BoundaryEvent');
 
         }));
@@ -150,38 +148,21 @@ describe('features/copy-paste', function() {
       });
 
 
-      it('should NOT override type property of descriptor', inject(function(elementRegistry) {
+      it('should not mutate copy', inject(function(copyPaste, elementRegistry, modeling) {
 
         // given
-        var startEvent = elementRegistry.get('StartEvent_1'),
-            startEventBo = getBusinessObject(startEvent);
+        var parent = elementRegistry.get('Process_1'),
+            event = elementRegistry.get('IntermediateThrowEvent_1');
 
-        // add type property to business object
-        startEventBo.type = 'external';
-
-        // when
-        var tree = copy(startEvent);
-
-        // then
-        expect(findDescriptorInTree('StartEvent_1', tree).type).to.eql('bpmn:StartEvent');
-      }));
-
-
-      it.skip('should not mutate copied elements', inject(function(copyPaste, elementRegistry, modeling) {
-
-        // given
-        var process = elementRegistry.get('Process_1'),
-            intermediateThrowEvent = elementRegistry.get('IntermediateThrowEvent_1');
-
-        copyPaste.copy(intermediateThrowEvent);
+        copyPaste.copy(event);
 
         // when
-        modeling.updateProperties(intermediateThrowEvent, {
+        modeling.updateProperties(event, {
           name: 'foo'
         });
 
         var elements = copyPaste.paste({
-          element: process,
+          element: parent,
           point: {
             x: 1000,
             y: 1000
@@ -189,16 +170,12 @@ describe('features/copy-paste', function() {
         });
 
         // then
-        intermediateThrowEvent = find(elements, function(element) {
+        var pastedEvent = find(elements, function(element) {
           return is(element, 'bpmn:IntermediateThrowEvent');
         });
 
-        var intermediateThrowEventBo = getBusinessObject(intermediateThrowEvent);
-
-        // due to https://github.com/bpmn-io/bpmn-js/blob/v5.1.2/lib/features/modeling/behavior/LabelBehavior.js#L97
-        // the business object of the copied element is mutated
-        // see https://github.com/bpmn-io/bpmn-js/issues/798
-        expect(intermediateThrowEventBo.name).not.to.exist;
+        var pastedEventBo = getBusinessObject(pastedEvent);
+        expect(pastedEventBo.name).not.to.exist;
       }));
 
     });
@@ -739,20 +716,41 @@ describe('features/copy-paste', function() {
     }));
 
 
-    it('should copy process when copying participant', inject(
+    function expectEqual(copy, original) {
+      var originalBo = getBusinessObject(original);
+      var copyBo = getBusinessObject(copy);
+
+      expect(originalBo).not.to.equal(copyBo);
+
+      var originalProcessRef = originalBo.processRef;
+      var copyProcessRef = copyBo.processRef;
+
+      expect(copyProcessRef).not.to.equal(originalProcessRef);
+      expect(copyProcessRef.extensionElements).to.exist;
+      expect(copyProcessRef.extensionElements.values).to.have.length(1);
+      expect(copyProcessRef.get('flowElements')).to.have.length(originalProcessRef.get('flowElements').length);
+
+      var copyExecutionListener = copyProcessRef.extensionElements.values[0];
+      var originalExtensionListener = originalProcessRef.extensionElements.values[0];
+
+      expect(copyExecutionListener.$type).to.equal(originalExtensionListener.$type);
+      expect(copyExecutionListener.class).to.equal(originalExtensionListener.class);
+      expect(copyExecutionListener.event).to.equal(originalExtensionListener.event);
+    }
+
+
+    it('should copy participant with process', inject(
       function(canvas, copyPaste, elementRegistry) {
 
         // given
         var participantInput = elementRegistry.get('Participant_Input'),
-            participantInputBo = getBusinessObject(participantInput),
             participantOutput = elementRegistry.get('Participant_Output'),
-            participantOutputBo = getBusinessObject(participantOutput),
             rootElement = canvas.getRootElement();
 
         // when
         copyPaste.copy([ participantInput, participantOutput ]);
 
-        var elements = copyPaste.paste({
+        var elements_1 = copyPaste.paste({
           element: rootElement,
           point: {
             x: 5000,
@@ -761,29 +759,37 @@ describe('features/copy-paste', function() {
         });
 
         // then
-        var participants = elements.filter(function(element) {
+        var participants_1 = elements_1.filter(function(element) {
           return is(element, 'bpmn:Participant');
         });
 
-        forEach(participants, function(participant) {
-          var participantBo = getBusinessObject(participant);
+        expect(participants_1).to.have.length(2);
 
-          expect(participantBo.processRef).not.to.equal(participantInputBo.processRef);
-          expect(participantBo.processRef).not.to.equal(participantOutputBo.processRef);
+        expectEqual(participantInput, participants_1[0]);
+        expectEqual(participantOutput, participants_1[1]);
 
-          expect(participantBo.processRef.isExecutable).to.be.true;
-
-          expect(participantBo.processRef.extensionElements.values).to.have.length(1);
-
-          var executionListener = participantBo.processRef.extensionElements.values[0];
-
-          expect(executionListener.$type).to.equal('camunda:ExecutionListener');
-          expect(executionListener.class).to.equal('Foo');
-          expect(executionListener.event).to.equal('start');
+        // but when
+        // paste second time
+        var elements_2 = copyPaste.paste({
+          element: rootElement,
+          point: {
+            x: 7000,
+            y: 5000
+          }
         });
 
-        expect(getBusinessObject(participants[0]).processRef)
-          .not.to.equal(getBusinessObject(participants[1]).processRef);
+        // then
+        var participants_2 = elements_2.filter(function(element) {
+          return is(element, 'bpmn:Participant');
+        });
+
+        expect(participants_2).to.have.length(2);
+
+        expectEqual(participants_2[0], participantInput);
+        expectEqual(participants_2[1], participantOutput);
+
+        expectEqual(participants_2[0], participants_1[0]);
+        expectEqual(participants_2[1], participants_1[1]);
       }
     ));
 

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -215,6 +215,7 @@ describe('features/copy-paste', function() {
       });
 
       expect(subProcesses[0].id).not.to.equal(subProcesses[1].id);
+      expect(subProcesses[0].businessObject).not.to.equal(subProcesses[1].businessObject);
     }));
 
 

--- a/test/spec/features/copy-paste/ModdleCopySpec.js
+++ b/test/spec/features/copy-paste/ModdleCopySpec.js
@@ -727,6 +727,33 @@ describe('features/copy-paste/ModdleCopy', function() {
         expect(endEvent.eventDefinitions[0].$type).to.equal('bpmn:MessageEventDefinition');
       }));
 
+
+      it('should clone', inject(function(moddleCopy, eventBus, moddle) {
+
+        // given
+        var task = moddle.create('bpmn:Task', {
+          name: 'foo'
+        });
+
+        eventBus.once('moddleCopy.canCopyProperty', HIGH_PRIORITY, function(context) {
+          var propertyName = context.propertyName;
+
+          var clone = context.clone;
+
+          expect(clone).to.be.true;
+
+          if (propertyName === 'name') {
+            return 'bar';
+          }
+        });
+
+        // when
+        var userTask = moddleCopy.copyElement(task, moddle.create('bpmn:UserTask'), null, true);
+
+        // then
+        expect(userTask.id).to.eql(task.id);
+      }));
+
     });
 
 
@@ -804,7 +831,10 @@ describe('features/copy-paste/ModdleCopy', function() {
       });
 
       // when
-      var newElement = moddleCopy.copyElement(customElement, moddle.create('custom:CustomSendElement'));
+      var newElement = moddleCopy.copyElement(
+        customElement,
+        moddle.create('custom:CustomSendElement')
+      );
 
       // then
       expect(newElement.paths).to.have.length(3);

--- a/test/spec/features/copy-paste/ModdleCopySpec.js
+++ b/test/spec/features/copy-paste/ModdleCopySpec.js
@@ -133,19 +133,36 @@ describe('features/copy-paste/ModdleCopy', function() {
     }));
 
 
-    it('should NOT copy references', inject(function(moddle, moddleCopy) {
+    it('should NOT copy <processRef>', inject(function(moddle, moddleCopy) {
 
       // given
-      var processRef = moddle.create('bpmn:Process'),
+      var processElement = moddle.create('bpmn:Process'),
           participant = moddle.create('bpmn:Participant');
 
-      participant.processRef = processRef;
+      participant.processRef = processElement;
 
       // when
-      participant = moddleCopy.copyElement(participant, moddle.create('bpmn:Participant'));
+      var copiedParticipant = moddleCopy.copyElement(participant, moddle.create('bpmn:Participant'));
 
       // then
-      expect(participant.processRef).not.to.equal(processRef);
+      expect(copiedParticipant).not.to.equal(participant);
+      expect(copiedParticipant.processRef).not.to.exist;
+    }));
+
+
+    it('should NOT copy misc references', inject(function(moddle, moddleCopy) {
+
+      // given
+      var label = moddle.create('bpmndi:BPMNLabel'),
+          labelStyle = moddle.create('bpmndi:BPMNLabelStyle');
+
+      label.labelStyle = labelStyle;
+
+      // when
+      var copiedLabel = moddleCopy.copyElement(label, moddle.create('bpmndi:BPMNLabel'));
+
+      // then
+      expect(copiedLabel.labelStyle).not.to.exist;
     }));
 
 

--- a/test/spec/features/copy-paste/collapsed-subprocess.bpmn
+++ b/test/spec/features/copy-paste/collapsed-subprocess.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="PROCESS" name="PROCESS" isExecutable="true">
+    <bpmn:subProcess id="SUB_PROCESS" name="SUB_PROCESS">
+      <bpmn:task id="SUB_TASK" name="SUB_TASK" />
+      <bpmn:boundaryEvent id="SUB_BOUNDARY" name="SUB_BOUNDARY" cancelActivity="false" attachedToRef="SUB_TASK">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" escalationRef="ESCALATION" />
+      </bpmn:boundaryEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:escalation id="ESCALATION" name="ESCALATION" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PROCESS">
+      <bpmndi:BPMNShape id="SUB_PROCESS_di" bpmnElement="SUB_PROCESS">
+        <dc:Bounds x="170" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_SUB_PROCESS" bpmnElement="SUB_PROCESS">
+      <bpmndi:BPMNShape id="SUB_TASK_di" bpmnElement="SUB_TASK">
+        <dc:Bounds x="190" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SUB_BOUNDARY_di" bpmnElement="SUB_BOUNDARY">
+        <dc:Bounds x="232" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="208" y="185" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/copy-paste/data-associations.bpmn
+++ b/test/spec/features/copy-paste/data-associations.bpmn
@@ -15,9 +15,9 @@
     </bpmn:task>
     <bpmn:dataStoreReference id="DataStoreReference_1" />
   </bpmn:process>
-  <bpmn:process id="Process_Input" isExecutable="true">
+  <bpmn:process id="Process_Input" isExecutable="false">
     <bpmn:extensionElements>
-      <camunda:executionListener class="Foo" event="start" />
+      <camunda:executionListener class="Bar" event="start" />
     </bpmn:extensionElements>
     <bpmn:dataStoreReference id="DataStoreReference_2" />
     <bpmn:task id="Task_2">

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -582,7 +582,7 @@ describe('features - label-editing', function() {
     }));
 
 
-    it('should initialize categoryValue for empty group', inject(
+    it('should set label on group (no category value)', inject(
       function(elementRegistry, directEditing) {
 
         // given

--- a/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
@@ -18,7 +18,7 @@ describe('features/modeling/behavior - boundary event', function() {
   beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
 
-  describe('implicitly removing boundary events', function() {
+  describe('should implicitly remove boundary events', function() {
 
     it('after connecting to event-based gateway',
       inject(function(modeling, elementRegistry) {
@@ -64,11 +64,11 @@ describe('features/modeling/behavior - boundary event', function() {
   });
 
 
-  describe('copy reference on replace', function() {
+  describe('should keep root element reference on replace', function() {
 
     it('interrupting to non-interrupting', function() {
 
-      it('should copy message reference', inject(function(bpmnReplace, elementRegistry) {
+      it('message reference', inject(function(bpmnReplace, elementRegistry) {
 
         // given
         var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_2'),
@@ -89,7 +89,7 @@ describe('features/modeling/behavior - boundary event', function() {
       }));
 
 
-      it('should copy escalation reference', inject(function(bpmnReplace, elementRegistry) {
+      it('escalation reference', inject(function(bpmnReplace, elementRegistry) {
 
         // given
         var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_3'),
@@ -110,7 +110,7 @@ describe('features/modeling/behavior - boundary event', function() {
       }));
 
 
-      it('should copy error reference', inject(function(bpmnReplace, elementRegistry) {
+      it('error reference', inject(function(bpmnReplace, elementRegistry) {
 
         // given
         var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_4'),
@@ -131,7 +131,7 @@ describe('features/modeling/behavior - boundary event', function() {
       }));
 
 
-      it('should copy signal reference', inject(function(bpmnReplace, elementRegistry) {
+      it('signal reference', inject(function(bpmnReplace, elementRegistry) {
 
         // given
         var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_5'),
@@ -156,7 +156,7 @@ describe('features/modeling/behavior - boundary event', function() {
 
     it('non-interrupting to interrupting', function() {
 
-      it('should copy message reference', inject(function(bpmnReplace, elementRegistry) {
+      it('message reference', inject(function(bpmnReplace, elementRegistry) {
 
         // given
         var interruptingBoundaryEvent = elementRegistry.get('BoundaryEvent_6'),
@@ -181,6 +181,7 @@ describe('features/modeling/behavior - boundary event', function() {
   });
 
 });
+
 
 // helpers //////////
 

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.bpmn
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.bpmn
@@ -13,6 +13,7 @@
     <group id="Group_2" categoryValueRef="CategoryValue_1" />
     <group id="Group_3" categoryValueRef="CategoryValue_2" />
     <group id="Group_4" categoryValueRef="CategoryValue_3" />
+    <group id="Group_NO_CATEGORY_VALUE" />
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane bpmnElement="Process_1">
@@ -33,6 +34,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_4_di" bpmnElement="Group_4">
         <omgdc:Bounds x="836" y="75" width="200" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_NO_CATEGORY_VALUE_di" bpmnElement="Group_NO_CATEGORY_VALUE">
+        <omgdc:Bounds x="610" y="320" width="199" height="200" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -25,7 +25,6 @@ describe('features/modeling/behavior - groups', function() {
     modelingModule
   ];
 
-
   var processDiagramXML = require('./GroupBehaviorSpec.bpmn');
 
   beforeEach(bootstrapModeler(processDiagramXML, {
@@ -330,6 +329,57 @@ describe('features/modeling/behavior - groups', function() {
         // then
         expect(category.get('categoryValue')).not.to.include(categoryValue);
         expect(definitions.get('rootElements')).not.to.include(category);
+      }));
+
+    });
+
+
+    describe('should handle non-existing CategoryValue gracefully', function() {
+
+      it('execute', inject(function(elementRegistry, modeling) {
+
+        // given
+        var groupShape = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(groupShape);
+
+        // assume
+        expect(groupBo.categoryValueRef).not.to.exist;
+
+        // then
+        modeling.removeShape(groupShape);
+      }));
+
+
+      it('undo', inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        var groupShape = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(groupShape);
+
+        // when
+        modeling.removeShape(groupShape);
+
+        commandStack.undo();
+
+        // then
+        expect(groupBo.categoryValueRef).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        var groupShape = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(groupShape);
+
+        // when
+        modeling.removeShape(groupShape);
+
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(groupBo.categoryValueRef).not.to.exist;
       }));
 
     });

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -8,10 +8,6 @@ import {
   is
 } from 'lib/util/ModelUtil';
 
-import {
-  indexOf as collectionIndexOf
-} from 'diagram-js/lib/util/Collections';
-
 import bpmnCopyPasteModule from 'lib/features/copy-paste';
 import copyPasteModule from 'diagram-js/lib/features/copy-paste';
 import modelingModule from 'lib/features/modeling';
@@ -26,18 +22,16 @@ describe('features/modeling/behavior - groups', function() {
     coreModule,
     copyPasteModule,
     bpmnCopyPasteModule,
-    modelingModule ];
+    modelingModule
+  ];
 
 
   var processDiagramXML = require('./GroupBehaviorSpec.bpmn');
 
-  beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules.concat(modelingModule) }));
+  beforeEach(bootstrapModeler(processDiagramXML, {
+    modules: testModules.concat(modelingModule)
+  }));
 
-  function expectIncludedOrNot(collection, object, expected) {
-    var isIncluded = collectionIndexOf(collection, object) >= 0;
-
-    expect(isIncluded).to.equal(expected);
-  }
 
   describe('creation', function() {
 
@@ -61,102 +55,67 @@ describe('features/modeling/behavior - groups', function() {
 
         // then
         expect(categoryValueRef).to.eql(categoryValue);
-        expect(originalSize).to.equal(definitions.get('rootElements').length);
 
+        expect(definitions.get('rootElements')).to.have.length(originalSize);
       }
     ));
 
 
-    describe('should create new Category for every new Group', function() {
+    describe('should NOT create Category for new Group', function() {
 
       it('execute', inject(function(canvas, elementFactory, modeling) {
 
         // given
-        var group = elementFactory.createShape({ type: 'bpmn:Group' }),
-            root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent;
+        var root = canvas.getRootElement();
 
         // when
-        var groupShape = modeling.createShape(group, { x: 100, y: 100 }, root),
-            categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
+        var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
+            groupBo = getBusinessObject(group),
+            categoryValue = groupBo.categoryValueRef;
 
         // then
-        expect(categoryValueRef).to.exist;
-        expect(category).to.exist;
-
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          true
-        );
-
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          true
-        );
-
+        expect(categoryValue).not.to.exist;
       }));
 
 
       it('undo', inject(function(canvas, elementFactory, modeling, commandStack) {
 
         // given
-        var group = elementFactory.createShape({ type: 'bpmn:Group' }),
-            root = canvas.getRootElement();
+        var root = canvas.getRootElement();
 
         // when
-        var groupShape = modeling.createShape(group, { x: 100, y: 100 }, root);
+        var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
+            groupBo = getBusinessObject(group);
 
         commandStack.undo();
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef;
+        var categoryValue = groupBo.categoryValueRef;
 
         // then
-        expect(categoryValueRef).not.to.exist;
-
+        expect(categoryValue).not.to.exist;
       }));
 
 
       it('redo', inject(function(canvas, elementFactory, modeling, commandStack) {
 
         // given
-        var group = elementFactory.createShape({ type: 'bpmn:Group' }),
-            root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent;
+        var root = canvas.getRootElement();
 
         // when
-        var groupShape = modeling.createShape(group, { x: 100, y: 100 }, root);
+        var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
+            groupBo = getBusinessObject(group);
 
         commandStack.undo();
         commandStack.redo();
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
-
         // then
-        expect(categoryValueRef).to.exist;
-        expect(categoryValueRef.$parent).to.exist;
-
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          true
-        );
-
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          true
-        );
-
+        expect(groupBo.categoryValueRef).not.to.exist;
       }));
 
     });
 
 
-    describe('integration', function() {
+    describe('should paste with Category', function() {
 
       var groupBo, rootElements;
 
@@ -208,140 +167,124 @@ describe('features/modeling/behavior - groups', function() {
       }));
 
 
-      it('<redo>', function() {
+      it('<redo>', inject(function(commandStack) {
+
+        // given
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
 
         // then
-        expect(groupBo.categoryValueRef).to.exist;
-        expect(groupBo.categoryValueRef.$parent).to.exist;
-        expect(groupBo.categoryValueRef.value).to.equal('Value 1');
+        expect(groupBo.categoryValueRef).to.equal(categoryValue);
+        expect(groupBo.categoryValueRef.$parent).to.equal(category);
 
         expect(rootElements).to.have.length(4);
-      });
+      }));
 
     });
 
 
-    it('should always create new Category in definitions',
-      inject(function(canvas, elementFactory, modeling, bpmnjs) {
+    it('should create new Category in definitions', inject(
+      function(canvas, elementFactory, modeling, bpmnjs) {
 
         // given
-        var group = elementFactory.createShape({ type: 'bpmn:Group' }),
-            root = canvas.findRoot('Subprocess_1_plane'),
-            rootParent = getBusinessObject(root).$parent,
-            definitions = bpmnjs._definitions;
+        var root = canvas.findRoot('Subprocess_1_plane'),
+            definitions = bpmnjs.getDefinitions();
 
+        // operate on sub-process plane
         canvas.setRootElement(root);
 
         // when
-        var groupShape = modeling.createShape(group, { x: 100, y: 100 }, root),
-            categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
+        var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
+            groupBo = getBusinessObject(group);
+
+        // create label
+        modeling.updateLabel(group, 'FOO BAR');
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // then
-        expect(categoryValueRef).to.exist;
+        expect(categoryValue).to.exist;
         expect(category).to.exist;
 
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          true
-        );
-
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          true
-        );
-
-        expectIncludedOrNot(
-          rootParent.get('rootElements'),
-          category,
-          false
-        );
-
-      }));
+        expect(category.get('categoryValue')).to.include(categoryValue);
+        expect(definitions.get('rootElements')).to.include(category);
+      }
+    ));
 
   });
 
 
   describe('deletion', function() {
 
-    it('should NOT remove CategoryValue if it is still referenced somewhere', inject(
+    it('should NOT remove CategoryValue if still referenced', inject(
       function(elementRegistry, modeling) {
 
         // given
-        var groupShape = elementRegistry.get('Group_1');
+        var groupShape = elementRegistry.get('Group_1'),
+            groupBo = getBusinessObject(groupShape);
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // when
         modeling.removeShape(groupShape);
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
-
         // then
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          true
-        );
+        expect(groupBo.categoryValueRef).not.to.exist;
 
+        expect(category.get('categoryValue')).to.contain(categoryValue);
       }
     ));
 
 
-    it('should NOT remove Category if it still has CategoryValues', inject(
+    it('should NOT remove Category if still referenced', inject(
       function(canvas, elementRegistry, modeling) {
 
         // given
         var groupShape = elementRegistry.get('Group_3'),
+            groupBo = getBusinessObject(groupShape),
             root = canvas.getRootElement(),
             definitions = getBusinessObject(root).$parent;
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // when
         modeling.removeShape(groupShape);
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef;
-
         // then
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          categoryValueRef.$parent,
-          true
-        );
+        expect(groupBo.categoryValueRef).not.to.exist;
 
+        expect(definitions.get('rootElements')).to.contain(category);
       }
     ));
 
 
-    describe('should remove referenced Category + Value when Group was deleted', function() {
+    describe('should remove Category + CategoryValue on deletion', function() {
 
       it('execute', inject(function(canvas, elementRegistry, modeling) {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
+            groupBo = getBusinessObject(groupShape),
             root = canvas.getRootElement(),
             definitions = getBusinessObject(root).$parent;
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // when
         modeling.removeShape(groupShape);
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
-
-
         // then
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          false
-        );
+        expect(category.get('categoryValue')).not.to.contain(categoryValue);
 
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          false
-        );
-
+        expect(definitions.get('rootElements')).not.to.contain(category);
       }));
 
 
@@ -349,30 +292,21 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
+            groupBo = getBusinessObject(groupShape),
             root = canvas.getRootElement(),
             definitions = getBusinessObject(root).$parent;
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // when
         modeling.removeShape(groupShape);
 
         commandStack.undo();
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
-
         // then
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          true
-        );
-
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          true
-        );
-
+        expect(category.get('categoryValue')).to.include(categoryValue);
+        expect(definitions.get('rootElements')).to.include(category);
       }));
 
 
@@ -380,8 +314,12 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
+            groupBo = getBusinessObject(groupShape),
             root = canvas.getRootElement(),
             definitions = getBusinessObject(root).$parent;
+
+        var categoryValue = groupBo.categoryValueRef,
+            category = categoryValue.$parent;
 
         // when
         modeling.removeShape(groupShape);
@@ -389,23 +327,79 @@ describe('features/modeling/behavior - groups', function() {
         commandStack.undo();
         commandStack.redo();
 
-        var categoryValueRef = getBusinessObject(groupShape).categoryValueRef,
-            category = categoryValueRef.$parent;
+        // then
+        expect(category.get('categoryValue')).not.to.include(categoryValue);
+        expect(definitions.get('rootElements')).not.to.include(category);
+      }));
 
+    });
+
+  });
+
+
+  describe('label editing', function() {
+
+    describe('should create Category before setting label', function() {
+
+      it('execute', inject(function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(group);
+
+        // assume
+        expect(groupBo.categoryValueRef).not.to.exist;
+
+        // when
+        modeling.updateLabel(group, 'Foo bar');
 
         // then
-        expectIncludedOrNot(
-          category.get('categoryValue'),
-          categoryValueRef,
-          false
-        );
+        expect(groupBo.categoryValueRef).to.exist;
+        expect(groupBo.categoryValueRef.value).to.eql('Foo bar');
 
-        expectIncludedOrNot(
-          definitions.get('rootElements'),
-          category,
-          false
-        );
+        expect(groupBo.categoryValueRef.$parent).to.exist;
+      }));
 
+
+      it('undo', inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        var group = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(group);
+
+        // assume
+        expect(groupBo.categoryValueRef).not.to.exist;
+
+        // when
+        modeling.updateLabel(group, 'Foo bar');
+
+        commandStack.undo();
+
+        // then
+        expect(groupBo.categoryValueRef).not.to.exist;
+      }));
+
+
+      it('redo', inject(function(elementRegistry, modeling, commandStack) {
+
+        // given
+        var group = elementRegistry.get('Group_NO_CATEGORY_VALUE'),
+            groupBo = getBusinessObject(group);
+
+        // assume
+        expect(groupBo.categoryValueRef).not.to.exist;
+
+        // when
+        modeling.updateLabel(group, 'Foo bar');
+
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        expect(groupBo.categoryValueRef).to.exist;
+        expect(groupBo.categoryValueRef.value).to.eql('Foo bar');
+
+        expect(groupBo.categoryValueRef.$parent).to.exist;
       }));
 
     });

--- a/test/spec/features/modeling/behavior/RootElementReferenceBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/RootElementReferenceBehaviorSpec.js
@@ -101,6 +101,9 @@ describe('features/modeling - root element reference behavior', function() {
             // then
             expect(hasRootElement(rootElement)).to.be.false;
             expect(hasRootElement(pastedRootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
           });
 
 
@@ -126,6 +129,9 @@ describe('features/modeling - root element reference behavior', function() {
             // then
             expect(hasRootElement(rootElement)).to.be.false;
             expect(hasRootElement(pastedRootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
           }));
 
         });

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -1191,7 +1191,7 @@ describe('features/replace - bpmn replace', function() {
         })[0];
 
         // then
-        expect(startEventAfter.businessObject.eventDefinitions).to.be.undefined;
+        expect(startEventAfter.businessObject.eventDefinitions).not.to.exist;
       })
     );
 


### PR DESCRIPTION
This fixes a fundamental flaw in our copy mechanism.

Until today we would carry around a mutable copy of `oldBusinessObject` and `oldDi` that would change what has been copied if the copied element changes after the copy operation:

```
Copy <Task> with name <OLD>
Change <Task.name> property to <FOO>
Paste <Task'>
<Task'.name> is <FOO> despite it having name <OLD> at the time of copy
```

Unfortunately the PR got a little bigger than intended, fixing numerous small issues _and_ addition additional test coverage to test copy + paste end-to-end.


### Contributions

* fixes the issue by cloning each element _as we copy_. As a result what is copied is frozen at copy time and not affected by future changes anymore.
* fixes that paste behaviors would execute when pasting both labels and actual shapes (https://github.com/bpmn-io/bpmn-js/pull/1707/commits/fac5f92c3dd80ad488d8b855ab8027f617e94046, verified via https://github.com/bpmn-io/bpmn-js/pull/1707/commits/076bb35d42897a277459b0dafabd9db8126a3736)
* fix bogus meta-date being attached to shapes on paste (https://github.com/bpmn-io/bpmn-js/pull/1707/commits/1f40b65f537957dfe65c7484c1ce70aba38d71fc)
* adds a bunch of test cases to verify paste works in the way intended: 
    * keeping IDs where possible, working with serialization (https://github.com/bpmn-io/bpmn-js/pull/1707/commits/076bb35d42897a277459b0dafabd9db8126a3736)
    * verify collapsed sub-process handling (https://github.com/bpmn-io/bpmn-js/pull/1707/commits/63e6e2ec11735ad9d78f5f2af80e8c4412c1d074)

----

Closes https://github.com/bpmn-io/bpmn-js/issues/798
Closes https://github.com/bpmn-io/bpmn-js/issues/1708