### PR TITLE
Adds opportunity to fully translate "Append TextAnnotation" phrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ## Unreleased
 
-___Note:__ Yet to be released changes appear here._
+* `FEAT`: opportunity to fully translate "Append TextAnnotation" phrase ([bpmn-js-i18n #22]https://github.com/bpmn-io/bpmn-js-i18n/issues/22)
 
 ## 13.2.2
 

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -452,7 +452,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     assign(actions, {
       'append.text-annotation': appendAction(
         'bpmn:TextAnnotation',
-        'bpmn-icon-text-annotation'
+        'bpmn-icon-text-annotation',
+        translate('Append TextAnnotation')
       )
     });
   }
@@ -468,7 +469,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     assign(actions, {
       'append.text-annotation': appendAction(
         'bpmn:TextAnnotation',
-        'bpmn-icon-text-annotation'
+        'bpmn-icon-text-annotation',
+        translate('Append TextAnnotation')
       ),
 
       'connect': {
@@ -519,7 +521,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   if (is(businessObject, 'bpmn:Group')) {
     assign(actions, {
-      'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation')
+      'append.text-annotation': appendAction('bpmn:TextAnnotation', 'bpmn-icon-text-annotation', translate('Append TextAnnotation'))
     });
   }
 


### PR DESCRIPTION
## Description

This PR resolves a problem with translating "Append TextAnnotation" phrase. 

## Related issues:

* https://github.com/bpmn-io/bpmn-js-i18n/issues/22

## Related PRs:

* https://github.com/bpmn-io/bpmn-js-i18n/pull/25

_N.B. You can check this realization after https://github.com/bpmn-io/bpmn-js-i18n/pull/25 will be merged_