### PR TITLE
Use ES2018 syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,9 @@
 {
-  "extends": "plugin:bpmn-io/es6",
-  "env": {
-    "browser": true
-  },
+  "extends": "plugin:bpmn-io/browser",
   "rules": {
     "no-restricted-imports": [ "error", {
       "name": "inherits",
       "message": "Use inherits-browser instead"
     } ]
-  },
-  "globals": {
-    "Promise": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 10.0.0
+
+* `FEAT`: use ES2018 syntax ([#1737](https://github.com/bpmn-io/bpmn-js/pull/1737))
+
+### Breaking Changes
+
+* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).
+
 ## 9.4.1
 
 * `FIX`: ignore elements which cannot be colored ([#1734](https://github.com/bpmn-io/bpmn-js/pull/1734))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### Breaking Changes
 
-* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).
+* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-migration-to-es2018.html).
 
 ## 9.4.1
 

--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -107,13 +107,13 @@ inherits(BaseViewer, Diagram);
  *
  * Returns {Promise<ImportXMLResult, ImportXMLError>}
  */
-BaseViewer.prototype.importXML = wrapForCompatibility(function importXML(xml, bpmnDiagram) {
+BaseViewer.prototype.importXML = wrapForCompatibility(async function importXML(xml, bpmnDiagram) {
 
-  var self = this;
+  const self = this;
 
   function ParseCompleteEvent(data) {
 
-    var event = self.get('eventBus').createEvent(data);
+    const event = self.get('eventBus').createEvent(data);
 
     // TODO(nikku): remove with future bpmn-js version
     Object.defineProperty(event, 'context', {
@@ -136,54 +136,59 @@ BaseViewer.prototype.importXML = wrapForCompatibility(function importXML(xml, bp
     return event;
   }
 
-  return new Promise(function(resolve, reject) {
+  let aggregatedWarnings = [];
+  try {
 
     // hook in pre-parse listeners +
     // allow xml manipulation
-    xml = self._emit('import.parse.start', { xml: xml }) || xml;
+    xml = this._emit('import.parse.start', { xml: xml }) || xml;
 
-    self._moddle.fromXML(xml, 'bpmn:Definitions').then(function(result) {
-      var definitions = result.rootElement;
-      var references = result.references;
-      var parseWarnings = result.warnings;
-      var elementsById = result.elementsById;
-
-      // hook in post parse listeners +
-      // allow definitions manipulation
-      definitions = self._emit('import.parse.complete', ParseCompleteEvent({
-        error: null,
-        definitions: definitions,
-        elementsById: elementsById,
-        references: references,
-        warnings: parseWarnings
-      })) || definitions;
-
-      self.importDefinitions(definitions, bpmnDiagram).then(function(result) {
-        var allWarnings = [].concat(parseWarnings, result.warnings || []);
-
-        self._emit('import.done', { error: null, warnings: allWarnings });
-
-        return resolve({ warnings: allWarnings });
-      }).catch(function(err) {
-        var allWarnings = [].concat(parseWarnings, err.warnings || []);
-
-        self._emit('import.done', { error: err, warnings: allWarnings });
-
-        return reject(addWarningsToError(err, allWarnings));
-      });
-    }).catch(function(err) {
-
-      self._emit('import.parse.complete', {
-        error: err
+    let parseResult;
+    try {
+      parseResult = await this._moddle.fromXML(xml, 'bpmn:Definitions');
+    } catch (error) {
+      this._emit('import.parse.complete', {
+        error
       });
 
-      err = checkValidationError(err);
+      throw error;
+    }
 
-      self._emit('import.done', { error: err, warnings: err.warnings });
+    let definitions = parseResult.rootElement;
+    const references = parseResult.references;
+    const parseWarnings = parseResult.warnings;
+    const elementsById = parseResult.elementsById;
 
-      return reject(err);
-    });
-  });
+    aggregatedWarnings = aggregatedWarnings.concat(parseWarnings);
+
+    // hook in post parse listeners +
+    // allow definitions manipulation
+    definitions = this._emit('import.parse.complete', ParseCompleteEvent({
+      error: null,
+      definitions: definitions,
+      elementsById: elementsById,
+      references: references,
+      warnings: aggregatedWarnings
+    })) || definitions;
+
+    const importResult = await this.importDefinitions(definitions, bpmnDiagram);
+
+    aggregatedWarnings = aggregatedWarnings.concat(importResult.warnings);
+
+    this._emit('import.done', { error: null, warnings: aggregatedWarnings });
+
+    return { warnings: aggregatedWarnings };
+  } catch (err) {
+    let error = err;
+    aggregatedWarnings = aggregatedWarnings.concat(error.warnings || []);
+    addWarningsToError(error, aggregatedWarnings);
+
+    error = checkValidationError(error);
+
+    this._emit('import.done', { error, warnings: error.warnings });
+
+    throw error;
+  }
 });
 
 /**
@@ -222,24 +227,11 @@ BaseViewer.prototype.importXML = wrapForCompatibility(function importXML(xml, bp
  *
  * Returns {Promise<ImportDefinitionsResult, ImportDefinitionsError>}
  */
-BaseViewer.prototype.importDefinitions = wrapForCompatibility(function importDefinitions(definitions, bpmnDiagram) {
+BaseViewer.prototype.importDefinitions = wrapForCompatibility(async function importDefinitions(definitions, bpmnDiagram) {
+  this._setDefinitions(definitions);
+  const result = await this.open(bpmnDiagram);
 
-  var self = this;
-
-  return new Promise(function(resolve, reject) {
-
-    self._setDefinitions(definitions);
-
-    self.open(bpmnDiagram).then(function(result) {
-
-      var warnings = result.warnings;
-
-      return resolve({ warnings: warnings });
-    }).catch(function(err) {
-
-      return reject(err);
-    });
-  });
+  return { warnings: result.warnings };
 });
 
 /**
@@ -277,50 +269,43 @@ BaseViewer.prototype.importDefinitions = wrapForCompatibility(function importDef
  *
  * Returns {Promise<OpenResult, OpenError>}
  */
-BaseViewer.prototype.open = wrapForCompatibility(function open(bpmnDiagramOrId) {
+BaseViewer.prototype.open = wrapForCompatibility(async function open(bpmnDiagramOrId) {
 
-  var definitions = this._definitions;
-  var bpmnDiagram = bpmnDiagramOrId;
+  const definitions = this._definitions;
+  let bpmnDiagram = bpmnDiagramOrId;
 
-  var self = this;
+  if (!definitions) {
+    const error = new Error('no XML imported');
+    addWarningsToError(error, []);
 
-  return new Promise(function(resolve, reject) {
-    if (!definitions) {
-      var err1 = new Error('no XML imported');
+    throw error;
+  }
 
-      return reject(addWarningsToError(err1, []));
+  if (typeof bpmnDiagramOrId === 'string') {
+    bpmnDiagram = findBPMNDiagram(definitions, bpmnDiagramOrId);
+
+    if (!bpmnDiagram) {
+      const error = new Error('BPMNDiagram <' + bpmnDiagramOrId + '> not found');
+      addWarningsToError(error, []);
+
+      throw error;
     }
+  }
 
-    if (typeof bpmnDiagramOrId === 'string') {
-      bpmnDiagram = findBPMNDiagram(definitions, bpmnDiagramOrId);
+  // clear existing rendered diagram
+  // catch synchronous exceptions during #clear()
+  try {
+    this.clear();
+  } catch (error) {
+    addWarningsToError(error, []);
 
-      if (!bpmnDiagram) {
-        var err2 = new Error('BPMNDiagram <' + bpmnDiagramOrId + '> not found');
+    throw error;
+  }
 
-        return reject(addWarningsToError(err2, []));
-      }
-    }
+  // perform graphical import
+  const { warnings } = await importBpmnDiagram(this, definitions, bpmnDiagram);
 
-    // clear existing rendered diagram
-    // catch synchronous exceptions during #clear()
-    try {
-      self.clear();
-    } catch (error) {
-
-      return reject(addWarningsToError(error, []));
-    }
-
-    // perform graphical import
-    importBpmnDiagram(self, definitions, bpmnDiagram).then(function(result) {
-
-      var warnings = result.warnings;
-
-      return resolve({ warnings: warnings });
-    }).catch(function(err) {
-
-      return reject(err);
-    });
-  });
+  return { warnings };
 });
 
 /**
@@ -351,53 +336,42 @@ BaseViewer.prototype.open = wrapForCompatibility(function open(bpmnDiagramOrId) 
  *
  * Returns {Promise<SaveXMLResult, Error>}
  */
-BaseViewer.prototype.saveXML = wrapForCompatibility(function saveXML(options) {
+BaseViewer.prototype.saveXML = wrapForCompatibility(async function saveXML(options) {
 
   options = options || {};
 
-  var self = this;
+  let definitions = this._definitions,
+      error, xml;
 
-  var definitions = this._definitions;
-
-  return new Promise(function(resolve) {
-
+  try {
     if (!definitions) {
-      return resolve({
-        error: new Error('no definitions loaded')
-      });
+      throw new Error('no definitions loaded');
     }
 
     // allow to fiddle around with definitions
-    definitions = self._emit('saveXML.start', {
-      definitions: definitions
+    definitions = this._emit('saveXML.start', {
+      definitions
     }) || definitions;
 
-    self._moddle.toXML(definitions, options).then(function(result) {
+    const result = await this._moddle.toXML(definitions, options);
+    xml = result.xml;
 
-      var xml = result.xml;
+    xml = this._emit('saveXML.serialized', {
+      xml
+    }) || xml;
+  } catch (err) {
+    error = err;
+  }
 
-      xml = self._emit('saveXML.serialized', {
-        xml: xml
-      }) || xml;
+  const result = error ? { error } : { xml };
 
-      return resolve({
-        xml: xml
-      });
-    });
-  }).catch(function(error) {
-    return { error: error };
-  }).then(function(result) {
+  this._emit('saveXML.done', result);
 
-    self._emit('saveXML.done', result);
+  if (error) {
+    throw error;
+  }
 
-    var error = result.error;
-
-    if (error) {
-      return Promise.reject(error);
-    }
-
-    return result;
-  });
+  return result;
 });
 
 /**
@@ -425,53 +399,45 @@ BaseViewer.prototype.saveXML = wrapForCompatibility(function saveXML(options) {
  *
  * Returns {Promise<SaveSVGResult, Error>}
  */
-BaseViewer.prototype.saveSVG = wrapForCompatibility(function saveSVG(options) {
+BaseViewer.prototype.saveSVG = wrapForCompatibility(async function saveSVG(options = {}) {
+  this._emit('saveSVG.start');
 
-  options = options || {};
+  let svg, err;
 
-  var self = this;
+  try {
+    const canvas = this.get('canvas');
 
-  return new Promise(function(resolve, reject) {
-
-    self._emit('saveSVG.start');
-
-    var svg, err;
-
-    try {
-      var canvas = self.get('canvas');
-
-      var contentNode = canvas.getActiveLayer(),
+    const contentNode = canvas.getActiveLayer(),
           defsNode = domQuery('defs', canvas._svg);
 
-      var contents = innerSVG(contentNode),
+    const contents = innerSVG(contentNode),
           defs = defsNode ? '<defs>' + innerSVG(defsNode) + '</defs>' : '';
 
-      var bbox = contentNode.getBBox();
+    const bbox = contentNode.getBBox();
 
-      svg =
-        '<?xml version="1.0" encoding="utf-8"?>\n' +
-        '<!-- created with bpmn-js / http://bpmn.io -->\n' +
-        '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
-        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
-             'width="' + bbox.width + '" height="' + bbox.height + '" ' +
-             'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" version="1.1">' +
-          defs + contents +
-        '</svg>';
-    } catch (e) {
-      err = e;
-    }
+    svg =
+      '<?xml version="1.0" encoding="utf-8"?>\n' +
+      '<!-- created with bpmn-js / http://bpmn.io -->\n' +
+      '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
+      'width="' + bbox.width + '" height="' + bbox.height + '" ' +
+      'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" version="1.1">' +
+      defs + contents +
+      '</svg>';
+  } catch (e) {
+    err = e;
+  }
 
-    self._emit('saveSVG.done', {
-      error: err,
-      svg: svg
-    });
-
-    if (!err) {
-      return resolve({ svg: svg });
-    }
-
-    return reject(err);
+  this._emit('saveSVG.done', {
+    error: err,
+    svg: svg
   });
+
+  if (err) {
+    throw err;
+  }
+
+  return { svg };
 });
 
 /**
@@ -479,8 +445,8 @@ BaseViewer.prototype.saveSVG = wrapForCompatibility(function saveSVG(options) {
  *
  * @example
  *
- * var elementRegistry = viewer.get('elementRegistry');
- * var startEventShape = elementRegistry.get('StartEvent_1');
+ * const elementRegistry = viewer.get('elementRegistry');
+ * const startEventShape = elementRegistry.get('StartEvent_1');
  *
  * @param {string} name
  *
@@ -495,7 +461,7 @@ BaseViewer.prototype.saveSVG = wrapForCompatibility(function saveSVG(options) {
  * @example
  *
  * viewer.invoke(function(elementRegistry) {
- *   var startEventShape = elementRegistry.get('StartEvent_1');
+ *   const startEventShape = elementRegistry.get('StartEvent_1');
  * });
  *
  * @param {Function} fn to be invoked
@@ -602,8 +568,8 @@ BaseViewer.prototype.getDefinitions = function() {
 
 BaseViewer.prototype.detach = function() {
 
-  var container = this._container,
-      parentNode = container.parentNode;
+  const container = this._container,
+        parentNode = container.parentNode;
 
   if (!parentNode) {
     return;
@@ -616,18 +582,18 @@ BaseViewer.prototype.detach = function() {
 
 BaseViewer.prototype._init = function(container, moddle, options) {
 
-  var baseModules = options.modules || this.getModules(),
-      additionalModules = options.additionalModules || [],
-      staticModules = [
-        {
-          bpmnjs: [ 'value', this ],
-          moddle: [ 'value', moddle ]
-        }
-      ];
+  const baseModules = options.modules || this.getModules(),
+        additionalModules = options.additionalModules || [],
+        staticModules = [
+          {
+            bpmnjs: [ 'value', this ],
+            moddle: [ 'value', moddle ]
+          }
+        ];
 
-  var diagramModules = [].concat(staticModules, baseModules, additionalModules);
+  const diagramModules = [].concat(staticModules, baseModules, additionalModules);
 
-  var diagramOptions = assign(omit(options, [ 'additionalModules' ]), {
+  const diagramOptions = assign(omit(options, [ 'additionalModules' ]), {
     canvas: assign({}, options.canvas, { container: container }),
     modules: diagramModules
   });
@@ -654,7 +620,7 @@ BaseViewer.prototype._emit = function(type, event) {
 
 BaseViewer.prototype._createContainer = function(options) {
 
-  var container = domify('<div class="bjs-container"></div>');
+  const container = domify('<div class="bjs-container"></div>');
 
   assignStyle(container, {
     width: ensureUnit(options.width),
@@ -666,7 +632,7 @@ BaseViewer.prototype._createContainer = function(options) {
 };
 
 BaseViewer.prototype._createModdle = function(options) {
-  var moddleOptions = assign({}, this._moddleExtensions, options.moddleExtensions);
+  const moddleOptions = assign({}, this._moddleExtensions, options.moddleExtensions);
 
   return new BpmnModdle(moddleOptions);
 };
@@ -685,8 +651,8 @@ function checkValidationError(err) {
   // check if we can help the user by indicating wrong BPMN 2.0 xml
   // (in case he or the exporting tool did not get that right)
 
-  var pattern = /unparsable content <([^>]+)> detected([\s\S]*)$/;
-  var match = pattern.exec(err.message);
+  const pattern = /unparsable content <([^>]+)> detected([\s\S]*)$/;
+  const match = pattern.exec(err.message);
 
   if (match) {
     err.message =
@@ -697,7 +663,7 @@ function checkValidationError(err) {
   return err;
 }
 
-var DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS = {
   width: '100%',
   height: '100%',
   position: 'relative'
@@ -753,18 +719,18 @@ import {
  * @param {Element} container
  */
 function addProjectLogo(container) {
-  var img = BPMNIO_IMG;
+  const img = BPMNIO_IMG;
 
-  var linkMarkup =
+  const linkMarkup =
     '<a href="http://bpmn.io" ' +
-       'target="_blank" ' +
-       'class="bjs-powered-by" ' +
-       'title="Powered by bpmn.io" ' +
-      '>' +
-      img +
+    'target="_blank" ' +
+    'class="bjs-powered-by" ' +
+    'title="Powered by bpmn.io" ' +
+    '>' +
+    img +
     '</a>';
 
-  var linkElement = domify(linkMarkup);
+  const linkElement = domify(linkMarkup);
 
   assignStyle(domQuery('svg', linkElement), LOGO_STYLES);
   assignStyle(linkElement, LINK_STYLES, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "cross-env": "^7.0.3",
         "del": "^6.0.0",
         "eslint": "^8.22.0",
-        "eslint-plugin-bpmn-io": "^0.14.1",
+        "eslint-plugin-bpmn-io": "^0.15.1",
         "eslint-plugin-import": "^2.26.0",
         "execa": "^5.1.1",
         "karma": "^6.4.0",
@@ -176,42 +176,6 @@
       "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz",
-      "integrity": "sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "^5.1.1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
@@ -439,21 +403,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
@@ -3561,168 +3510,16 @@
       "dev": true
     },
     "node_modules/eslint-plugin-bpmn-io": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.14.1.tgz",
-      "integrity": "sha512-W7JTh/wnwzeUH+FMuLSsGeonVaMwxX6s+hopaeRLAcfYG06HwI/NOcPzPQxBTDYJ19xFBiqj24zKcppf3mvFxg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.15.1.tgz",
+      "integrity": "sha512-J0eN4rzyNTER6dpW8EbiDZ6uhvOZXmvvmWABB4t2fQtUHyHZ0zd3gLMtYWZI0yMurVxpr7KWOzo7Yokz5QDILg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.18.10",
-        "@babel/eslint-parser": "^7.18.9",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.30.1"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/core": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.18.10",
-        "@babel/helper-compilation-targets": "^7.18.9",
-        "@babel/helper-module-transforms": "^7.18.9",
-        "@babel/helpers": "^7.18.9",
-        "@babel/parser": "^7.18.10",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.18.10",
-        "@babel/types": "^7.18.10",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-module-transforms": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/@babel/helpers": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.18.6",
-        "@babel/traverse": "^7.18.9",
-        "@babel/types": "^7.18.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-bpmn-io/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+        "eslint": "^8.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -13507,31 +13304,6 @@
         }
       }
     },
-    "@babel/eslint-parser": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz",
-      "integrity": "sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^5.1.1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "@babel/generator": {
       "version": "7.18.12",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
@@ -13698,15 +13470,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
       "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
       "dev": true
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
     },
     "@babel/template": {
       "version": "7.18.10",
@@ -16432,128 +16195,13 @@
       }
     },
     "eslint-plugin-bpmn-io": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.14.1.tgz",
-      "integrity": "sha512-W7JTh/wnwzeUH+FMuLSsGeonVaMwxX6s+hopaeRLAcfYG06HwI/NOcPzPQxBTDYJ19xFBiqj24zKcppf3mvFxg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.15.1.tgz",
+      "integrity": "sha512-J0eN4rzyNTER6dpW8EbiDZ6uhvOZXmvvmWABB4t2fQtUHyHZ0zd3gLMtYWZI0yMurVxpr7KWOzo7Yokz5QDILg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.18.10",
-        "@babel/eslint-parser": "^7.18.9",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.30.1"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.18.10",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-          "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
-          "dev": true,
-          "requires": {
-            "@ampproject/remapping": "^2.1.0",
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.18.10",
-            "@babel/helper-compilation-targets": "^7.18.9",
-            "@babel/helper-module-transforms": "^7.18.9",
-            "@babel/helpers": "^7.18.9",
-            "@babel/parser": "^7.18.10",
-            "@babel/template": "^7.18.10",
-            "@babel/traverse": "^7.18.10",
-            "@babel/types": "^7.18.10",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.2.1",
-            "semver": "^6.3.0"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-          "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.18.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-          "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-module-imports": "^7.18.6",
-            "@babel/helper-simple-access": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "@babel/template": "^7.18.6",
-            "@babel/traverse": "^7.18.9",
-            "@babel/types": "^7.18.9"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-          "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-          "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-          "dev": true
-        },
-        "@babel/helpers": {
-          "version": "7.18.9",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-          "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.6",
-            "@babel/traverse": "^7.18.9",
-            "@babel/types": "^7.18.9"
-          }
-        },
-        "convert-source-map": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-          "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cross-env": "^7.0.3",
     "del": "^6.0.0",
     "eslint": "^8.22.0",
-    "eslint-plugin-bpmn-io": "^0.14.1",
+    "eslint-plugin-bpmn-io": "^0.15.1",
     "eslint-plugin-import": "^2.26.0",
     "execa": "^5.1.1",
     "karma": "^6.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 import { terser } from 'rollup-plugin-terser';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';

--- a/tasks/.eslintrc
+++ b/tasks/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "plugin:bpmn-io/node"
+}


### PR DESCRIPTION
# Breaking Changes

* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).

---

Requires https://github.com/bpmn-io/bpmn.io/pull/147