### PR TITLE
ci: fix POST_RELEASE job

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -1,7 +1,17 @@
 name: POST_RELEASE
 on:
-  - workflow_call
-  - workflow_dispatch
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'The released tag'
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: 'The released tag'
+        required: true
 
 jobs:
   post-release:
@@ -14,15 +24,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       STABLE_RELEASE: ${{ steps.is_stable.outputs.STABLE_RELEASE }}
+    env:
+      TAG: ${{ inputs.tag }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set TAG
-      run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
     - name: Wait for published
       env:
-        PKG: 'bpmn-js@${{ env.TAG }}'
+        PKG: 'bpmn-js@${{ inputs.tag }}'
       run: tasks/stages/await-published
     - name: Use Node.js
       uses: actions/setup-node@v3
@@ -32,7 +42,7 @@ jobs:
     - name: Check for stable release
       id: is_stable
       run: |
-        if [[ ${{ env.TAG }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+        if [[ ${{ inputs.tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
         then echo "STABLE_RELEASE=true" >> $GITHUB_OUTPUT
         else echo "STABLE_RELEASE=false" >> $GITHUB_OUTPUT
         fi
@@ -64,8 +74,11 @@ jobs:
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
       run: tasks/stages/update-website
+
   update-translations:
     needs: post-release
     secrets: inherit
     if: ${{ needs.post-release.outputs.STABLE_RELEASE == 'true' }}
     uses: ./.github/workflows/UPDATE_TRANSLATIONS.yml
+    with:
+      tag: ${{ inputs.tag }}

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -51,3 +51,5 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     secrets: inherit
     uses: ./.github/workflows/POST_RELEASE.yml
+    with:
+      tag: ${{ needs.release-please.outputs.release_created.tag_name }}

--- a/.github/workflows/UPDATE_TRANSLATIONS.yml
+++ b/.github/workflows/UPDATE_TRANSLATIONS.yml
@@ -1,7 +1,17 @@
 name: UPDATE_TRANSLATIONS
 on:
-- workflow_call
-- workflow_dispatch
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'The released tag'
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: 'The released tag'
+        required: true
 
 jobs:
   update-translations:
@@ -27,4 +37,5 @@ jobs:
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
         REVIEWERS: 'bpmn-io/modeling-dev'
+        TAG: ${{ inputs.tag }}
       run: tasks/stages/update-translations


### PR DESCRIPTION
Closes #1979

We are using release-please action outputs in this solution: https://github.com/google-github-actions/release-please-action#outputs
