### PR TITLE
fix: allow to create connection + event-based gateway

### DIFF
--- a/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
+++ b/lib/features/modeling/behavior/EventBasedGatewayBehavior.js
@@ -43,12 +43,18 @@ export default function EventBasedGatewayBehavior(eventBus, modeling) {
     var sequenceFlows = [];
 
     if (is(source, 'bpmn:EventBasedGateway')) {
-      sequenceFlows = target.incoming.filter(isSequenceFlow);
+      sequenceFlows = target.incoming
+        .filter(flow =>
+          flow !== connection &&
+          isSequenceFlow(flow)
+        );
     } else {
-      sequenceFlows = target.incoming.filter(function(connection) {
-        return isSequenceFlow(connection)
-          && is(connection.source, 'bpmn:EventBasedGateway');
-      });
+      sequenceFlows = target.incoming
+        .filter(flow =>
+          flow !== connection &&
+          isSequenceFlow(flow) &&
+          is(flow.source, 'bpmn:EventBasedGateway')
+        );
     }
 
     sequenceFlows.forEach(function(sequenceFlow) {


### PR DESCRIPTION
The change ensures that if a connection is scaffolded as part of `create` then it is not removed right during placement.

Closes https://github.com/bpmn-io/bpmn-js/issues/1490