### PR TITLE
ci: extract translations update to separate workflow

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -12,6 +12,8 @@ jobs:
         node-version: [ 16 ]
 
     runs-on: ${{ matrix.os }}
+    outputs:
+      STABLE_RELEASE: ${{ steps.is_stable.outputs.STABLE_RELEASE }}
 
     steps:
     - name: Checkout
@@ -28,9 +30,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: Check for stable release
+      id: is_stable
       run: |
         if [[ ${{ env.TAG }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-        then echo "STABLE_RELEASE=true" >> $GITHUB_ENV
+        then echo "STABLE_RELEASE=true" >> $GITHUB_OUTPUT
+        else echo "STABLE_RELEASE=false" >> $GITHUB_OUTPUT
         fi
     - name: Update integration test
       env:
@@ -39,7 +43,7 @@ jobs:
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: tasks/stages/update-integration-test
     - name: Update demo
-      if: ${{ env.STABLE_RELEASE == 'true' }}
+      if: ${{ steps.is_stable.outputs.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
@@ -47,24 +51,21 @@ jobs:
         BPMN_IO_DEMO_ENDPOINT: ${{ secrets.BPMN_IO_DEMO_ENDPOINT }}
       run: tasks/stages/update-demo
     - name: Update examples
-      if: ${{ env.STABLE_RELEASE == 'true' }}
+      if: ${{ steps.is_stable.outputs.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: tasks/stages/update-examples
     - name: Update website
-      if: ${{ env.STABLE_RELEASE == 'true' }}
+      if: ${{ steps.is_stable.outputs.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: tasks/stages/update-website
-    - name: Update translations
-      if: ${{ env.STABLE_RELEASE == 'true' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
-        BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
-        BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-        REVIEWERS: 'bpmn-io/modeling-dev'
-      run: tasks/stages/update-translations
+  update-translations:
+    needs: post-release
+    secrets: inherit
+    if: ${{ needs.post-release.outputs.STABLE_RELEASE == 'true' }}
+    uses: ./.github/workflows/UPDATE_TRANSLATIONS.yml

--- a/.github/workflows/UPDATE_TRANSLATIONS.yml
+++ b/.github/workflows/UPDATE_TRANSLATIONS.yml
@@ -1,0 +1,30 @@
+name: POST_RELEASE
+on:
+- workflow_call
+- workflow_dispatch
+
+jobs:
+  post-release:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        node-version: [ 16 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Update translations
+      env:
+        GITHUB_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
+        BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
+        BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
+        REVIEWERS: 'bpmn-io/modeling-dev'
+      run: tasks/stages/update-translations

--- a/tasks/stages/update-translations
+++ b/tasks/stages/update-translations
@@ -9,7 +9,7 @@ npm ci
 npm run collect-translations
 
 # exit if no changes
-if [[ "x$(git status --porcelain)" = "x" ]]; then echo "No changes; exiting" && exit 0; fi
+if [[ "x$(git status --porcelain docs/translations.json)" = "x" ]]; then echo "No changes; exiting" && exit 0; fi
 
 if [[ "x$SKIP_COMMIT" = "x" ]]; then
 


### PR DESCRIPTION
This allows to trigger translations update at convenience.

Related to https://github.com/bpmn-io/bpmn-js/actions/runs/5177347753/jobs/9327333594
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
