### PR TITLE
feat: add root elements to definitions for updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add root elements to definitions when provided via `modeling#update(Moddle)Properties`
+
 ## 11.4.1
 
 * `FIX`: correct redo triggering on international keyboard layouts ([#1842](https://github.com/bpmn-io/bpmn-js/issues/1842))

--- a/lib/features/modeling/behavior/RootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/RootElementReferenceBehavior.js
@@ -87,8 +87,12 @@ export default function RootElementReferenceBehavior(
   }
 
   // create shape
-  this.executed('shape.create', function(context) {
-    var shape = context.shape;
+  this.executed([
+    'shape.create',
+    'element.updateProperties',
+    'element.updateModdleProperties'
+  ], function(context) {
+    var shape = context.shape || context.element;
 
     if (!canHaveRootElementReference(shape)) {
       return;
@@ -108,7 +112,11 @@ export default function RootElementReferenceBehavior(
     }
   }, true);
 
-  this.reverted('shape.create', function(context) {
+  this.reverted([
+    'shape.create',
+    'element.updateProperties',
+    'element.updateModdleProperties'
+  ], function(context) {
     var addedRootElement = context.addedRootElement;
 
     if (!addedRootElement) {

--- a/test/spec/features/modeling/behavior/RootElementReferenceBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/RootElementReferenceBehavior.bpmn
@@ -15,8 +15,11 @@
       <bpmn:signalEventDefinition signalRef="Signal_1" />
     </bpmn:boundaryEvent>
     <bpmn:receiveTask id="ReceiveTask" messageRef="Message_2" />
+    <bpmn:receiveTask id="ReceiveTask_noRef" />
     <bpmn:task id="Task_2" />
     <bpmn:sendTask id="SendTask" messageRef="Message_3" />
+    <bpmn:sendTask id="SendTask_noRef" />
+    <bpmn:boundaryEvent id="BoundaryEvent" attachedToRef="Task_2" />
   </bpmn:process>
   <bpmn:message id="Message_1" name="Message_1" />
   <bpmn:escalation id="Escalation_1" name="Escalation_1" escalationCode="42" />
@@ -29,26 +32,35 @@
       <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="170" y="60" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="MessageBoundaryEvent_1_di" bpmnElement="MessageBoundaryEvent_1">
-        <dc:Bounds x="152" y="122" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EscalationBoundaryEvent_1_di" bpmnElement="EscalationBoundaryEvent_1">
-        <dc:Bounds x="252" y="42" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ErrorBoundaryEvent_1_di" bpmnElement="ErrorBoundaryEvent_1">
-        <dc:Bounds x="152" y="42" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SignalBoundaryEvent_1_di" bpmnElement="SignalBoundaryEvent_1">
-        <dc:Bounds x="252" y="122" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ReceiveTask_di" bpmnElement="ReceiveTask">
         <dc:Bounds x="170" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReceiveTask_noRef_di" bpmnElement="ReceiveTask_noRef">
+        <dc:Bounds x="170" y="320" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
         <dc:Bounds x="370" y="60" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SendTask_1y80j0q_di" bpmnElement="SendTask">
         <dc:Bounds x="370" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SendTask_noRef_di" bpmnElement="SendTask_noRef">
+        <dc:Bounds x="370" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1b2yxlf_di" bpmnElement="BoundaryEvent">
+        <dc:Bounds x="452" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SignalBoundaryEvent_1_di" bpmnElement="SignalBoundaryEvent_1">
+        <dc:Bounds x="252" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ErrorBoundaryEvent_1_di" bpmnElement="ErrorBoundaryEvent_1">
+        <dc:Bounds x="152" y="42" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EscalationBoundaryEvent_1_di" bpmnElement="EscalationBoundaryEvent_1">
+        <dc:Bounds x="252" y="42" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="MessageBoundaryEvent_1_di" bpmnElement="MessageBoundaryEvent_1">
+        <dc:Bounds x="152" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/RootElementReferenceBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/RootElementReferenceBehaviorSpec.js
@@ -189,6 +189,204 @@ describe('features/modeling - root element reference behavior', function() {
 
       });
 
+      describe(`${type} (modeling#updateProperties)`, function() {
+
+        var boundaryEvent,
+            rootElement;
+
+        describe('should add root element if not added to diagram', function() {
+
+          beforeEach(inject(function(bpmnFactory, elementRegistry, modeling) {
+
+            // given
+            boundaryEvent = elementRegistry.get('BoundaryEvent');
+            rootElement = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}`);
+            var eventDefinition = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}EventDefinition`, {
+              [`${type}Ref`]: rootElement
+            });
+
+            // when
+            modeling.updateProperties(boundaryEvent, {
+              eventDefinitions: [
+                eventDefinition
+              ]
+            });
+          }));
+
+
+          it('<do>', function() {
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          });
+
+
+          it('<undo>', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.false;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          }));
+
+
+          it('<redo>', inject(function(commandStack) {
+
+            // given
+            commandStack.undo();
+
+            // when
+            commandStack.redo();
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          }));
+
+        });
+
+
+        it('should NOT add root element to root elements if already present', inject(function(
+            bpmnFactory, bpmnjs, elementRegistry, modeling) {
+
+          // given
+          var rootElements = bpmnjs.getDefinitions().get('rootElements');
+          boundaryEvent = elementRegistry.get('BoundaryEvent');
+          rootElement = rootElements.find(matchPattern({ id: `${capitalizeFirstChar(type)}_1` }));
+
+          var rootElementsOfTypeCount = filter(
+            rootElements, matchPattern({ $type: rootElement.$type })
+          ).length;
+
+          var eventDefinition = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}EventDefinition`, {
+            [`${type}Ref`]: rootElement
+          });
+
+
+          // when
+          modeling.updateProperties(boundaryEvent, {
+            eventDefinitions: [
+              eventDefinition
+            ]
+          });
+
+          // then
+          var rootElementsOfType = filter(rootElements, matchPattern({ $type: rootElement.$type }));
+
+          expect(rootElementsOfType).to.have.lengthOf(rootElementsOfTypeCount);
+        }));
+
+      });
+
+      describe(`${type} (modeling#updateModdleProperties)`, function() {
+
+        var boundaryEvent,
+            rootElement;
+
+        describe('should add root element if not added to diagram', function() {
+
+          beforeEach(inject(function(bpmnFactory, elementRegistry, modeling) {
+
+            // given
+            boundaryEvent = elementRegistry.get('BoundaryEvent');
+            rootElement = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}`);
+            var bo = getBusinessObject(boundaryEvent);
+            var eventDefinition = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}EventDefinition`, {
+              [`${type}Ref`]: rootElement
+            });
+
+            // when
+            modeling.updateModdleProperties(boundaryEvent, bo, {
+              eventDefinitions: [
+                eventDefinition
+              ]
+            });
+          }));
+
+
+          it('<do>', function() {
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          });
+
+
+          it('<undo>', inject(function(commandStack) {
+
+            // when
+            commandStack.undo();
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.false;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          }));
+
+
+          it('<redo>', inject(function(commandStack) {
+
+            // given
+            commandStack.undo();
+
+            // when
+            commandStack.redo();
+
+            // then
+            expect(hasRootElement(rootElement)).to.be.true;
+
+            // no garbage attached to element
+            expect(boundaryEvent.referencedRootElements).not.to.exist;
+          }));
+
+        });
+
+
+        it('should NOT add root element to root elements if already present', inject(function(
+            bpmnFactory, bpmnjs, elementRegistry, modeling) {
+
+          // given
+          var rootElements = bpmnjs.getDefinitions().get('rootElements');
+          boundaryEvent = elementRegistry.get('BoundaryEvent');
+          rootElement = rootElements.find(matchPattern({ id: `${capitalizeFirstChar(type)}_1` }));
+
+          var rootElementsOfTypeCount = filter(
+            rootElements, matchPattern({ $type: rootElement.$type })
+          ).length;
+
+          var bo = getBusinessObject(boundaryEvent);
+          var eventDefinition = bpmnFactory.create(`bpmn:${capitalizeFirstChar(type)}EventDefinition`, {
+            [`${type}Ref`]: rootElement
+          });
+
+
+          // when
+          modeling.updateProperties(boundaryEvent, bo, {
+            eventDefinitions: [
+              eventDefinition
+            ]
+          });
+
+          // then
+          var rootElementsOfType = filter(rootElements, matchPattern({ $type: rootElement.$type }));
+
+          expect(rootElementsOfType).to.have.lengthOf(rootElementsOfTypeCount);
+        }));
+
+      });
+
     });
 
 
@@ -315,6 +513,184 @@ describe('features/modeling - root element reference behavior', function() {
 
           expect(rootElementsOfType).to.have.lengthOf(rootElementsOfTypeCount);
         }));
+      });
+
+
+      describe('modeling#updateProperties', function() {
+        forEach([
+          'ReceiveTask_noRef',
+          'SendTask_noRef'
+        ], function(type) {
+
+          var id = type;
+
+          var task,
+              rootElement;
+
+          describe('should add on modeling#updateProperties', function() {
+
+
+            beforeEach(inject(function(bpmnFactory, elementRegistry, modeling) {
+
+              // given
+              task = elementRegistry.get(id);
+
+              rootElement = bpmnFactory.create('bpmn:Message', { id: 'NewMessage' });
+
+              // when
+              modeling.updateProperties(task, {
+                messageRef: rootElement,
+              });
+            }));
+
+
+            it('<do>', function() {
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.true;
+            });
+
+
+            it('<undo>', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.false;
+            }));
+
+
+            it('<redo>', inject(function(commandStack) {
+
+              // given
+              commandStack.undo();
+
+              // when
+              commandStack.redo();
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.true;
+            }));
+          });
+
+
+          it('should NOT add message to root elements if already present', inject(function(
+              bpmnjs, elementRegistry, modeling
+          ) {
+
+            // given
+            task = elementRegistry.get(id);
+            var bo = getBusinessObject(task);
+
+            var rootElements = bpmnjs.getDefinitions().get('rootElements');
+            var message = rootElements.find(matchPattern({ id: 'Message_2' }));
+
+            var rootElementsOfTypeCount = filter(
+              rootElements, matchPattern({ $type: 'bpmn:Message' })
+            ).length;
+
+            // when
+            modeling.updateProperties(task, {
+              messageRef: message,
+            });
+
+            // then
+            var rootElementsOfType = filter(rootElements, matchPattern({ $type: 'bpmn:Message' }));
+            expect(rootElementsOfType).to.have.lengthOf(rootElementsOfTypeCount);
+            expect(bo.get('messageRef')).to.eq(message);
+          }));
+        });
+      });
+
+
+      describe('modeling#updateModdleProperties', function() {
+        forEach([
+          'ReceiveTask_noRef',
+          'SendTask_noRef'
+        ], function(type) {
+
+          var id = type;
+
+          var task,
+              rootElement;
+
+
+          describe('should add message to root elements', function() {
+
+
+            beforeEach(inject(function(bpmnFactory, elementRegistry, modeling) {
+
+              // given
+              task = elementRegistry.get(id);
+              var bo = getBusinessObject(task);
+
+              rootElement = bpmnFactory.create('bpmn:Message', { id: 'NewMessage' });
+
+              // when
+              modeling.updateModdleProperties(task, bo, {
+                messageRef: rootElement,
+              });
+            }));
+
+
+            it('<do>', function() {
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.true;
+            });
+
+
+            it('<undo>', inject(function(commandStack) {
+
+              // when
+              commandStack.undo();
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.false;
+            }));
+
+
+            it('<redo>', inject(function(commandStack) {
+
+              // given
+              commandStack.undo();
+
+              // when
+              commandStack.redo();
+
+              // then
+              expect(hasRootElement(rootElement)).to.be.true;
+            }));
+          });
+
+
+          it('should NOT add message to root elements if already present', inject(function(
+              bpmnjs, elementRegistry, modeling
+          ) {
+
+            // given
+            task = elementRegistry.get(id);
+            var bo = getBusinessObject(task);
+
+            var rootElements = bpmnjs.getDefinitions().get('rootElements');
+            var message = rootElements.find(matchPattern({ id: 'Message_2' }));
+
+            var rootElementsOfTypeCount = filter(
+              rootElements, matchPattern({ $type: 'bpmn:Message' })
+            ).length;
+
+            // when
+            modeling.updateModdleProperties(task, bo, {
+              messageRef: message,
+            });
+
+            // then
+            var rootElementsOfType = filter(rootElements, matchPattern({ $type: 'bpmn:Message' }));
+            expect(rootElementsOfType).to.have.lengthOf(rootElementsOfTypeCount);
+            expect(bo.get('messageRef')).to.eq(message);
+          }));
+        });
       });
     });
 


### PR DESCRIPTION
This is so that I don't need to manually add root element when updating messageRef or event definitions.