### PR TITLE
Improve single connection presence

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -425,7 +425,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
       'connect': {
         group: 'connect',
-        className: 'bpmn-icon-connection',
+        className: 'bpmn-icon-connection-multi',
         title: translate(
           'Connect using ' +
             (businessObject.isForCompensation
@@ -445,7 +445,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     assign(actions, {
       'connect': {
         group: 'connect',
-        className: 'bpmn-icon-connection',
+        className: 'bpmn-icon-connection-multi',
         title: translate('Connect using Association'),
         action: {
           click: startConnect,
@@ -459,7 +459,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     assign(actions, {
       'connect': {
         group: 'connect',
-        className: 'bpmn-icon-connection',
+        className: 'bpmn-icon-connection-multi',
         title: translate('Connect using DataInputAssociation'),
         action: {
           click: startConnect,

--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -132,7 +132,7 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
     },
     'global-connect-tool': {
       group: 'tools',
-      className: 'bpmn-icon-connection',
+      className: 'bpmn-icon-connection-multi',
       title: translate('Activate the global connect tool'),
       action: {
         click: function(event) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@rollup/plugin-terser": "^0.1.0",
         "babel-loader": "^9.1.0",
         "babel-plugin-istanbul": "^6.1.1",
-        "bpmn-font": "^0.11.0",
+        "bpmn-font": "^0.12.0",
         "camunda-bpmn-moddle": "^4.0.1",
         "chai": "4.1.2",
         "chai-match": "^1.1.1",
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/bpmn-font": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.11.0.tgz",
-      "integrity": "sha512-+Vi+QjAoMebRaSHdranAxLk+6k/4q2VIpS9VoXrU1bwMZpcnV+i04hNXGGV1fbrOZL4YscuDp49OvAErzU1Qpg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.12.0.tgz",
+      "integrity": "sha512-JQBXri5Dp5q+YgvpeTKkETnwr2eCLlUjIjIBPDmAVP1hZD0dS2Om59IjX/FCTf+/Ja1+AJw6ClEGW6DFIaVLhQ==",
       "dev": true
     },
     "node_modules/bpmn-moddle": {
@@ -14089,9 +14089,9 @@
       }
     },
     "bpmn-font": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.11.0.tgz",
-      "integrity": "sha512-+Vi+QjAoMebRaSHdranAxLk+6k/4q2VIpS9VoXrU1bwMZpcnV+i04hNXGGV1fbrOZL4YscuDp49OvAErzU1Qpg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.12.0.tgz",
+      "integrity": "sha512-JQBXri5Dp5q+YgvpeTKkETnwr2eCLlUjIjIBPDmAVP1hZD0dS2Om59IjX/FCTf+/Ja1+AJw6ClEGW6DFIaVLhQ==",
       "dev": true
     },
     "bpmn-moddle": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@rollup/plugin-terser": "^0.1.0",
     "babel-loader": "^9.1.0",
     "babel-plugin-istanbul": "^6.1.1",
-    "bpmn-font": "^0.11.0",
+    "bpmn-font": "^0.12.0",
     "camunda-bpmn-moddle": "^4.0.1",
     "chai": "4.1.2",
     "chai-match": "^1.1.1",


### PR DESCRIPTION
This builds on top of https://github.com/bpmn-io/bpmn-js/pull/1822 and further improves the visual presence of the single connection tool.

| _Before_ | _After_ |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/58601/215989757-db3c4571-4ebb-4ff6-a29e-c5fba029e8bd.png) | ![image](https://user-images.githubusercontent.com/58601/215989487-1ea359b5-533f-43d4-8c97-b5300ebc10c9.png) |


#### Full screen

![image](https://user-images.githubusercontent.com/58601/215990274-a78878fb-a303-4a09-94d8-ad21a8f8449b.png)
