### PR TITLE
fix(create-append-anything): extend append shortcut use case

### DIFF
--- a/lib/features/create-append-anything/CreateAppendEditorActions.js
+++ b/lib/features/create-append-anything/CreateAppendEditorActions.js
@@ -25,16 +25,23 @@ CreateAppendEditorActions.prototype.registerActions = function() {
   var selection = this._injector.get('selection', false);
   var contextPad = this._injector.get('contextPad', false);
   var palette = this._injector.get('palette', false);
+  var popupMenu = this._injector.get('popupMenu', false);
 
   const actions = {};
 
   // append
-  if (selection && contextPad) {
+  if (selection && contextPad && palette && popupMenu && palette) {
     assign(actions, {
       'appendElement': function(event) {
-        contextPad.triggerEntry('append', 'click', event);
-      } }
-    );
+        const selected = selection && selection.get();
+
+        if (selected.length == 1 && !popupMenu.isEmpty(selected[0], 'bpmn-append')) {
+          contextPad.triggerEntry('append', 'click', event);
+        } else {
+          palette.triggerEntry('create', 'click', event);
+        }
+      }
+    });
   }
 
   // create

--- a/lib/features/create-append-anything/CreateAppendKeyboardBindings.js
+++ b/lib/features/create-append-anything/CreateAppendKeyboardBindings.js
@@ -13,7 +13,6 @@ export default function CreateAppendKeyboardBindings(injector) {
   this._injector = injector;
   this._keyboard = this._injector.get('keyboard', false);
   this._editorActions = this._injector.get('editorActions', false);
-  this._selection = this._injector.get('selection', false);
 
   if (this._keyboard) {
     this._injector.invoke(KeyboardBindings, this);
@@ -37,7 +36,6 @@ CreateAppendKeyboardBindings.prototype.registerBindings = function() {
 
   var keyboard = this._keyboard;
   var editorActions = this._editorActions;
-  var selection = this._selection;
 
   // inherit default bindings
   KeyboardBindings.prototype.registerBindings.call(this, keyboard, editorActions);
@@ -68,12 +66,7 @@ CreateAppendKeyboardBindings.prototype.registerBindings = function() {
 
     if (keyboard && keyboard.isKey([ 'a', 'A' ], event)) {
 
-      if (selection && selection.get().length == 1) {
-        editorActions && editorActions.trigger('appendElement', event);
-      } else {
-        editorActions && editorActions.trigger('createElement', event);
-      }
-
+      editorActions && editorActions.trigger('appendElement', event);
       return true;
     }
   });

--- a/test/spec/features/create-append-anything/CreateAppendEditorActionsSpec.js
+++ b/test/spec/features/create-append-anything/CreateAppendEditorActionsSpec.js
@@ -1,7 +1,12 @@
 import {
   bootstrapModeler,
-  inject
+  inject,
+  getBpmnJS
 } from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
 
 import selectionModule from 'diagram-js/lib/features/selection';
 import modelingModule from 'lib/features/modeling';
@@ -42,25 +47,11 @@ describe('features/create-append-anything - editor actions', function() {
 
       // then
       expect(changedSpy).to.have.been.called;
+      expect(isMenu('bpmn-append')).to.be.true;
     }));
 
 
-    it('should not open append element if no selection', inject(function(editorActions, eventBus) {
-
-      // given
-      var changedSpy = sinon.spy();
-
-      // when
-      eventBus.once('popupMenu.open', changedSpy);
-
-      editorActions.trigger('appendElement', {});
-
-      // then
-      expect(changedSpy).to.not.have.been.called;
-    }));
-
-
-    it('should not open append element if multiple elements selected', inject(function(elementRegistry, selection, editorActions, eventBus) {
+    it('should open create element if multiple elements selected', inject(function(elementRegistry, selection, editorActions, eventBus) {
 
       // given
       var elementIds = [ 'StartEvent_1', 'UserTask_1' ];
@@ -77,7 +68,43 @@ describe('features/create-append-anything - editor actions', function() {
       editorActions.trigger('appendElement', {});
 
       // then
-      expect(changedSpy).to.not.have.been.called;
+      expect(changedSpy).to.have.been.called;
+      expect(isMenu('bpmn-create')).to.be.true;
+    }));
+
+
+    it('should open create element if no selection', inject(function(elementRegistry, selection, editorActions, eventBus) {
+
+      // given
+      var changedSpy = sinon.spy();
+
+      // when
+      eventBus.once('popupMenu.open', changedSpy);
+
+      editorActions.trigger('appendElement', {});
+
+      // then
+      expect(changedSpy).to.have.been.called;
+      expect(isMenu('bpmn-create')).to.be.true;
+    }));
+
+
+    it('should open create element if append not allowed', inject(function(elementRegistry, selection, editorActions, eventBus) {
+
+      // given
+      const element = elementRegistry.get('EndEvent_1');
+
+      selection.select(element);
+      var changedSpy = sinon.spy();
+
+      // when
+      eventBus.once('popupMenu.open', changedSpy);
+
+      editorActions.trigger('appendElement', {});
+
+      // then
+      expect(changedSpy).to.have.been.called;
+      expect(isMenu('bpmn-create')).to.be.true;
     }));
 
   });
@@ -112,3 +139,12 @@ describe('features/create-append-anything - editor actions', function() {
   });
 
 });
+
+
+// helpers //////////////////////
+function isMenu(menuId) {
+  const popup = getBpmnJS().get('popupMenu');
+  const popupElement = popup._current && domQuery('.djs-popup', popup._current.container);
+
+  return popupElement.classList.contains(menuId);
+}


### PR DESCRIPTION
Closes #1840

I decided to move the "trigger create action if append not allowed" logic to the action itself. I figure this will also make it easier to use it in Camunda Modeler (no need to repeat logic, just trigger action). Let me know if you think this doesn't make sense