### PR TITLE
ci: use node@16 for post-release

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 14 ]
+        node-version: [ 16 ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
For some reason, the integration test update downgraded the package-lock to version 1: https://github.com/bpmn-io/bpmn-js-integration/commit/be37eafd7def3ac48a37fe47eecf13b71c5d6189#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L4

I suspect that this was done due to outdated Node version, as the original image contains npm@8.