### PR TITLE
test: allow diagrams to be dropped onto active test editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-bpmn-io": "^0.16.0",
         "eslint-plugin-import": "^2.26.0",
         "execa": "^5.1.1",
+        "file-drops": "^0.4.0",
         "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
         "karma-coverage": "^2.2.0",
@@ -4648,6 +4649,34 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/file-drops": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
+      "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
+      "dev": true,
+      "dependencies": {
+        "min-dom": "^3.1.1"
+      }
+    },
+    "node_modules/file-drops/node_modules/min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg==",
+      "dev": true
+    },
+    "node_modules/file-drops/node_modules/min-dom": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
+      "dev": true,
+      "dependencies": {
+        "component-event": "^0.1.4",
+        "domify": "^1.3.1",
+        "indexof": "0.0.1",
+        "matches-selector": "^1.2.0",
+        "min-dash": "^3.8.1"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6274,6 +6303,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7664,6 +7699,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/matches-selector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
+      "dev": true
     },
     "node_modules/math-random": {
       "version": "1.0.1",
@@ -16121,6 +16162,36 @@
         "pend": "~1.2.0"
       }
     },
+    "file-drops": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
+      "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
+      "dev": true,
+      "requires": {
+        "min-dom": "^3.1.1"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+          "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg==",
+          "dev": true
+        },
+        "min-dom": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+          "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
+          "dev": true,
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.3.1",
+            "indexof": "0.0.1",
+            "matches-selector": "^1.2.0",
+            "min-dash": "^3.8.1"
+          }
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -17337,6 +17408,12 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -18384,6 +18461,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "matches-selector": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
+      "dev": true
     },
     "math-random": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-bpmn-io": "^0.16.0",
     "eslint-plugin-import": "^2.26.0",
     "execa": "^5.1.1",
+    "file-drops": "^0.4.0",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
     "karma-coverage": "^2.2.0",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -1,7 +1,10 @@
 export * from './helper';
 
+import fileDrop from 'file-drops';
+
 import {
-  insertCSS
+  insertCSS,
+  getBpmnJS
 } from './helper';
 
 insertCSS('bpmn-js.css', require('../assets/bpmn-js.css'));
@@ -28,3 +31,26 @@ chai.use(ChaiMatch);
 chai.use(BoundsMatchers);
 chai.use(ConnectionMatchers);
 chai.use(JSONMatcher);
+
+// be able to load files into running bpmn-js test cases
+document.documentElement.addEventListener('dragover', fileDrop('Drop a BPMN diagram to open it in the currently active test.', function(files) {
+  const bpmnJS = getBpmnJS();
+
+  if (bpmnJS && files.length === 1) {
+    bpmnJS.importXML(files[0].contents);
+  }
+}));
+
+insertCSS('file-drops.css', `
+  .drop-overlay .box {
+    background: orange;
+    border-radius: 3px;
+    display: inline-block;
+    font-family: sans-serif;
+    padding: 4px 10px;
+    position: fixed;
+    top: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+`);


### PR DESCRIPTION
I found this to be useful (bring our test editors close to actual bpmn.io demo / modeler use-cases):

![capture 3unL8c_optimized](https://user-images.githubusercontent.com/58601/201332077-229a62f6-c256-466e-87d0-f3b5a25a374a.gif)
