### PR TITLE
Integrate new popup menu

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -115,7 +115,7 @@
   display: inherit;
 }
 
-[data-popup="align-elements"] .djs-popup-body {
+[data-popup="align-elements"] .djs-popup-results {
   display: flex;
 }
 
@@ -132,13 +132,13 @@
   padding: 6px 8px;
 }
 
-[data-popup="align-elements"] .djs-popup-body .entry img {
-  display: block;
-
-  height: 20px;
-  width: 20px;
+[data-popup="align-elements"] .djs-popup-body .entry:not(:first-child) {
+  margin-top: 0;
 }
 
-[data-popup="align-elements"] .bjs-align-elements-menu-entry {
-  display: inline-block;
+[data-popup="align-elements"] .djs-popup-entry-icon {
+  display: block;
+  margin: 0;
+  height: 20px;
+  width: 20px;
 }

--- a/lib/features/align-elements/AlignElementsContextPadProvider.js
+++ b/lib/features/align-elements/AlignElementsContextPadProvider.js
@@ -69,18 +69,13 @@ AlignElementsContextPadProvider.prototype._getEntries = function(elements) {
 AlignElementsContextPadProvider.prototype._getMenuPosition = function(elements) {
   var Y_OFFSET = 5;
 
-  var diagramContainer = this._canvas.getContainer(),
-      pad = this._contextPad.getPad(elements).html;
+  var pad = this._contextPad.getPad(elements).html;
 
-  var diagramRect = diagramContainer.getBoundingClientRect(),
-      padRect = pad.getBoundingClientRect();
-
-  var top = padRect.top - diagramRect.top;
-  var left = padRect.left - diagramRect.left;
+  var padRect = pad.getBoundingClientRect();
 
   var pos = {
-    x: left,
-    y: top + padRect.height + Y_OFFSET
+    x: padRect.left,
+    y: padRect.bottom + Y_OFFSET
   };
 
   return pos;

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -137,7 +137,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       connect = this._connect,
       create = this._create,
       popupMenu = this._popupMenu,
-      canvas = this._canvas,
       rules = this._rules,
       autoPlace = this._autoPlace,
       translate = this._translate;
@@ -162,18 +161,13 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
     var Y_OFFSET = 5;
 
-    var diagramContainer = canvas.getContainer(),
-        pad = contextPad.getPad(element).html;
+    var pad = contextPad.getPad(element).html;
 
-    var diagramRect = diagramContainer.getBoundingClientRect(),
-        padRect = pad.getBoundingClientRect();
-
-    var top = padRect.top - diagramRect.top;
-    var left = padRect.left - diagramRect.left;
+    var padRect = pad.getBoundingClientRect();
 
     var pos = {
-      x: left,
-      y: top + padRect.height + Y_OFFSET
+      x: padRect.left,
+      y: padRect.bottom + Y_OFFSET
     };
 
     return pos;

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -396,7 +396,11 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
               cursor: { x: event.x, y: event.y }
             });
 
-            popupMenu.open(element, 'bpmn-replace', position);
+            popupMenu.open(element, 'bpmn-replace', position, {
+              title: translate('Change element'),
+              width: 300,
+              search: true
+            });
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^10.0.0",
+        "diagram-js": "^11.1.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",
         "inherits-browser": "^0.1.0",
@@ -460,6 +460,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bpmn-io/diagram-js-ui": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.0.tgz",
+      "integrity": "sha512-5uP4xgJHynGwq5SsyzzEGdRdhFUu/jfh/0tfcxH/K+W2TE7cdBde45kQdh601xzvCet+RrL8PY82uxs5D0d7qA==",
+      "dependencies": {
+        "htm": "^3.1.1",
+        "preact": "^10.11.2"
       }
     },
     "node_modules/@colors/colors": {
@@ -2549,6 +2558,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3077,10 +3094,12 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.1.0.tgz",
+      "integrity": "sha512-LDfSPHpFaXiu2LkElf2iIBmM0M9iyN189Tt0xk/GsMqm468BUXsDKBSZEqwSUPGOPd5+afCtZIS4SRlr/vgZwg==",
       "dependencies": {
+        "@bpmn-io/diagram-js-ui": "^0.2.0",
+        "clsx": "^1.2.1",
         "css.escape": "^1.5.1",
         "didi": "^9.0.0",
         "hammerjs": "^2.0.1",
@@ -6051,6 +6070,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -9357,6 +9381,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -12761,6 +12794,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bpmn-io/diagram-js-ui": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.0.tgz",
+      "integrity": "sha512-5uP4xgJHynGwq5SsyzzEGdRdhFUu/jfh/0tfcxH/K+W2TE7cdBde45kQdh601xzvCet+RrL8PY82uxs5D0d7qA==",
+      "requires": {
+        "htm": "^3.1.1",
+        "preact": "^10.11.2"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -14345,6 +14387,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -14763,10 +14810,12 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.1.0.tgz",
+      "integrity": "sha512-LDfSPHpFaXiu2LkElf2iIBmM0M9iyN189Tt0xk/GsMqm468BUXsDKBSZEqwSUPGOPd5+afCtZIS4SRlr/vgZwg==",
       "requires": {
+        "@bpmn-io/diagram-js-ui": "^0.2.0",
+        "clsx": "^1.2.1",
         "css.escape": "^1.5.1",
         "didi": "^9.0.0",
         "hammerjs": "^2.0.1",
@@ -17027,6 +17076,11 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -19483,6 +19537,11 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
     "css.escape": "^1.5.1",
-    "diagram-js": "^10.0.0",
+    "diagram-js": "^11.1.0",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.0",
     "inherits-browser": "^0.1.0",

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -438,13 +438,6 @@ describe('features - context-pad', function() {
       modules: testModules
     }));
 
-    var container;
-
-    beforeEach(function() {
-      container = TestContainer.get(this);
-    });
-
-
     it('should show popup menu in the correct position', inject(function(elementRegistry, contextPad) {
 
       // given
@@ -459,7 +452,7 @@ describe('features - context-pad', function() {
       contextPad.trigger('click', padEvent('replace'));
 
       padMenuRect = contextPad.getPad(element).html.getBoundingClientRect();
-      replaceMenuRect = domQuery('.bpmn-replace', container).getBoundingClientRect();
+      replaceMenuRect = domQuery('.bpmn-replace', getMenuContainer()).getBoundingClientRect();
 
       // then
       expect(replaceMenuRect.left).to.be.at.most(padMenuRect.left);
@@ -530,7 +523,7 @@ describe('features - context-pad', function() {
 
           dragging.end(canvasEvent({ x: 75, y: 75 }, { ctrlKey: true, metaKey: true }));
 
-          replaceMenu = domQuery('.bpmn-replace', container);
+          replaceMenu = domQuery('.bpmn-replace', getMenuContainer());
 
           // then
           expect(replaceMenu).to.exist;
@@ -558,7 +551,7 @@ describe('features - context-pad', function() {
           dragging.end(canvasEvent({ x: 50, y: 65 }, { ctrlKey: true, metaKey: true }));
 
           // then
-          var replaceMenu = domQueryAll('[data-id$="-boundary"]', popupMenu._current.container);
+          var replaceMenu = domQueryAll('[data-id$="-boundary"]', getMenuContainer());
           expect(replaceMenu).to.exist;
           expect(replaceMenu.length).to.eql(12);
         }
@@ -582,7 +575,7 @@ describe('features - context-pad', function() {
 
           dragging.end(canvasEvent({ x: 75, y: 75 }, { ctrlKey: true, metaKey: true }));
 
-          replaceMenu = domQuery('.bpmn-replace', container);
+          replaceMenu = domQuery('.bpmn-replace', getMenuContainer());
 
           // then
           expect(replaceMenu).not.to.exist;
@@ -608,7 +601,7 @@ describe('features - context-pad', function() {
           dragging.end(canvasEvent({ x: 75, y: 75 }, { ctrlKey: true, metaKey: true }));
 
           // then
-          var replaceMenu = domQuery('.bpmn-replace', container);
+          var replaceMenu = domQuery('.bpmn-replace', getMenuContainer());
 
           expect(replaceMenu).not.to.exist;
         }
@@ -711,4 +704,10 @@ function padEvent(entry) {
       clientY: 100
     };
   });
+}
+
+
+function getMenuContainer() {
+  const popup = getBpmnJS().get('popupMenu');
+  return popup._current.container;
 }

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -2470,13 +2470,13 @@ function openPopup(element, offset) {
 }
 
 function queryEntry(id) {
-  var container = getBpmnJS().get('canvas').getContainer();
+  var container = getMenuContainer();
 
   return domQuery('.djs-popup [data-id="' + id + '"]', container);
 }
 
 function queryEntries() {
-  var container = getBpmnJS().get('canvas').getContainer();
+  var container = getMenuContainer();
 
   return domQueryAll('.djs-popup .entry', container);
 }
@@ -2497,4 +2497,9 @@ function triggerAction(id) {
   var popupMenu = getBpmnJS().get('popupMenu');
 
   return popupMenu.trigger(globalEvent(entry, { x: 0, y: 0 }));
+}
+
+function getMenuContainer() {
+  const popup = getBpmnJS().get('popupMenu');
+  return popup._current.container;
 }


### PR DESCRIPTION
Closes #1775 

~~This is targeting `diagram-js@develop` since [this bug fix](https://github.com/bpmn-io/diagram-js/issues/695) was added after the alpha release. My idea is to pre-approve this to make sure the new popup menu is working as expected so we can have the stable release of `diagram-js`, and later integrate it here.~~

Integrate ~~`diagram-js@11.0.0`~~ `diagram-js@11.1.0`

Following the title discussion in the issue, I decided not to add the align title for now.