### PR TITLE
Improve semantic ordering / filter rare elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 11.3.0
+
+* `FEAT`: feature `service` and `user` tasks more prominently in replace menu ([#1836](https://github.com/bpmn-io/bpmn-js/pull/1836))
+* `FEAT`: hide rare items initially from create/append menus ([#1836](https://github.com/bpmn-io/bpmn-js/pull/1836))
+* `FEAT`: retrieve instantiation modules with context ([#1835](https://github.com/bpmn-io/bpmn-js/pull/1835))
+* `DEPS`: update to `diagram-js@11.9.0`
+
 ## 11.2.0
 
 * `FEAT`: append menu available via context pad ([#1802](https://github.com/bpmn-io/bpmn-js/pull/1802), [#1809](https://github.com/bpmn-io/bpmn-js/pull/1809), [#1815](https://github.com/bpmn-io/bpmn-js/pull/1815), [#1818](https://github.com/bpmn-io/bpmn-js/pull/1818), [#1831](https://github.com/bpmn-io/bpmn-js/pull/1831))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: join paths `round` by default ([1827](https://github.com/bpmn-io/bpmn-js/pull/1827))
 * `FEAT`: improved BPMN symbol rendering ([#1830](https://github.com/bpmn-io/bpmn-js/pull/1830))
 * `FEAT`: round connection corners ([#1828](https://github.com/bpmn-io/bpmn-js/pull/1828))
+* `FEAT`: improve visibility of popup menu ([#1812](https://github.com/bpmn-io/bpmn-js/issues/1812))
 * `FIX`: missing special attributes in `bpmnElementFactory` ([#1807](https://github.com/bpmn-io/bpmn-js/pull/1807))
 * `FIX`: handle `bpmn:DataObjectReference` without data object in replace menu ([#1823](https://github.com/bpmn-io/bpmn-js/pull/1823))
 * `DEPS`: update to `diagram-js@11.8.0`

--- a/lib/features/create-append-anything/AppendMenuProvider.js
+++ b/lib/features/create-append-anything/AppendMenuProvider.js
@@ -66,7 +66,8 @@ AppendMenuProvider.prototype.getPopupMenuEntries = function(element) {
       target,
       description,
       group,
-      search
+      search,
+      rank
     } = option;
 
     entries[`append-${actionName}`] = {
@@ -75,6 +76,7 @@ AppendMenuProvider.prototype.getPopupMenuEntries = function(element) {
       description,
       group,
       search,
+      rank,
       action: this._createEntryAction(element, target)
     };
   });

--- a/lib/features/create-append-anything/CreateMenuProvider.js
+++ b/lib/features/create-append-anything/CreateMenuProvider.js
@@ -53,7 +53,8 @@ CreateMenuProvider.prototype.getPopupMenuEntries = function() {
       target,
       description,
       group,
-      search
+      search,
+      rank
     } = option;
 
     const targetAction = this._createEntryAction(target);
@@ -67,6 +68,7 @@ CreateMenuProvider.prototype.getPopupMenuEntries = function() {
         name: this._translate(group.name)
       },
       search,
+      rank,
       action: {
         click: targetAction,
         dragstart: targetAction

--- a/lib/features/create-append-anything/util/OptionsUtil.js
+++ b/lib/features/create-append-anything/util/OptionsUtil.js
@@ -416,7 +416,8 @@ export var GATEWAY = [
     className: 'bpmn-icon-gateway-or',
     target: {
       type: 'bpmn:InclusiveGateway'
-    }
+    },
+    rank: -1
   },
   {
     label: 'Complex Gateway',
@@ -424,7 +425,8 @@ export var GATEWAY = [
     className: 'bpmn-icon-gateway-complex',
     target: {
       type: 'bpmn:ComplexGateway'
-    }
+    },
+    rank: -1
   },
   {
     label: 'Event based Gateway',
@@ -512,7 +514,8 @@ export var TASK = [
     className: 'bpmn-icon-send',
     target: {
       type: 'bpmn:SendTask'
-    }
+    },
+    rank: -1
   },
   {
     label: 'Receive Task',
@@ -520,6 +523,8 @@ export var TASK = [
     className: 'bpmn-icon-receive',
     target: {
       type: 'bpmn:ReceiveTask'
+    },
+    rank: -1
   },
   {
     label: 'Manual Task',
@@ -527,7 +532,8 @@ export var TASK = [
     className: 'bpmn-icon-manual',
     target: {
       type: 'bpmn:ManualTask'
-    }
+    },
+    rank: -1
   },
   {
     label: 'Business Rule Task',

--- a/lib/features/create-append-anything/util/OptionsUtil.js
+++ b/lib/features/create-append-anything/util/OptionsUtil.js
@@ -491,6 +491,22 @@ export var TASK = [
     }
   },
   {
+    label: 'User Task',
+    actionName: 'user-task',
+    className: 'bpmn-icon-user',
+    target: {
+      type: 'bpmn:UserTask'
+    }
+  },
+  {
+    label: 'Service Task',
+    actionName: 'service-task',
+    className: 'bpmn-icon-service',
+    target: {
+      type: 'bpmn:ServiceTask'
+    }
+  },
+  {
     label: 'Send Task',
     actionName: 'send-task',
     className: 'bpmn-icon-send',
@@ -504,15 +520,6 @@ export var TASK = [
     className: 'bpmn-icon-receive',
     target: {
       type: 'bpmn:ReceiveTask'
-    }
-  },
-  {
-    label: 'User Task',
-    actionName: 'user-task',
-    className: 'bpmn-icon-user',
-    target: {
-      type: 'bpmn:UserTask'
-    }
   },
   {
     label: 'Manual Task',
@@ -528,14 +535,6 @@ export var TASK = [
     className: 'bpmn-icon-business-rule',
     target: {
       type: 'bpmn:BusinessRuleTask'
-    }
-  },
-  {
-    label: 'Service Task',
-    actionName: 'service-task',
-    className: 'bpmn-icon-service',
-    target: {
-      type: 'bpmn:ServiceTask'
     }
   },
   {

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -444,6 +444,22 @@ export var TASK = [
     }
   },
   {
+    label: 'User Task',
+    actionName: 'replace-with-user-task',
+    className: 'bpmn-icon-user',
+    target: {
+      type: 'bpmn:UserTask'
+    }
+  },
+  {
+    label: 'Service Task',
+    actionName: 'replace-with-service-task',
+    className: 'bpmn-icon-service',
+    target: {
+      type: 'bpmn:ServiceTask'
+    }
+  },
+  {
     label: 'Send Task',
     actionName: 'replace-with-send-task',
     className: 'bpmn-icon-send',
@@ -460,14 +476,6 @@ export var TASK = [
     }
   },
   {
-    label: 'User Task',
-    actionName: 'replace-with-user-task',
-    className: 'bpmn-icon-user',
-    target: {
-      type: 'bpmn:UserTask'
-    }
-  },
-  {
     label: 'Manual Task',
     actionName: 'replace-with-manual-task',
     className: 'bpmn-icon-manual',
@@ -481,14 +489,6 @@ export var TASK = [
     className: 'bpmn-icon-business-rule',
     target: {
       type: 'bpmn:BusinessRuleTask'
-    }
-  },
-  {
-    label: 'Service Task',
-    actionName: 'replace-with-service-task',
-    className: 'bpmn-icon-service',
-    target: {
-      type: 'bpmn:ServiceTask'
     }
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^11.8.0",
+        "diagram-js": "^11.9.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",
         "inherits-browser": "^0.1.0",
@@ -3388,9 +3388,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.8.0.tgz",
-      "integrity": "sha512-N1V3GjHeTdsWUPd4rjYun503b31GdDFy8VvaI/91CrnJr+iIAjiRlbH5vyiSHc8bmzKe6ykoiNe8Nm9ZJrg2AQ==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.9.0.tgz",
+      "integrity": "sha512-1SKhsTB05TtYkm7x4kGT37p5j87OaLvSz2rqyuM1ZzB9fkolrEXyeU+xgdzeq2QtAcg/mwyOnhlANVLGH8pRqQ==",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",
@@ -19033,9 +19033,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.8.0.tgz",
-      "integrity": "sha512-N1V3GjHeTdsWUPd4rjYun503b31GdDFy8VvaI/91CrnJr+iIAjiRlbH5vyiSHc8bmzKe6ykoiNe8Nm9ZJrg2AQ==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-11.9.0.tgz",
+      "integrity": "sha512-1SKhsTB05TtYkm7x4kGT37p5j87OaLvSz2rqyuM1ZzB9fkolrEXyeU+xgdzeq2QtAcg/mwyOnhlANVLGH8pRqQ==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
     "css.escape": "^1.5.1",
-    "diagram-js": "^11.8.0",
+    "diagram-js": "^11.9.0",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.0",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
This closes https://github.com/bpmn-io/bpmn-js/issues/1621 in two ways:

* Initially rare elements are not shown in create/append anything menus
* User and service tasks are moved up in the menu to make them more prominent

---

![capture Tv7P1h_optimized](https://user-images.githubusercontent.com/58601/217030468-f66dc36a-d271-4eee-914e-b8f8f9b8a729.gif)
