### PR TITLE
Fix oder of styles inclusion

### DIFF
--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -7,9 +7,9 @@ import {
   getBpmnJS
 } from './helper';
 
-insertCSS('bpmn-js.css', require('../assets/bpmn-js.css'));
-
 insertCSS('diagram-js.css', require('diagram-js/assets/diagram-js.css'));
+
+insertCSS('bpmn-js.css', require('../assets/bpmn-js.css'));
 
 insertCSS('bpmn-embedded.css', require('bpmn-font/dist/css/bpmn-embedded.css'));
 


### PR DESCRIPTION
**Context:** the oder in which we include `bpmn.css` and `diagram.css` in the test suite is switched. We should match it to how it is built in [build-distro](https://github.com/bpmn-io/bpmn-js/blob/60ad7d4696baf7fb839704394b332cf424ff4824/tasks/build-distro.js#L29), which is the correct order so that CSS overrides are simple to do.