### PR TITLE
fix(popup-menu): handle `bpmn:DataObjectReference` without data object

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -505,6 +505,12 @@ ReplaceMenuProvider.prototype._getDataObjectIsCollection = function(element) {
   var self = this;
   var translate = this._translate;
 
+  var dataObject = element.businessObject.dataObjectRef;
+
+  if (!dataObject) {
+    return [];
+  }
+
   function toggleIsCollection(event, entry) {
     self._modeling.updateModdleProperties(
       element,
@@ -512,8 +518,7 @@ ReplaceMenuProvider.prototype._getDataObjectIsCollection = function(element) {
       { isCollection: !entry.active });
   }
 
-  var dataObject = element.businessObject.dataObjectRef,
-      isCollection = dataObject.isCollection;
+  var isCollection = dataObject.isCollection;
 
   var dataObjectEntries = [
     {

--- a/test/fixtures/bpmn/features/replace/data-elements.bpmn
+++ b/test/fixtures/bpmn/features/replace/data-elements.bpmn
@@ -4,8 +4,10 @@
     <bpmn:dataObjectReference id="DataObjectReference_1" dataObjectRef="DataObject" />
     <bpmn:dataObject id="DataObject" />
     <bpmn:dataObjectReference id="DataObjectReference_2" dataObjectRef="DataObject" />
+    <bpmn:dataObjectReference id="DataObjectReference_NO_DataObject" />
     <bpmn:dataStoreReference id="DataStoreReference_1" dataStoreRef="DataStore" />
     <bpmn:dataStore id="DataStore" />
+    <bpmn:dataStoreReference id="DataStoreReference_NO_DataStore" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
@@ -15,8 +17,14 @@
       <bpmndi:BPMNShape id="DataObjectReference_2_di" bpmnElement="DataObjectReference_2">
         <dc:Bounds x="300" y="200" width="36" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_NO_DataObject_di" bpmnElement="DataObjectReference_NO_DataObject">
+        <dc:Bounds x="300" y="300" width="36" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataStoreReference_1_di" bpmnElement="DataStoreReference_1">
         <dc:Bounds x="400" y="200" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_NO_DataStore_di" bpmnElement="DataStoreReference_NO_DataStore">
+        <dc:Bounds x="400" y="300" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -1518,6 +1518,20 @@ describe('features/popup-menu - replace menu provider', function() {
         expect(queryEntry('replace-with-data-store-reference')).to.exist;
         expect(queryEntry('replace-with-data-object-reference')).to.be.null;
       }));
+
+
+      it('should handle missing dataObjectRef', inject(function(elementRegistry) {
+
+        // given
+        var dataObjectReference = elementRegistry.get('DataObjectReference_NO_DataObject');
+
+        // when
+        openPopup(dataObjectReference);
+
+        // then
+        expect(queryEntry('toggle-is-collection')).not.to.exist;
+      }));
+
     });
 
 
@@ -1539,6 +1553,19 @@ describe('features/popup-menu - replace menu provider', function() {
         expect(queryEntry('toggle-is-collection')).to.be.null;
         expect(queryEntry('replace-with-data-store-reference')).to.be.null;
         expect(queryEntry('replace-with-data-object-reference')).to.exist;
+      }));
+
+
+      it('should handle missing dataStoreRef', inject(function(elementRegistry) {
+
+        // given
+        var dataStoreReference = elementRegistry.get('DataStoreReference_NO_DataStore');
+
+        // when
+        openPopup(dataStoreReference);
+
+        // then
+        expect(queryEntry('toggle-is-collection')).to.be.null;
       }));
 
     });


### PR DESCRIPTION
Ensures we can open popup menu on data objects without attached `dataObjectRef` (legal in accordance with the BPMN 2.0 spec).

Reproduce bug on [demo](https://demo.bpmn.io/s/application-processing) `> Bewerber`.