### PR TITLE
fix: restore marker `stroke-dasharray` 2015 workaround

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -177,7 +177,11 @@ export default function BpmnRenderer(
         ...shapeStyle({
           fill: fill,
           stroke: stroke,
-          strokeWidth: 1
+          strokeWidth: 1,
+
+          // fix for safari / chrome / firefox bug not correctly
+          // resetting stroke dash array
+          strokeDasharray: [ 10000, 1 ]
         })
       });
 
@@ -193,7 +197,11 @@ export default function BpmnRenderer(
         ...shapeStyle({
           fill: fill,
           stroke: stroke,
-          strokeWidth: 1
+          strokeWidth: 1,
+
+          // fix for safari / chrome / firefox bug not correctly
+          // resetting stroke dash array
+          strokeDasharray: [ 10000, 1 ]
         })
       });
 
@@ -209,7 +217,11 @@ export default function BpmnRenderer(
         ...lineStyle({
           fill: 'none',
           stroke: stroke,
-          strokeWidth: 1.5
+          strokeWidth: 1.5,
+
+          // fix for safari / chrome / firefox bug not correctly
+          // resetting stroke dash array
+          strokeDasharray: [ 10000, 1 ]
         })
       });
 
@@ -226,7 +238,11 @@ export default function BpmnRenderer(
         ...lineStyle({
           fill: 'none',
           stroke: stroke,
-          strokeWidth: 1.5
+          strokeWidth: 1.5,
+
+          // fix for safari / chrome / firefox bug not correctly
+          // resetting stroke dash array
+          strokeDasharray: [ 10000, 1 ]
         })
       });
 


### PR DESCRIPTION
Reverts https://github.com/bpmn-io/bpmn-js/commit/eb4b54f7ffdb55e340aac291c33a5f4d66e246b3 as it breaks image export.

Related to https://github.com/camunda/camunda-modeler/issues/3442.