### PR TITLE
refactor: replace `css.escape` npm module with builtin API

### DIFF
--- a/lib/features/replace-preview/BpmnReplacePreview.js
+++ b/lib/features/replace-preview/BpmnReplacePreview.js
@@ -2,7 +2,7 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import inherits from 'inherits-browser';
 
-import { escapeCSS as cssEscape } from 'diagram-js/util/EscapeUtil';
+import { escapeCSS as cssEscape } from 'diagram-js/lib/util/EscapeUtil';
 
 import {
   assign,

--- a/lib/features/replace-preview/BpmnReplacePreview.js
+++ b/lib/features/replace-preview/BpmnReplacePreview.js
@@ -2,7 +2,7 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
 import inherits from 'inherits-browser';
 
-import cssEscape from 'css.escape';
+import { escapeCSS as cssEscape } from 'diagram-js/util/EscapeUtil';
 
 import {
   assign,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
-        "css.escape": "^1.5.1",
         "diagram-js": "^11.9.1",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
   },
   "dependencies": {
     "bpmn-moddle": "^8.0.0",
-    "css.escape": "^1.5.1",
     "diagram-js": "^11.9.1",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.0",


### PR DESCRIPTION
Closes #1850 
