### PR TITLE
Improve shape rendering / join path `round`

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -106,8 +106,7 @@ export default function BpmnRenderer(
     var {
       ref = { x: 0, y: 0 },
       scale = 1,
-      element,
-      attrs
+      element
     } = options;
 
     var marker = svgCreate('marker', {
@@ -119,8 +118,6 @@ export default function BpmnRenderer(
       markerHeight: 20 * scale,
       orient: 'auto'
     });
-
-    svgAttr(element, attrs);
 
     svgAppend(marker, element);
 
@@ -156,18 +153,19 @@ export default function BpmnRenderer(
   function createMarker(id, type, fill, stroke) {
 
     if (type === 'sequenceflow-end') {
-      var sequenceflowEnd = svgCreate('path');
-      svgAttr(sequenceflowEnd, { d: 'M 1 5 L 11 10 L 1 15 Z' });
-
-      addMarker(id, {
-        element: sequenceflowEnd,
-        ref: { x: 11, y: 10 },
-        scale: 0.5,
-        attrs: shapeStyle({
+      var sequenceflowEnd = svgCreate('path', {
+        d: 'M 1 5 L 11 10 L 1 15 Z',
+        ...shapeStyle({
           fill: stroke,
           stroke: stroke,
           strokeWidth: 1
         })
+      });
+
+      addMarker(id, {
+        element: sequenceflowEnd,
+        ref: { x: 11, y: 10 },
+        scale: 0.5
       });
     }
 
@@ -175,48 +173,48 @@ export default function BpmnRenderer(
       var messageflowStart = svgCreate('circle', {
         cx: 6,
         cy: 6,
-        r: 3.5
+        r: 3.5,
+        ...shapeStyle({
+          fill: fill,
+          stroke: stroke,
+          strokeWidth: 1
+        })
       });
 
       addMarker(id, {
         element: messageflowStart,
-        attrs: shapeStyle({
-          fill: fill,
-          stroke: stroke,
-          strokeWidth: 1
-        }),
         ref: { x: 6, y: 6 }
       });
     }
 
     if (type === 'messageflow-end') {
       var messageflowEnd = svgCreate('path', {
-        d: 'm 1 5 l 0 -3 l 7 3 l -7 3 z'
+        d: 'm 1 5 l 0 -3 l 7 3 l -7 3 z',
+        ...shapeStyle({
+          fill: fill,
+          stroke: stroke,
+          strokeWidth: 1
+        })
       });
 
       addMarker(id, {
         element: messageflowEnd,
-        attrs: shapeStyle({
-          fill: fill,
-          stroke: stroke,
-          strokeWidth: 1
-        }),
         ref: { x: 8.5, y: 5 }
       });
     }
 
     if (type === 'association-start') {
       var associationStart = svgCreate('path', {
-        d: 'M 11 5 L 1 10 L 11 15'
+        d: 'M 11 5 L 1 10 L 11 15',
+        ...lineStyle({
+          fill: 'none',
+          stroke: stroke,
+          strokeWidth: 1.5
+        })
       });
 
       addMarker(id, {
         element: associationStart,
-        attrs: lineStyle({
-          fill: 'none',
-          stroke: stroke,
-          strokeWidth: 1.5
-        }),
         ref: { x: 1, y: 10 },
         scale: 0.5
       });
@@ -224,16 +222,16 @@ export default function BpmnRenderer(
 
     if (type === 'association-end') {
       var associationEnd = svgCreate('path', {
-        d: 'M 1 5 L 11 10 L 1 15'
+        d: 'M 1 5 L 11 10 L 1 15',
+        ...lineStyle({
+          fill: 'none',
+          stroke: stroke,
+          strokeWidth: 1.5
+        })
       });
 
       addMarker(id, {
         element: associationEnd,
-        attrs: lineStyle({
-          fill: 'none',
-          stroke: stroke,
-          strokeWidth: 1.5
-        }),
         ref: { x: 12, y: 10 },
         scale: 0.5
       });
@@ -241,15 +239,15 @@ export default function BpmnRenderer(
 
     if (type === 'conditional-flow-marker') {
       var conditionalFlowMarker = svgCreate('path', {
-        d: 'M 0 10 L 8 6 L 16 10 L 8 14 Z'
+        d: 'M 0 10 L 8 6 L 16 10 L 8 14 Z',
+        ...shapeStyle({
+          fill: fill,
+          stroke: stroke
+        })
       });
 
       addMarker(id, {
         element: conditionalFlowMarker,
-        attrs: shapeStyle({
-          fill: fill,
-          stroke: stroke
-        }),
         ref: { x: -1, y: 10 },
         scale: 0.5
       });
@@ -257,14 +255,14 @@ export default function BpmnRenderer(
 
     if (type === 'conditional-default-flow-marker') {
       var defaultFlowMarker = svgCreate('path', {
-        d: 'M 6 4 L 10 16'
+        d: 'M 6 4 L 10 16',
+        ...shapeStyle({
+          stroke: stroke
+        })
       });
 
       addMarker(id, {
         element: defaultFlowMarker,
-        attrs: shapeStyle({
-          stroke: stroke
-        }),
         ref: { x: 0, y: 10 },
         scale: 0.5
       });

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1442,7 +1442,7 @@ export default function BpmnRenderer(
         markerEnd: marker('messageflow-end', fill, stroke),
         markerStart: marker('messageflow-start', fill, stroke),
         strokeDasharray: '10, 11',
-        strokeWidth: '1.5px',
+        strokeWidth: 1.5,
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
 

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -83,27 +83,34 @@ export default function BpmnRenderer(
 
   var markers = {};
 
-  var computeStyle = styles.computeStyle;
+  function shapeStyle(attrs) {
+    return styles.computeStyle(attrs, {
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round',
+      stroke: black,
+      strokeWidth: 2,
+      fill: 'white'
+    });
+  }
+
+  function lineStyle(attrs) {
+    return styles.computeStyle(attrs, [ 'no-fill' ], {
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round',
+      stroke: black,
+      strokeWidth: 2
+    });
+  }
 
   function addMarker(id, options) {
-    var attrs = assign({
-      fill: black,
-      strokeWidth: 1,
-      strokeLinecap: 'round',
-      strokeDasharray: 'none'
-    }, options.attrs);
+    var {
+      ref = { x: 0, y: 0 },
+      scale = 1,
+      element,
+      attrs
+    } = options;
 
-    var ref = options.ref || { x: 0, y: 0 };
-
-    var scale = options.scale || 1;
-
-    var marker = svgCreate('marker');
-
-    svgAttr(options.element, attrs);
-
-    svgAppend(marker, options.element);
-
-    svgAttr(marker, {
+    var marker = svgCreate('marker', {
       id: id,
       viewBox: '0 0 20 20',
       refX: ref.x,
@@ -112,6 +119,10 @@ export default function BpmnRenderer(
       markerHeight: 20 * scale,
       orient: 'auto'
     });
+
+    svgAttr(element, attrs);
+
+    svgAppend(marker, element);
 
     var defs = domQuery('defs', canvas._svg);
 
@@ -152,98 +163,108 @@ export default function BpmnRenderer(
         element: sequenceflowEnd,
         ref: { x: 11, y: 10 },
         scale: 0.5,
-        attrs: {
+        attrs: shapeStyle({
           fill: stroke,
-          stroke: stroke
-        }
+          stroke: stroke,
+          strokeWidth: 1
+        })
       });
     }
 
     if (type === 'messageflow-start') {
-      var messageflowStart = svgCreate('circle');
-      svgAttr(messageflowStart, { cx: 6, cy: 6, r: 3.5 });
+      var messageflowStart = svgCreate('circle', {
+        cx: 6,
+        cy: 6,
+        r: 3.5
+      });
 
       addMarker(id, {
         element: messageflowStart,
-        attrs: {
+        attrs: shapeStyle({
           fill: fill,
-          stroke: stroke
-        },
+          stroke: stroke,
+          strokeWidth: 1
+        }),
         ref: { x: 6, y: 6 }
       });
     }
 
     if (type === 'messageflow-end') {
-      var messageflowEnd = svgCreate('path');
-      svgAttr(messageflowEnd, { d: 'm 1 5 l 0 -3 l 7 3 l -7 3 z' });
+      var messageflowEnd = svgCreate('path', {
+        d: 'm 1 5 l 0 -3 l 7 3 l -7 3 z'
+      });
 
       addMarker(id, {
         element: messageflowEnd,
-        attrs: {
+        attrs: shapeStyle({
           fill: fill,
           stroke: stroke,
-          strokeLinecap: 'butt'
-        },
+          strokeWidth: 1
+        }),
         ref: { x: 8.5, y: 5 }
       });
     }
 
     if (type === 'association-start') {
-      var associationStart = svgCreate('path');
-      svgAttr(associationStart, { d: 'M 11 5 L 1 10 L 11 15' });
+      var associationStart = svgCreate('path', {
+        d: 'M 11 5 L 1 10 L 11 15'
+      });
 
       addMarker(id, {
         element: associationStart,
-        attrs: {
+        attrs: lineStyle({
           fill: 'none',
           stroke: stroke,
           strokeWidth: 1.5
-        },
+        }),
         ref: { x: 1, y: 10 },
         scale: 0.5
       });
     }
 
     if (type === 'association-end') {
-      var associationEnd = svgCreate('path');
-      svgAttr(associationEnd, { d: 'M 1 5 L 11 10 L 1 15' });
+      var associationEnd = svgCreate('path', {
+        d: 'M 1 5 L 11 10 L 1 15'
+      });
 
       addMarker(id, {
         element: associationEnd,
-        attrs: {
+        attrs: lineStyle({
           fill: 'none',
           stroke: stroke,
           strokeWidth: 1.5
-        },
+        }),
         ref: { x: 12, y: 10 },
         scale: 0.5
       });
     }
 
     if (type === 'conditional-flow-marker') {
-      var conditionalflowMarker = svgCreate('path');
-      svgAttr(conditionalflowMarker, { d: 'M 0 10 L 8 6 L 16 10 L 8 14 Z' });
+      var conditionalFlowMarker = svgCreate('path', {
+        d: 'M 0 10 L 8 6 L 16 10 L 8 14 Z'
+      });
 
       addMarker(id, {
-        element: conditionalflowMarker,
-        attrs: {
+        element: conditionalFlowMarker,
+        attrs: shapeStyle({
           fill: fill,
           stroke: stroke
-        },
+        }),
         ref: { x: -1, y: 10 },
         scale: 0.5
       });
     }
 
     if (type === 'conditional-default-flow-marker') {
-      var conditionaldefaultflowMarker = svgCreate('path');
-      svgAttr(conditionaldefaultflowMarker, { d: 'M 6 4 L 10 16' });
+      var defaultFlowMarker = svgCreate('path', {
+        d: 'M 6 4 L 10 16'
+      });
 
       addMarker(id, {
-        element: conditionaldefaultflowMarker,
-        attrs: {
+        element: defaultFlowMarker,
+        attrs: shapeStyle({
           stroke: stroke
-        },
+        }),
         ref: { x: 0, y: 10 },
         scale: 0.5
       });
@@ -259,11 +280,7 @@ export default function BpmnRenderer(
 
     offset = offset || 0;
 
-    attrs = computeStyle(attrs, {
-      stroke: black,
-      strokeWidth: 2,
-      fill: 'white'
-    });
+    attrs = shapeStyle(attrs);
 
     if (attrs.fill === 'none') {
       delete attrs.fillOpacity;
@@ -272,13 +289,12 @@ export default function BpmnRenderer(
     var cx = width / 2,
         cy = height / 2;
 
-    var circle = svgCreate('circle');
-    svgAttr(circle, {
+    var circle = svgCreate('circle', {
       cx: cx,
       cy: cy,
-      r: Math.round((width + height) / 4 - offset)
+      r: Math.round((width + height) / 4 - offset),
+      ...attrs
     });
-    svgAttr(circle, attrs);
 
     svgAppend(parentGfx, circle);
 
@@ -294,22 +310,17 @@ export default function BpmnRenderer(
 
     offset = offset || 0;
 
-    attrs = computeStyle(attrs, {
-      stroke: black,
-      strokeWidth: 2,
-      fill: 'white'
-    });
+    attrs = shapeStyle(attrs);
 
-    var rect = svgCreate('rect');
-    svgAttr(rect, {
+    var rect = svgCreate('rect', {
       x: offset,
       y: offset,
       width: width - offset * 2,
       height: height - offset * 2,
       rx: r,
-      ry: r
+      ry: r,
+      ...attrs
     });
-    svgAttr(rect, attrs);
 
     svgAppend(parentGfx, rect);
 
@@ -321,35 +332,39 @@ export default function BpmnRenderer(
     var x_2 = width / 2;
     var y_2 = height / 2;
 
-    var points = [ { x: x_2, y: 0 }, { x: width, y: y_2 }, { x: x_2, y: height }, { x: 0, y: y_2 } ];
+    var points = [
+      { x: x_2, y: 0 },
+      { x: width, y: y_2 },
+      { x: x_2, y: height },
+      { x: 0, y: y_2 }
+    ];
 
     var pointsString = points.map(function(point) {
       return point.x + ',' + point.y;
     }).join(' ');
 
-    attrs = computeStyle(attrs, {
-      stroke: black,
-      strokeWidth: 2,
-      fill: 'white'
-    });
+    attrs = shapeStyle(attrs);
 
-    var polygon = svgCreate('polygon');
-    svgAttr(polygon, {
+    var polygon = svgCreate('polygon', {
+      ...attrs,
       points: pointsString
     });
-    svgAttr(polygon, attrs);
 
     svgAppend(parentGfx, polygon);
 
     return polygon;
   }
 
+  /**
+   * @param {SVGElement} parentGfx
+   * @param {Point[]} waypoints
+   * @param {any} attrs
+   * @param {number} [radius]
+   *
+   * @return {SVGElement}
+   */
   function drawLine(parentGfx, waypoints, attrs) {
-    attrs = computeStyle(attrs, [ 'no-fill' ], {
-      stroke: black,
-      strokeWidth: 2,
-      fill: 'none'
-    });
+    attrs = lineStyle(attrs);
 
     var line = createLine(waypoints, attrs);
 
@@ -360,14 +375,12 @@ export default function BpmnRenderer(
 
   function drawPath(parentGfx, d, attrs) {
 
-    attrs = computeStyle(attrs, [ 'no-fill' ], {
-      strokeWidth: 2,
-      stroke: black
-    });
+    attrs = lineStyle(attrs);
 
-    var path = svgCreate('path');
-    svgAttr(path, { d: d });
-    svgAttr(path, attrs);
+    var path = svgCreate('path', {
+      ...attrs,
+      d
+    });
 
     svgAppend(parentGfx, path);
 
@@ -544,7 +557,6 @@ export default function BpmnRenderer(
       if (!semantic.isInterrupting) {
         attrs = {
           strokeDasharray: '6',
-          strokeLinecap: 'round',
           fill: getFillColor(element, defaultFillColor),
           stroke: getStrokeColor(element, defaultStrokeColor)
         };
@@ -599,7 +611,6 @@ export default function BpmnRenderer(
 
       drawPath(parentGfx, pathData, {
         strokeWidth: 2,
-        strokeLinecap: 'square',
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
 
@@ -621,7 +632,6 @@ export default function BpmnRenderer(
 
         drawPath(parentGfx, linePathData, {
           strokeWidth: 1,
-          strokeLinecap: 'square',
           transform: 'rotate(' + (i * 30) + ',' + height + ',' + width + ')',
           stroke: getStrokeColor(element, defaultStrokeColor)
         });
@@ -1089,10 +1099,11 @@ export default function BpmnRenderer(
       return task;
     },
     'bpmn:SubProcess': function(parentGfx, element, attrs) {
-      attrs = assign({
+      attrs = {
         fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      }, attrs);
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        ...attrs
+      };
 
       var rect = renderer('bpmn:Activity')(parentGfx, element, attrs);
 
@@ -1175,11 +1186,12 @@ export default function BpmnRenderer(
       return lane;
     },
     'bpmn:Lane': function(parentGfx, element, attrs) {
-      var rect = drawRect(parentGfx, element.width, element.height, 0, assign({
+      var rect = drawRect(parentGfx, element.width, element.height, 0, {
         fill: getFillColor(element, defaultFillColor),
         fillOpacity: HIGH_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      }, attrs));
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        ...attrs
+      });
 
       var semantic = getSemantic(element);
 
@@ -1298,13 +1310,11 @@ export default function BpmnRenderer(
           }
         });
 
-        var attrs = {
+        /* event path */ drawPath(parentGfx, pathData, {
           strokeWidth: 2,
           fill: getFillColor(element, 'none'),
           stroke: getStrokeColor(element, defaultStrokeColor)
-        };
-
-        /* event path */ drawPath(parentGfx, pathData, attrs);
+        });
       }
 
       if (type === 'Parallel') {
@@ -1320,16 +1330,14 @@ export default function BpmnRenderer(
           }
         });
 
-        var parallelPath = drawPath(parentGfx, pathData);
-        svgAttr(parallelPath, {
+        drawPath(parentGfx, pathData, {
           strokeWidth: 1,
           fill: 'none'
         });
       } else if (type === 'Exclusive') {
 
         if (!instantiate) {
-          var innerCircle = drawCircle(parentGfx, element.width, element.height, element.height * 0.26);
-          svgAttr(innerCircle, {
+          drawCircle(parentGfx, element.width, element.height, element.height * 0.26, {
             strokeWidth: 1,
             fill: 'none',
             stroke: getStrokeColor(element, defaultStrokeColor)
@@ -1343,13 +1351,11 @@ export default function BpmnRenderer(
       return diamond;
     },
     'bpmn:Gateway': function(parentGfx, element) {
-      var attrs = {
+      return drawDiamond(parentGfx, element.width, element.height, {
         fill: getFillColor(element, defaultFillColor),
         fillOpacity: DEFAULT_FILL_OPACITY,
         stroke: getStrokeColor(element, defaultStrokeColor)
-      };
-
-      return drawDiamond(parentGfx, element.width, element.height, attrs);
+      });
     },
     'bpmn:SequenceFlow': function(parentGfx, element) {
       var pathData = createPathFromConnection(element);
@@ -1358,7 +1364,6 @@ export default function BpmnRenderer(
           stroke = getStrokeColor(element, defaultStrokeColor);
 
       var attrs = {
-        strokeLinejoin: 'round',
         markerEnd: marker('sequenceflow-end', fill, stroke),
         stroke: getStrokeColor(element, defaultStrokeColor)
       };
@@ -1397,12 +1402,11 @@ export default function BpmnRenderer(
       var fill = getFillColor(element, defaultFillColor),
           stroke = getStrokeColor(element, defaultStrokeColor);
 
-      attrs = assign({
+      attrs = {
         strokeDasharray: '0.5, 5',
-        strokeLinecap: 'round',
-        strokeLinejoin: 'round',
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      }, attrs || {});
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        ...attrs
+      };
 
       if (semantic.associationDirection === 'One' ||
           semantic.associationDirection === 'Both') {
@@ -1444,9 +1448,7 @@ export default function BpmnRenderer(
       var attrs = {
         markerEnd: marker('messageflow-end', fill, stroke),
         markerStart: marker('messageflow-start', fill, stroke),
-        strokeDasharray: '10, 12',
-        strokeLinecap: 'round',
-        strokeLinejoin: 'round',
+        strokeDasharray: '10, 11',
         strokeWidth: '1.5px',
         stroke: getStrokeColor(element, defaultStrokeColor)
       };
@@ -1581,18 +1583,19 @@ export default function BpmnRenderer(
 
       if (!cancel) {
         attrs.strokeDasharray = '6';
-        attrs.strokeLinecap = 'round';
       }
 
       // apply fillOpacity
-      var outerAttrs = assign({}, attrs, {
+      var outerAttrs = {
+        ...attrs,
         fillOpacity: 1
-      });
+      };
 
       // apply no-fill
-      var innerAttrs = assign({}, attrs, {
+      var innerAttrs = {
+        ...attrs,
         fill: 'none'
-      });
+      };
 
       var outer = renderer('bpmn:Event')(parentGfx, element, outerAttrs);
 
@@ -1603,27 +1606,22 @@ export default function BpmnRenderer(
       return outer;
     },
     'bpmn:Group': function(parentGfx, element) {
-
-      var group = drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
+      return drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
         stroke: getStrokeColor(element, defaultStrokeColor),
         strokeWidth: 1,
         strokeDasharray: '8,3,1,3',
         fill: 'none',
         pointerEvents: 'none'
       });
-
-      return group;
     },
     'label': function(parentGfx, element) {
       return renderExternalLabel(parentGfx, element);
     },
     'bpmn:TextAnnotation': function(parentGfx, element) {
-      var style = {
+      var textElement = drawRect(parentGfx, element.width, element.height, 0, 0, {
         'fill': 'none',
         'stroke': 'none'
-      };
-
-      var textElement = drawRect(parentGfx, element.width, element.height, 0, 0, style);
+      });
 
       var textPathData = pathMap.getScaledPath('TEXT_ANNOTATION', {
         xScaleFactor: 1,
@@ -1765,7 +1763,6 @@ export default function BpmnRenderer(
         strokeWidth: 1,
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeLinecap: 'round',
         strokeMiterlimit: 0.5
       });
     },

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -97,12 +97,6 @@ export default function BpmnRenderer(
 
     var scale = options.scale || 1;
 
-    // fix for safari / chrome / firefox bug not correctly
-    // resetting stroke dash array
-    if (attrs.strokeDasharray === 'none') {
-      attrs.strokeDasharray = [ 10000, 1 ];
-    }
-
     var marker = svgCreate('marker');
 
     svgAttr(options.element, attrs);

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -371,6 +371,17 @@ export default function BpmnRenderer(
     return line;
   }
 
+  /**
+   * @param {SVGElement} parentGfx
+   * @param {Point[]} waypoints
+   * @param {any} attrs
+   *
+   * @return {SVGElement}
+   */
+  function drawConnectionSegments(parentGfx, waypoints, attrs) {
+    return drawLine(parentGfx, waypoints, attrs);
+  }
+
   function drawPath(parentGfx, d, attrs) {
 
     attrs = lineStyle(attrs);
@@ -523,16 +534,6 @@ export default function BpmnRenderer(
     var top = -1 * element.height;
 
     transform(textBox, 0, -top, 270);
-  }
-
-  function createPathFromConnection(connection) {
-    var waypoints = connection.waypoints;
-
-    var pathData = 'm  ' + waypoints[0].x + ',' + waypoints[0].y;
-    for (var i = 1; i < waypoints.length; i++) {
-      pathData += 'L' + waypoints[i].x + ',' + waypoints[i].y + ' ';
-    }
-    return pathData;
   }
 
   var handlers = this.handlers = {
@@ -1356,17 +1357,13 @@ export default function BpmnRenderer(
       });
     },
     'bpmn:SequenceFlow': function(parentGfx, element) {
-      var pathData = createPathFromConnection(element);
-
       var fill = getFillColor(element, defaultFillColor),
           stroke = getStrokeColor(element, defaultStrokeColor);
 
-      var attrs = {
+      var path = drawConnectionSegments(parentGfx, element.waypoints, {
         markerEnd: marker('sequenceflow-end', fill, stroke),
         stroke: getStrokeColor(element, defaultStrokeColor)
-      };
-
-      var path = drawPath(parentGfx, pathData, attrs);
+      });
 
       var sequenceFlow = getSemantic(element);
 
@@ -1415,7 +1412,7 @@ export default function BpmnRenderer(
         attrs.markerStart = marker('association-start', fill, stroke);
       }
 
-      return drawLine(parentGfx, element.waypoints, attrs);
+      return drawConnectionSegments(parentGfx, element.waypoints, attrs);
     },
     'bpmn:DataInputAssociation': function(parentGfx, element) {
       var fill = getFillColor(element, defaultFillColor),
@@ -1441,17 +1438,13 @@ export default function BpmnRenderer(
       var fill = getFillColor(element, defaultFillColor),
           stroke = getStrokeColor(element, defaultStrokeColor);
 
-      var pathData = createPathFromConnection(element);
-
-      var attrs = {
+      var path = drawConnectionSegments(parentGfx, element.waypoints, {
         markerEnd: marker('messageflow-end', fill, stroke),
         markerStart: marker('messageflow-start', fill, stroke),
         strokeDasharray: '10, 11',
         strokeWidth: '1.5px',
         stroke: getStrokeColor(element, defaultStrokeColor)
-      };
-
-      var path = drawPath(parentGfx, pathData, attrs);
+      });
 
       if (semantic.messageRef) {
         var midPoint = path.getPointAtLength(path.getTotalLength() / 2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^11.7.0",
+        "diagram-js": "^11.8.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",
         "inherits-browser": "^0.1.0",
@@ -3388,9 +3388,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.7.0.tgz",
-      "integrity": "sha512-NGXQzrYpcC8dZgUSpIT0KwAlCX1ncfiGJr9h6NnAP9ylx/PjQ1ywiLwWQa7nk7Rx63GtJghs6KNF5/sISpeTmw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.8.0.tgz",
+      "integrity": "sha512-N1V3GjHeTdsWUPd4rjYun503b31GdDFy8VvaI/91CrnJr+iIAjiRlbH5vyiSHc8bmzKe6ykoiNe8Nm9ZJrg2AQ==",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",
@@ -19064,9 +19064,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.7.0.tgz",
-      "integrity": "sha512-NGXQzrYpcC8dZgUSpIT0KwAlCX1ncfiGJr9h6NnAP9ylx/PjQ1ywiLwWQa7nk7Rx63GtJghs6KNF5/sISpeTmw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.8.0.tgz",
+      "integrity": "sha512-N1V3GjHeTdsWUPd4rjYun503b31GdDFy8VvaI/91CrnJr+iIAjiRlbH5vyiSHc8bmzKe6ykoiNe8Nm9ZJrg2AQ==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
     "css.escape": "^1.5.1",
-    "diagram-js": "^11.7.0",
+    "diagram-js": "^11.8.0",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.0",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
This PR ensures that we render paths on the diagram with `round` linecap / linejoin. This leads to a (slightly) improved, less harsh for the eye visual representation for shapes, connections, and markers.

## Before 

![screenshot vdGOq3](https://user-images.githubusercontent.com/58601/216039608-ad174e17-57d2-453f-aa88-fe9cc9a15505.png)

## After

![screenshot ALOcmc](https://user-images.githubusercontent.com/58601/216039615-2154661d-0cfb-4e8d-b598-bd336dc929ed.png)

---

Noteworthy glitches fixed:

* Sequence Flow end marker has _one_ out of three sharp corners
* Data Object looks aweful 