### PR TITLE
Rework BPMN symbol rendering

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -232,7 +232,7 @@ export default function BpmnRenderer(
 
       addMarker(id, {
         element: associationEnd,
-        ref: { x: 12, y: 10 },
+        ref: { x: 11, y: 10 },
         scale: 0.5
       });
     }
@@ -1405,7 +1405,7 @@ export default function BpmnRenderer(
           stroke = getStrokeColor(element, defaultStrokeColor);
 
       attrs = {
-        strokeDasharray: '0.5, 5',
+        strokeDasharray: '0, 5',
         stroke: getStrokeColor(element, defaultStrokeColor),
         ...attrs
       };

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1129,13 +1129,14 @@ export default function BpmnRenderer(
       return renderer('bpmn:SubProcess')(parentGfx, element);
     },
     'bpmn:Transaction': function(parentGfx, element) {
-      var outer = renderer('bpmn:SubProcess')(parentGfx, element);
+      var outer = renderer('bpmn:SubProcess')(parentGfx, element, { strokeWidth: 1.5 });
 
       var innerAttrs = styles.style([ 'no-fill', 'no-events' ], {
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        strokeWidth: 1.5
       });
 
-      /* inner path */ drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS - 2, INNER_OUTER_DIST, innerAttrs);
+      /* inner path */ drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS - 3, INNER_OUTER_DIST, innerAttrs);
 
       return outer;
     },

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -838,14 +838,14 @@ export default function BpmnRenderer(
     },
     'bpmn:IntermediateEvent': function(parentGfx, element) {
       var outer = renderer('bpmn:Event')(parentGfx, element, {
-        strokeWidth: 1,
+        strokeWidth: 1.5,
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
 
       /* inner */
       drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, {
-        strokeWidth: 1,
+        strokeWidth: 1.5,
         fill: getFillColor(element, 'none'),
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
@@ -1574,7 +1574,7 @@ export default function BpmnRenderer(
           cancel = semantic.cancelActivity;
 
       var attrs = {
-        strokeWidth: 1,
+        strokeWidth: 1.5,
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor)
       };

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1110,7 +1110,8 @@ export default function BpmnRenderer(
 
       if (isEventSubProcess(element)) {
         svgAttr(rect, {
-          strokeDasharray: '1,2'
+          strokeDasharray: '0, 5',
+          strokeWidth: 2.5
         });
       }
 

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1145,10 +1145,13 @@ export default function BpmnRenderer(
     },
     'bpmn:Participant': function(parentGfx, element) {
 
+      var strokeWidth = 1.5;
+
       var attrs = {
         fillOpacity: DEFAULT_FILL_OPACITY,
         fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        strokeWidth
       };
 
       var lane = renderer('bpmn:Lane')(parentGfx, element, attrs);
@@ -1160,13 +1163,14 @@ export default function BpmnRenderer(
           { x: 30, y: 0 },
           { x: 30, y: element.height }
         ], {
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          stroke: getStrokeColor(element, defaultStrokeColor),
+          strokeWidth
         });
         var text = getSemantic(element).name;
         renderLaneLabel(parentGfx, text, element);
       } else {
 
-        // Collapsed pool draw text inline
+        // collapsed pool draw text inline
         var text2 = getSemantic(element).name;
         renderLabel(parentGfx, text2, {
           box: element, align: 'center-middle',
@@ -1189,6 +1193,7 @@ export default function BpmnRenderer(
         fill: getFillColor(element, defaultFillColor),
         fillOpacity: HIGH_FILL_OPACITY,
         stroke: getStrokeColor(element, defaultStrokeColor),
+        strokeWidth: 1.5,
         ...attrs
       });
 

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -490,7 +490,7 @@ export default function BpmnRenderer(
     return renderLabel(parentGfx, semantic.name, {
       box: element,
       align: align,
-      padding: 5,
+      padding: 7,
       style: {
         fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
       }
@@ -1640,7 +1640,7 @@ export default function BpmnRenderer(
       renderLabel(parentGfx, text, {
         box: element,
         align: 'left-top',
-        padding: 5,
+        padding: 7,
         style: {
           fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
         }

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1606,8 +1606,8 @@ export default function BpmnRenderer(
     'bpmn:Group': function(parentGfx, element) {
       return drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
         stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeWidth: 1,
-        strokeDasharray: '8,3,1,3',
+        strokeWidth: 1.5,
+        strokeDasharray: '10,6,0,6',
         fill: 'none',
         pointerEvents: 'none'
       });

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1751,7 +1751,7 @@ export default function BpmnRenderer(
       });
 
       drawMarker('loop', parentGfx, markerPath, {
-        strokeWidth: 1,
+        strokeWidth: 1.5,
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor),
         strokeMiterlimit: 0.5


### PR DESCRIPTION
This builds on top of #1827 and reworks rendering of different BPMN symbols:

* Group (alignment with BPMN 2.0 spec, improved visual presence)
* Participant / Lane (decreased visual presence)
* Event Sub-Process (alignment with BPMN 2.0 spec)
* Transaction (adjusted visual presence)
* Intermediate Event / Boundary Event (adjusted visual presence)
* ...

### Before

![image](https://user-images.githubusercontent.com/58601/216146875-03d4a907-8f81-4f80-bb9f-4a0b8748484c.png)

### After

![image](https://user-images.githubusercontent.com/58601/216146704-e0403524-3765-481d-ba0d-679c2b02d65c.png)
