### PR TITLE
Allow event rendering without icons

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -444,8 +444,8 @@ export default function BpmnRenderer(
   }
 
   function as(type) {
-    return function(parentGfx, element) {
-      return renderer(type)(parentGfx, element);
+    return function(parentGfx, element, options) {
+      return renderer(type)(parentGfx, element, options);
     };
   }
 
@@ -584,7 +584,7 @@ export default function BpmnRenderer(
 
       return drawCircle(parentGfx, element.width, element.height, attrs);
     },
-    'bpmn:StartEvent': function(parentGfx, element) {
+    'bpmn:StartEvent': function(parentGfx, element, options) {
       var attrs = {
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor)
@@ -602,7 +602,9 @@ export default function BpmnRenderer(
 
       var circle = renderer('bpmn:Event')(parentGfx, element, attrs);
 
-      renderEventContent(element, parentGfx);
+      if (!options || options.renderIcon !== false) {
+        renderEventContent(element, parentGfx);
+      }
 
       return circle;
     },
@@ -855,14 +857,16 @@ export default function BpmnRenderer(
         stroke: getStrokeColor(event, defaultStrokeColor)
       });
     },
-    'bpmn:EndEvent': function(parentGfx, element) {
+    'bpmn:EndEvent': function(parentGfx, element, options) {
       var circle = renderer('bpmn:Event')(parentGfx, element, {
         strokeWidth: 4,
         fill: getFillColor(element, defaultFillColor),
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
 
-      renderEventContent(element, parentGfx, true);
+      if (!options || options.renderIcon !== false) {
+        renderEventContent(element, parentGfx, true);
+      }
 
       return circle;
     },
@@ -875,7 +879,7 @@ export default function BpmnRenderer(
 
       return circle;
     },
-    'bpmn:IntermediateEvent': function(parentGfx, element) {
+    'bpmn:IntermediateEvent': function(parentGfx, element, options) {
       var outer = renderer('bpmn:Event')(parentGfx, element, {
         strokeWidth: 1.5,
         fill: getFillColor(element, defaultFillColor),
@@ -889,7 +893,9 @@ export default function BpmnRenderer(
         stroke: getStrokeColor(element, defaultStrokeColor)
       });
 
-      renderEventContent(element, parentGfx);
+      if (!options || options.renderIcon !== false) {
+        renderEventContent(element, parentGfx);
+      }
 
       return outer;
     },
@@ -1607,7 +1613,7 @@ export default function BpmnRenderer(
 
       return elementStore;
     },
-    'bpmn:BoundaryEvent': function(parentGfx, element) {
+    'bpmn:BoundaryEvent': function(parentGfx, element, options) {
 
       var semantic = getSemantic(element),
           cancel = semantic.cancelActivity;
@@ -1638,7 +1644,9 @@ export default function BpmnRenderer(
 
       /* inner path */ drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, innerAttrs);
 
-      renderEventContent(element, parentGfx);
+      if (!options || options.renderIcon !== false) {
+        renderEventContent(element, parentGfx);
+      }
 
       return outer;
     },

--- a/test/spec/draw/BpmnRenderer.no-event-icons.bpmn
+++ b/test/spec/draw/BpmnRenderer.no-event-icons.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="12.0.0">
+  <process id="Process_1" isExecutable="false">
+    <sequenceFlow id="Flow_1nt6baa" sourceRef="START_EVENT" targetRef="CATCH_EVENT" />
+    <task id="ACTVITIY">
+      <incoming>Flow_1qympxx</incoming>
+      <outgoing>Flow_1635gbq</outgoing>
+    </task>
+    <sequenceFlow id="Flow_1qympxx" sourceRef="CATCH_EVENT" targetRef="ACTVITIY" />
+    <sequenceFlow id="Flow_1635gbq" sourceRef="ACTVITIY" targetRef="END_EVENT" />
+    <intermediateCatchEvent id="CATCH_EVENT" name="CATCH_EVENT" >
+      <incoming>Flow_1nt6baa</incoming>
+      <outgoing>Flow_1qympxx</outgoing>
+      <messageEventDefinition id="MessageEventDefinition_155nigy" />
+    </intermediateCatchEvent>
+    <startEvent id="START_EVENT" name="START_EVENT">
+      <outgoing>Flow_1nt6baa</outgoing>
+      <timerEventDefinition id="TimerEventDefinition_1ot9ndh" />
+    </startEvent>
+    <boundaryEvent id="BOUNDARY_EVENT" name="BOUNDARY_EVENT" attachedToRef="ACTVITIY">
+      <errorEventDefinition id="ErrorEventDefinition_1t8kpuj" />
+    </boundaryEvent>
+    <endEvent id="END_EVENT" name="END_EVENT">
+      <incoming>Flow_1635gbq</incoming>
+      <errorEventDefinition id="ErrorEventDefinition_15xc39q" />
+    </endEvent>
+    <intermediateThrowEvent id="THROW_EVENT" name="THROW">
+      <messageEventDefinition id="MessageEventDefinition_155nagy" />
+    </intermediateThrowEvent>
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="ACTVITIY_di" bpmnElement="ACTVITIY">
+        <omgdc:Bounds x="340" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ssuqaa_di" bpmnElement="CATCH_EVENT">
+        <omgdc:Bounds x="242" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0g813my_di" bpmnElement="START_EVENT">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="134" y="145" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05fteh0_di" bpmnElement="END_EVENT">
+        <omgdc:Bounds x="502" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pb3v1z_di" bpmnElement="BOUNDARY_EVENT">
+        <omgdc:Bounds x="382" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+
+      <bpmndi:BPMNShape id="THROW_EVENT_di" bpmnElement="THROW_EVENT">
+        <omgdc:Bounds x="682" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1nt6baa_di" bpmnElement="Flow_1nt6baa">
+        <omgdi:waypoint x="188" y="120" />
+        <omgdi:waypoint x="242" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qympxx_di" bpmnElement="Flow_1qympxx">
+        <omgdi:waypoint x="278" y="120" />
+        <omgdi:waypoint x="340" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1635gbq_di" bpmnElement="Flow_1635gbq">
+        <omgdi:waypoint x="440" y="120" />
+        <omgdi:waypoint x="502" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -22,6 +22,9 @@ import {
   getDi
 } from 'lib/draw/BpmnRenderUtil';
 
+import customRendererModule from './custom-renderer';
+
+
 /**
  * @typedef {import('../../../lib/model/Types').Element} Element
  */
@@ -652,6 +655,43 @@ describe('draw - bpmn renderer', function() {
 
       // very unsafe to use internal state
       expect(bpmnRenderer.handlers).to.exist;
+    }));
+
+  });
+
+});
+
+
+
+describe('draw - bpmn renderer - integration', function() {
+
+  describe('custom icons', function() {
+
+    var xml = require('./BpmnRenderer.no-event-icons.bpmn');
+
+    beforeEach(bootstrapViewer(xml, {
+      additionalModules: [ customRendererModule ]
+    }));
+
+
+    it('should render blank', inject(function(elementRegistry) {
+
+      // given
+      var events = [
+        'START_EVENT',
+        'THROW_EVENT',
+        'CATCH_EVENT',
+        'END_EVENT',
+        'BOUNDARY_EVENT'
+      ];
+
+      for (var elementId of events) {
+
+        var gfx = elementRegistry.getGraphics(elementId);
+        var iconGfx = domQuery('path', gfx);
+
+        expect(iconGfx, `icon on element <#${ elementId }>`).not.to.exist;
+      }
     }));
 
   });

--- a/test/spec/draw/custom-renderer/CustomRenderer.js
+++ b/test/spec/draw/custom-renderer/CustomRenderer.js
@@ -1,0 +1,58 @@
+import inherits from 'inherits-browser';
+
+import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
+
+import {
+  is,
+  isAny
+} from 'lib/util/ModelUtil';
+
+import {
+  isLabel
+} from 'lib/util/LabelUtil';
+
+
+var HIGH_PRIORITY = 1250;
+
+
+export default function CustomRenderer(
+    bpmnRenderer,
+    eventBus) {
+
+  this._bpmnRenderer = bpmnRenderer;
+
+  BaseRenderer.call(this, eventBus, HIGH_PRIORITY);
+}
+
+inherits(CustomRenderer, BaseRenderer);
+
+CustomRenderer.prototype.canRender = function(element) {
+
+  if (isLabel(element)) {
+    return false;
+  }
+
+  return !!(
+    isAny(element, [ 'bpmn:Event' ])
+  );
+};
+
+CustomRenderer.prototype.drawShape = function(parentGfx, element) {
+
+  var renderer = this._bpmnRenderer.handlers[
+    [
+      'bpmn:StartEvent',
+      'bpmn:IntermediateCatchEvent',
+      'bpmn:IntermediateThrowEvent',
+      'bpmn:BoundaryEvent',
+      'bpmn:EndEvent'
+    ].find(t => is(element, t))
+  ];
+
+  return renderer(parentGfx, element, { renderIcon: false });
+};
+
+CustomRenderer.$inject = [
+  'bpmnRenderer',
+  'eventBus'
+];

--- a/test/spec/draw/custom-renderer/index.js
+++ b/test/spec/draw/custom-renderer/index.js
@@ -1,0 +1,6 @@
+import CustomRenderer from './CustomRenderer';
+
+export default {
+  __init__: [ 'customRenderer' ],
+  customRenderer: [ 'type', CustomRenderer ]
+};


### PR DESCRIPTION
This adds a new option to the `BpmnRenderer` to render events without icons. The use-case is customizing (cf. https://github.com/bpmn-io/element-template-icon-renderer/issues/6).

For detailed usage, checkout https://github.com/bpmn-io/bpmn-js/pull/1917/files#diff-c8205dfe6f35f2b861d97b83d680753e34aea03b27bbeee25bc42d8579604807R52.