### PR TITLE
fix(element-factory): add missing attributes

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -1,6 +1,7 @@
 import {
   assign,
   forEach,
+  isDefined,
   isObject,
   omit
 } from 'min-dash';
@@ -125,6 +126,16 @@ ElementFactory.prototype.createBpmnElement = function(elementType, attrs) {
 
   if (is(businessObject, 'bpmn:ExclusiveGateway')) {
     di.isMarkerVisible = true;
+  }
+
+  if (isDefined(attrs.triggeredByEvent)) {
+    businessObject.triggeredByEvent = attrs.triggeredByEvent;
+    delete attrs.triggeredByEvent;
+  }
+
+  if (isDefined(attrs.cancelActivity)) {
+    businessObject.cancelActivity = attrs.cancelActivity;
+    delete attrs.cancelActivity;
   }
 
   var eventDefinitions,

--- a/test/spec/features/modeling/ElementFactorySpec.js
+++ b/test/spec/features/modeling/ElementFactorySpec.js
@@ -176,6 +176,37 @@ describe('features - element factory', function() {
     }));
 
 
+    it('should create subprocess as event subprocess', inject(function(elementFactory) {
+
+      // when
+      var subprocess = elementFactory.createShape({
+        type: 'bpmn:SubProcess',
+        triggeredByEvent: true
+      });
+
+      var businessObject = getBusinessObject(subprocess);
+
+      // then
+      expect(businessObject.triggeredByEvent).to.be.true;
+    }));
+
+
+    it('should create boundary event as non-interrupting', inject(function(elementFactory) {
+
+      // when
+      var event = elementFactory.createShape({
+        type: 'bpmn:BoundaryEvent',
+        eventDefinitionType: 'bpmn:MessageEventDefinition',
+        cancelActivity: false
+      });
+
+      var businessObject = getBusinessObject(event);
+
+      // then
+      expect(businessObject.cancelActivity).to.be.false;
+    }));
+
+
     describe('integration', function() {
 
       it('should create event definition with ID', inject(function(elementFactory) {


### PR DESCRIPTION
Came up in the context of https://github.com/bpmn-io/bpmn-js/pull/1802

* Event subprocesses were being created as normal subprocesses
* Non interrupting boundary events were being created as interrupting events