### PR TITLE
chore(grid-snapping): rename / prefix behaviors

### DIFF
--- a/lib/features/grid-snapping/behavior/GridSnappingAutoPlaceBehavior.js
+++ b/lib/features/grid-snapping/behavior/GridSnappingAutoPlaceBehavior.js
@@ -6,7 +6,7 @@ import { is } from '../../../util/ModelUtil';
 var HIGH_PRIORITY = 2000;
 
 
-export default function AutoPlaceBehavior(eventBus, gridSnapping) {
+export default function GridSnappingAutoPlaceBehavior(eventBus, gridSnapping) {
   eventBus.on('autoPlace', HIGH_PRIORITY, function(context) {
     var source = context.source,
         sourceMid = getMid(source),
@@ -47,7 +47,7 @@ export default function AutoPlaceBehavior(eventBus, gridSnapping) {
   });
 }
 
-AutoPlaceBehavior.$inject = [
+GridSnappingAutoPlaceBehavior.$inject = [
   'eventBus',
   'gridSnapping'
 ];

--- a/lib/features/grid-snapping/behavior/GridSnappingLayoutConnectionBehavior.js
+++ b/lib/features/grid-snapping/behavior/GridSnappingLayoutConnectionBehavior.js
@@ -14,7 +14,7 @@ var HIGH_PRIORITY = 3000;
 /**
  * Snaps connections with Manhattan layout.
  */
-export default function LayoutConnectionBehavior(eventBus, gridSnapping, modeling) {
+export default function GridSnappingLayoutConnectionBehavior(eventBus, gridSnapping, modeling) {
   CommandInterceptor.call(this, eventBus);
 
   this._gridSnapping = gridSnapping;
@@ -42,13 +42,13 @@ export default function LayoutConnectionBehavior(eventBus, gridSnapping, modelin
   });
 }
 
-LayoutConnectionBehavior.$inject = [
+GridSnappingLayoutConnectionBehavior.$inject = [
   'eventBus',
   'gridSnapping',
   'modeling'
 ];
 
-inherits(LayoutConnectionBehavior, CommandInterceptor);
+inherits(GridSnappingLayoutConnectionBehavior, CommandInterceptor);
 
 /**
  * Snap middle segments of a given connection.
@@ -57,7 +57,7 @@ inherits(LayoutConnectionBehavior, CommandInterceptor);
  *
  * @returns {Array<Point>}
  */
-LayoutConnectionBehavior.prototype.snapMiddleSegments = function(waypoints) {
+GridSnappingLayoutConnectionBehavior.prototype.snapMiddleSegments = function(waypoints) {
   var gridSnapping = this._gridSnapping,
       snapped;
 

--- a/lib/features/grid-snapping/behavior/GridSnappingParticipantBehavior.js
+++ b/lib/features/grid-snapping/behavior/GridSnappingParticipantBehavior.js
@@ -3,7 +3,7 @@ import { is } from '../../../util/ModelUtil';
 var HIGHER_PRIORITY = 1750;
 
 
-export default function CreateParticipantBehavior(canvas, eventBus, gridSnapping) {
+export default function GridSnappingParticipantBehavior(canvas, eventBus, gridSnapping) {
   eventBus.on([
     'create.start',
     'shape.move.start'
@@ -29,7 +29,7 @@ export default function CreateParticipantBehavior(canvas, eventBus, gridSnapping
   });
 }
 
-CreateParticipantBehavior.$inject = [
+GridSnappingParticipantBehavior.$inject = [
   'canvas',
   'eventBus',
   'gridSnapping'

--- a/lib/features/grid-snapping/behavior/index.js
+++ b/lib/features/grid-snapping/behavior/index.js
@@ -1,14 +1,14 @@
-import AutoPlaceBehavior from './AutoPlaceBehavior';
-import CreateParticipantBehavior from './CreateParticipantBehavior';
-import LayoutConnectionBehavior from './LayoutConnectionBehavior';
+import GridSnappingAutoPlaceBehavior from './GridSnappingAutoPlaceBehavior';
+import GridSnappingParticipantBehavior from './GridSnappingParticipantBehavior';
+import GridSnappingLayoutConnectionBehavior from './GridSnappingLayoutConnectionBehavior';
 
 export default {
   __init__: [
     'gridSnappingAutoPlaceBehavior',
-    'gridSnappingCreateParticipantBehavior',
+    'gridSnappingParticipantBehavior',
     'gridSnappingLayoutConnectionBehavior',
   ],
-  gridSnappingAutoPlaceBehavior: [ 'type', AutoPlaceBehavior ],
-  gridSnappingCreateParticipantBehavior: [ 'type', CreateParticipantBehavior ],
-  gridSnappingLayoutConnectionBehavior: [ 'type', LayoutConnectionBehavior ]
+  gridSnappingAutoPlaceBehavior: [ 'type', GridSnappingAutoPlaceBehavior ],
+  gridSnappingParticipantBehavior: [ 'type', GridSnappingParticipantBehavior ],
+  gridSnappingLayoutConnectionBehavior: [ 'type', GridSnappingLayoutConnectionBehavior ]
 };


### PR DESCRIPTION
Prevents clashes in behavior names (i.e. `CreateParticipantBehavior`).

---

I repeatedly stumbled upon insufficient namespacing in grid snapping behaviors, hence this PR.