### PR TITLE
fix: correct `BaseViewer#saveXML` definition

### DIFF
--- a/lib/BaseViewer.d.ts
+++ b/lib/BaseViewer.d.ts
@@ -272,7 +272,7 @@ export default class BaseViewer extends Diagram {
    *
    * @return A promise resolving with the XML.
    */
-  saveXML(options: SaveXMLOptions): Promise<SaveXMLResult>;
+  saveXML(options?: SaveXMLOptions): Promise<SaveXMLResult>;
 
   /**
    * Export the currently displayed BPMN 2.0 diagram as

--- a/lib/BaseViewer.spec.ts
+++ b/lib/BaseViewer.spec.ts
@@ -81,6 +81,10 @@ export function testViewer(viewer: BaseViewer) {
       console.log(error);
     });
 
+  viewer.saveXML();
+
+  viewer.saveSVG();
+
   viewer.getModules();
 
   viewer.clear();


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/pull/1881