### PR TITLE
chore: drop deprecated `context` member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: translate _Append TextAnnotation_ context pad action ([#1932](https://github.com/bpmn-io/bpmn-js/pull/1932))
-* `CHORE`: drop callback support from public API
+* `CHORE`: drop deprecated callback support from public API
+* `CHORE`: drop deprecated `import.parse.complete` event member `context`
 
 ### Breaking Changes
 
-* Callback style API removed. Migrate to promise-based APIs, released with `v7.0.0`.
+* Deprecated callback style API removed. Migrate to promise-based APIs, released with `v7.0.0`.
+* Deprecated `import.parse.complete` event member `context` removed. Access the same information via the event itself, as released with `v7.0.0`.
 
 ## 13.2.2
 

--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -188,28 +188,7 @@ BaseViewer.prototype.importXML = async function importXML(xml, bpmnDiagram) {
   const self = this;
 
   function ParseCompleteEvent(data) {
-
-    const event = self.get('eventBus').createEvent(data);
-
-    // TODO(nikku): remove with future bpmn-js version
-    Object.defineProperty(event, 'context', {
-      enumerable: true,
-      get: function() {
-
-        console.warn(new Error(
-          'import.parse.complete <context> is deprecated ' +
-          'and will be removed in future library versions'
-        ));
-
-        return {
-          warnings: data.warnings,
-          references: data.references,
-          elementsById: data.elementsById
-        };
-      }
-    });
-
-    return event;
+    return self.get('eventBus').createEvent(data);
   }
 
   let aggregatedWarnings = [];

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -722,7 +722,7 @@ describe('Viewer', function() {
         // then
         expect(events).to.eql([
           [ 'import.parse.start', [ 'xml' ] ],
-          [ 'import.parse.complete', [ 'error', 'definitions', 'elementsById', 'references', 'warnings', 'context' ] ],
+          [ 'import.parse.complete', [ 'error', 'definitions', 'elementsById', 'references', 'warnings' ] ],
           [ 'import.render.start', [ 'definitions' ] ],
           [ 'import.render.complete', [ 'error', 'warnings' ] ],
           [ 'import.done', [ 'error', 'warnings' ] ]


### PR DESCRIPTION
As a follow-up to https://github.com/bpmn-io/bpmn-js/pull/1939 this removes the long deprecated `import.parse.complete` member `context`.

### BREAKING CHANGES

* `import.parse.complete` member `context` removed. Use the actual event to retrieve error, warning, and references information.

----

Deprecated since `v7.0.0` (released 3 years ago).