### PR TITLE
chore: bundle rollup config as CJS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ import {
 
 import path from 'path';
 
-const pkg = importPkg();
+import pkg from './package.json';
 
 const outputDir = 'dist';
 
@@ -139,8 +139,4 @@ function processTemplate(str, args) {
 
     return replacement;
   });
-}
-
-function importPkg() {
-  return JSON.parse(readFileSync('./package.json', { encoding:'utf8' }));
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,8 +11,6 @@ import {
   readFileSync
 } from 'fs';
 
-import path from 'path';
-
 import pkg from './package.json';
 
 const outputDir = 'dist';
@@ -83,7 +81,6 @@ function banner(bundleName, minified) {
       : 'banner'
   );
 
-  const __dirname = path.resolve();
   const bannerTemplate = readFileSync(`${__dirname}/resources/${bannerName}.txt`, 'utf8');
 
   const banner = processTemplate(bannerTemplate, {

--- a/tasks/build-distro.js
+++ b/tasks/build-distro.js
@@ -34,7 +34,7 @@ cp('./assets/bpmn-js.css', dest + '/assets');
 console.log('building pre-packaged distributions');
 
 try {
-  exec('rollup', [ '-c' ], {
+  exec('rollup', [ '-c', '--bundleConfigAsCjs' ], {
     stdio: 'inherit'
   });
 } catch (e) {


### PR DESCRIPTION
Allows us to get rid of some rollup@3 magic.
