### PR TITLE
Preview Append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: preview append on hover ([#1985](https://github.com/bpmn-io/bpmn-js/pull/1985))
+* `FEAT`: allow overriding `fill`, `stroke`, `width` and `height` when rendering elements ([#1985](https://github.com/bpmn-io/bpmn-js/pull/1985))
+* `FIX`: renderer only renders actual flow elements ([#1985](https://github.com/bpmn-io/bpmn-js/pull/1985))
+
+### Breaking Changes
+
+* `BpmnRenderer` only renders actual flow elements (e.g. `bpmn:IntermediateCatchEvent` but not `bpmn:MessageEventDefinition`)
+
 ## 14.2.0
 
 * `FEAT`: make spacetool local per default ([bpmn-io/diagram-js#811](https://github.com/bpmn-io/diagram-js/pull/811), [#1975](https://github.com/bpmn-io/bpmn-js/issues/1975))

--- a/lib/draw/BpmnRenderUtil.js
+++ b/lib/draw/BpmnRenderUtil.js
@@ -1,4 +1,5 @@
 import {
+  has,
   some
 } from 'min-dash';
 
@@ -16,6 +17,9 @@ import {
  * @typedef {import('../model').Element} Element
  *
  * @typedef {import('../model').ShapeLike} ShapeLike
+ *
+ * @typedef {import('diagram-js/lib/util/Types').Dimensions} Dimensions
+ * @typedef {import('diagram-js/lib/util/Types').Rect} Rect
  */
 
 // re-export for compatibility
@@ -26,6 +30,7 @@ export {
 
 
 export var black = 'hsl(225, 10%, 15%)';
+export var white = 'white';
 
 // element utils //////////////////////
 
@@ -73,39 +78,42 @@ export function isCollection(element) {
 /**
  * @param {Element} element
  * @param {string} [defaultColor]
+ * @param {string} [overrideColor]
  *
  * @return {string}
  */
-export function getFillColor(element, defaultColor) {
+export function getFillColor(element, defaultColor, overrideColor) {
   var di = getDi(element);
 
-  return di.get('color:background-color') || di.get('bioc:fill') || defaultColor || 'white';
+  return overrideColor || di.get('color:background-color') || di.get('bioc:fill') || defaultColor || white;
 }
 
 /**
  * @param {Element} element
  * @param {string} [defaultColor]
+ * @param {string} [overrideColor]
  *
  * @return {string}
  */
-export function getStrokeColor(element, defaultColor) {
+export function getStrokeColor(element, defaultColor, overrideColor) {
   var di = getDi(element);
 
-  return di.get('color:border-color') || di.get('bioc:stroke') || defaultColor || black;
+  return overrideColor || di.get('color:border-color') || di.get('bioc:stroke') || defaultColor || black;
 }
 
 /**
  * @param {Element} element
  * @param {string} [defaultColor]
  * @param {string} [defaultStrokeColor]
+ * @param {string} [overrideColor]
  *
  * @return {string}
  */
-export function getLabelColor(element, defaultColor, defaultStrokeColor) {
+export function getLabelColor(element, defaultColor, defaultStrokeColor, overrideColor) {
   var di = getDi(element),
       label = di.get('label');
 
-  return label && label.get('color:color') || defaultColor ||
+  return overrideColor || (label && label.get('color:color')) || defaultColor ||
     getStrokeColor(element, defaultStrokeColor);
 }
 
@@ -207,4 +215,43 @@ export function getRectPath(shape) {
   ];
 
   return componentsToPath(rectPath);
+}
+
+/**
+ * Get width and height from element or overrides.
+ *
+ * @param {Dimensions|Rect|Shape} bounds
+ * @param {Object} overrides
+ *
+ * @returns {Dimensions}
+ */
+export function getBounds(bounds, overrides = {}) {
+  return {
+    width: getWidth(bounds, overrides),
+    height: getHeight(bounds, overrides)
+  };
+}
+
+/**
+ * Get width from element or overrides.
+ *
+ * @param {Dimensions|Rect|Shape} bounds
+ * @param {Object} overrides
+ *
+ * @returns {number}
+ */
+export function getWidth(bounds, overrides = {}) {
+  return has(overrides, 'width') ? overrides.width : bounds.width;
+}
+
+/**
+ * Get height from element or overrides.
+ *
+ * @param {Dimensions|Rect|Shape} bounds
+ * @param {Object} overrides
+ *
+ * @returns {number}
+ */
+export function getHeight(bounds, overrides = {}) {
+  return has(overrides, 'height') ? overrides.height : bounds.height;
 }

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1,9 +1,9 @@
 import inherits from 'inherits-browser';
 
 import {
-  isObject,
   assign,
-  forEach
+  forEach,
+  isObject
 } from 'min-dash';
 
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
@@ -17,7 +17,9 @@ import {
   getLabel
 } from '../util/LabelUtil';
 
-import { is } from '../util/ModelUtil';
+import {
+  is
+} from '../util/ModelUtil';
 
 import {
   createLine
@@ -27,6 +29,7 @@ import {
   isTypedEvent,
   isThrowEvent,
   isCollection,
+  getBounds,
   getDi,
   getSemantic,
   getCirclePath,
@@ -35,7 +38,9 @@ import {
   getRectPath,
   getFillColor,
   getStrokeColor,
-  getLabelColor
+  getLabelColor,
+  getHeight,
+  getWidth
 } from './BpmnRenderUtil';
 
 import {
@@ -59,15 +64,16 @@ import Ids from 'ids';
 
 import { black } from './BpmnRenderUtil';
 
-var RENDERER_IDS = new Ids();
+var rendererIds = new Ids();
 
-var TASK_BORDER_RADIUS = 10;
-var INNER_OUTER_DIST = 3;
+var ELEMENT_LABEL_DISTANCE = 10,
+    INNER_OUTER_DIST = 3,
+    PARTICIPANT_STROKE_WIDTH = 1.5,
+    TASK_BORDER_RADIUS = 10;
 
-var DEFAULT_FILL_OPACITY = .95,
-    HIGH_FILL_OPACITY = .35;
-
-var ELEMENT_LABEL_DISTANCE = 10;
+var DEFAULT_OPACITY = 0.95,
+    FULL_OPACITY = 1,
+    LOW_OPACITY = 0.25;
 
 /**
  * @typedef { Partial<{
@@ -75,6 +81,13 @@ var ELEMENT_LABEL_DISTANCE = 10;
  *   defaultStrokeColor: string,
  *   defaultLabelColor: string
  * }> } BpmnRendererConfig
+ *
+ * @typedef { Partial<{
+ *   fill: string,
+ *   stroke: string,
+ *   width: string,
+ *   height: string
+ * }> } Attrs
  */
 
 /**
@@ -102,7 +115,7 @@ export default function BpmnRenderer(
       defaultStrokeColor = config && config.defaultStrokeColor,
       defaultLabelColor = config && config.defaultLabelColor;
 
-  var rendererId = RENDERER_IDS.next();
+  var rendererId = rendererIds.next();
 
   var markers = {};
 
@@ -198,7 +211,7 @@ export default function BpmnRenderer(
         cy: 6,
         r: 3.5,
         ...shapeStyle({
-          fill: fill,
+          fill,
           stroke: stroke,
           strokeWidth: 1,
 
@@ -218,7 +231,7 @@ export default function BpmnRenderer(
       var messageflowEnd = svgCreate('path', {
         d: 'm 1 5 l 0 -3 l 7 3 l -7 3 z',
         ...shapeStyle({
-          fill: fill,
+          fill,
           stroke: stroke,
           strokeWidth: 1,
 
@@ -239,7 +252,7 @@ export default function BpmnRenderer(
         d: 'M 11 5 L 1 10 L 11 15',
         ...lineStyle({
           fill: 'none',
-          stroke: stroke,
+          stroke,
           strokeWidth: 1.5,
 
           // fix for safari / chrome / firefox bug not correctly
@@ -260,7 +273,7 @@ export default function BpmnRenderer(
         d: 'M 1 5 L 11 10 L 1 15',
         ...lineStyle({
           fill: 'none',
-          stroke: stroke,
+          stroke,
           strokeWidth: 1.5,
 
           // fix for safari / chrome / firefox bug not correctly
@@ -280,7 +293,7 @@ export default function BpmnRenderer(
       var conditionalFlowMarker = svgCreate('path', {
         d: 'M 0 10 L 8 6 L 16 10 L 8 14 Z',
         ...shapeStyle({
-          fill: fill,
+          fill,
           stroke: stroke
         })
       });
@@ -308,7 +321,7 @@ export default function BpmnRenderer(
     }
   }
 
-  function drawCircle(parentGfx, width, height, offset, attrs) {
+  function drawCircle(parentGfx, width, height, offset, attrs = {}) {
 
     if (isObject(offset)) {
       attrs = offset;
@@ -318,10 +331,6 @@ export default function BpmnRenderer(
     offset = offset || 0;
 
     attrs = shapeStyle(attrs);
-
-    if (attrs.fill === 'none') {
-      delete attrs.fillOpacity;
-    }
 
     var cx = width / 2,
         cy = height / 2;
@@ -422,7 +431,6 @@ export default function BpmnRenderer(
   }
 
   function drawPath(parentGfx, d, attrs) {
-
     attrs = lineStyle(attrs);
 
     var path = svgCreate('path', {
@@ -444,171 +452,13 @@ export default function BpmnRenderer(
   }
 
   function as(type) {
-    return function(parentGfx, element, options) {
-      return renderer(type)(parentGfx, element, options);
+    return function(parentGfx, element, attrs) {
+      return renderer(type)(parentGfx, element, attrs);
     };
   }
 
-  function renderEventContent(element, parentGfx) {
-
-    var event = getSemantic(element);
-    var isThrowing = isThrowEvent(event);
-
-    if (event.eventDefinitions && event.eventDefinitions.length > 1) {
-      if (event.parallelMultiple) {
-        return renderer('bpmn:ParallelMultipleEventDefinition')(parentGfx, element, isThrowing);
-      }
-      else {
-        return renderer('bpmn:MultipleEventDefinition')(parentGfx, element, isThrowing);
-      }
-    }
-
-    if (isTypedEvent(event, 'bpmn:MessageEventDefinition')) {
-      return renderer('bpmn:MessageEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:TimerEventDefinition')) {
-      return renderer('bpmn:TimerEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:ConditionalEventDefinition')) {
-      return renderer('bpmn:ConditionalEventDefinition')(parentGfx, element);
-    }
-
-    if (isTypedEvent(event, 'bpmn:SignalEventDefinition')) {
-      return renderer('bpmn:SignalEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:EscalationEventDefinition')) {
-      return renderer('bpmn:EscalationEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:LinkEventDefinition')) {
-      return renderer('bpmn:LinkEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:ErrorEventDefinition')) {
-      return renderer('bpmn:ErrorEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:CancelEventDefinition')) {
-      return renderer('bpmn:CancelEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:CompensateEventDefinition')) {
-      return renderer('bpmn:CompensateEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    if (isTypedEvent(event, 'bpmn:TerminateEventDefinition')) {
-      return renderer('bpmn:TerminateEventDefinition')(parentGfx, element, isThrowing);
-    }
-
-    return null;
-  }
-
-  function renderLabel(parentGfx, label, options) {
-
-    options = assign({
-      size: {
-        width: 100
-      }
-    }, options);
-
-    var text = textRenderer.createText(label || '', options);
-
-    svgClasses(text).add('djs-label');
-
-    svgAppend(parentGfx, text);
-
-    return text;
-  }
-
-  function renderEmbeddedLabel(parentGfx, element, align) {
-    var semantic = getSemantic(element);
-
-    return renderLabel(parentGfx, semantic.name, {
-      box: element,
-      align: align,
-      padding: 7,
-      style: {
-        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
-      }
-    });
-  }
-
-  function renderExternalLabel(parentGfx, element) {
-
-    var box = {
-      width: 90,
-      height: 30,
-      x: element.width / 2 + element.x,
-      y: element.height / 2 + element.y
-    };
-
-    return renderLabel(parentGfx, getLabel(element), {
-      box: box,
-      fitBox: true,
-      style: assign(
-        {},
-        textRenderer.getExternalStyle(),
-        {
-          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
-        }
-      )
-    });
-  }
-
-  function renderLaneLabel(parentGfx, text, element) {
-    var textBox = renderLabel(parentGfx, text, {
-      box: {
-        height: 30,
-        width: element.height
-      },
-      align: 'center-middle',
-      style: {
-        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
-      }
-    });
-
-    var top = -1 * element.height;
-
-    transform(textBox, 0, -top, 270);
-  }
-
-  var handlers = this.handlers = {
-    'bpmn:Event': function(parentGfx, element, attrs) {
-
-      if (!('fillOpacity' in attrs)) {
-        attrs.fillOpacity = DEFAULT_FILL_OPACITY;
-      }
-
-      return drawCircle(parentGfx, element.width, element.height, attrs);
-    },
-    'bpmn:StartEvent': function(parentGfx, element, options) {
-      var attrs = {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      };
-
-      var semantic = getSemantic(element);
-
-      if (!semantic.isInterrupting) {
-        attrs = {
-          strokeDasharray: '6',
-          fill: getFillColor(element, defaultFillColor),
-          stroke: getStrokeColor(element, defaultStrokeColor)
-        };
-      }
-
-      var circle = renderer('bpmn:Event')(parentGfx, element, attrs);
-
-      if (!options || options.renderIcon !== false) {
-        renderEventContent(element, parentGfx);
-      }
-
-      return circle;
-    },
-    'bpmn:MessageEventDefinition': function(parentGfx, element, isThrowing) {
+  var eventIconRenderers = {
+    'bpmn:MessageEventDefinition': function(parentGfx, element, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_MESSAGE', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
@@ -620,22 +470,27 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(element, defaultStrokeColor) : getFillColor(element, defaultFillColor);
-      var stroke = isThrowing ? getFillColor(element, defaultFillColor) : getStrokeColor(element, defaultStrokeColor);
+      var fill = isThrowing
+        ? getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+        : getFillColor(element, defaultFillColor, attrs.fill);
+
+      var stroke = isThrowing
+        ? getFillColor(element, defaultFillColor, attrs.fill)
+        : getStrokeColor(element, defaultStrokeColor, attrs.stroke);
 
       var messagePath = drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: stroke
+        fill,
+        stroke,
+        strokeWidth: 1
       });
 
       return messagePath;
     },
-    'bpmn:TimerEventDefinition': function(parentGfx, element) {
+    'bpmn:TimerEventDefinition': function(parentGfx, element, attrs = {}) {
       var circle = drawCircle(parentGfx, element.width, element.height, 0.2 * element.height, {
-        strokeWidth: 2,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 2
       });
 
       var pathData = pathMap.getScaledPath('EVENT_TIMER_WH', {
@@ -650,12 +505,11 @@ export default function BpmnRenderer(
       });
 
       drawPath(parentGfx, pathData, {
-        strokeWidth: 2,
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 2
       });
 
-      for (var i = 0;i < 12; i++) {
-
+      for (var i = 0; i < 12; i++) {
         var linePathData = pathMap.getScaledPath('EVENT_TIMER_LINE', {
           xScaleFactor: 0.75,
           yScaleFactor: 0.75,
@@ -667,19 +521,19 @@ export default function BpmnRenderer(
           }
         });
 
-        var width = element.width / 2;
-        var height = element.height / 2;
+        var width = element.width / 2,
+            height = element.height / 2;
 
         drawPath(parentGfx, linePathData, {
           strokeWidth: 1,
-          transform: 'rotate(' + (i * 30) + ',' + height + ',' + width + ')',
-          stroke: getStrokeColor(element, defaultStrokeColor)
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          transform: 'rotate(' + (i * 30) + ',' + height + ',' + width + ')'
         });
       }
 
       return circle;
     },
-    'bpmn:EscalationEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:EscalationEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_ESCALATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -691,15 +545,17 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:ConditionalEventDefinition': function(parentGfx, event) {
+    'bpmn:ConditionalEventDefinition': function(parentGfx, event, attrs = {}) {
       var pathData = pathMap.getScaledPath('EVENT_CONDITIONAL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -712,11 +568,12 @@ export default function BpmnRenderer(
       });
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill: getFillColor(event, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:LinkEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:LinkEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_LINK', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -728,15 +585,17 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:ErrorEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:ErrorEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_ERROR', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
@@ -748,15 +607,17 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:CancelEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:CancelEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_CANCEL_45', {
         xScaleFactor: 1.0,
         yScaleFactor: 1.0,
@@ -768,19 +629,19 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor, attrs.stroke) : 'none';
 
       var path = drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
 
       rotate(path, 45);
 
       return path;
     },
-    'bpmn:CompensateEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:CompensateEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_COMPENSATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
@@ -792,15 +653,17 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:SignalEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:SignalEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_SIGNAL', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
@@ -812,15 +675,17 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
         strokeWidth: 1,
-        fill: fill,
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke)
       });
     },
-    'bpmn:MultipleEventDefinition': function(parentGfx, event, isThrowing) {
+    'bpmn:MultipleEventDefinition': function(parentGfx, event, attrs = {}, isThrowing) {
       var pathData = pathMap.getScaledPath('EVENT_MULTIPLE', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
@@ -832,14 +697,16 @@ export default function BpmnRenderer(
         }
       });
 
-      var fill = isThrowing ? getStrokeColor(event, defaultStrokeColor) : 'none';
+      var fill = isThrowing
+        ? getStrokeColor(event, defaultStrokeColor, attrs.stroke)
+        : getFillColor(event, defaultFillColor, attrs.fill);
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: fill
+        fill,
+        strokeWidth: 1
       });
     },
-    'bpmn:ParallelMultipleEventDefinition': function(parentGfx, event) {
+    'bpmn:ParallelMultipleEventDefinition': function(parentGfx, event, attrs = {}) {
       var pathData = pathMap.getScaledPath('EVENT_PARALLEL_MULTIPLE', {
         xScaleFactor: 1.2,
         yScaleFactor: 1.2,
@@ -852,876 +719,107 @@ export default function BpmnRenderer(
       });
 
       return drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getStrokeColor(event, defaultStrokeColor),
-        stroke: getStrokeColor(event, defaultStrokeColor)
+        fill: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
       });
     },
-    'bpmn:EndEvent': function(parentGfx, element, options) {
-      var circle = renderer('bpmn:Event')(parentGfx, element, {
-        strokeWidth: 4,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      if (!options || options.renderIcon !== false) {
-        renderEventContent(element, parentGfx, true);
-      }
-
-      return circle;
-    },
-    'bpmn:TerminateEventDefinition': function(parentGfx, element) {
+    'bpmn:TerminateEventDefinition': function(parentGfx, element, attrs = {}) {
       var circle = drawCircle(parentGfx, element.width, element.height, 8, {
-        strokeWidth: 4,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 4
       });
 
       return circle;
-    },
-    'bpmn:IntermediateEvent': function(parentGfx, element, options) {
-      var outer = renderer('bpmn:Event')(parentGfx, element, {
-        strokeWidth: 1.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
+    }
+  };
 
-      /* inner */
-      drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, {
-        strokeWidth: 1.5,
-        fill: getFillColor(element, 'none'),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
+  function renderEventIcon(element, parentGfx, attrs = {}) {
+    var semantic = getSemantic(element),
+        isThrowing = isThrowEvent(semantic);
 
-      if (!options || options.renderIcon !== false) {
-        renderEventContent(element, parentGfx);
+    if (semantic.get('eventDefinitions') && semantic.get('eventDefinitions').length > 1) {
+      if (semantic.get('parallelMultiple')) {
+        return eventIconRenderers[ 'bpmn:ParallelMultipleEventDefinition' ](parentGfx, element, attrs, isThrowing);
       }
-
-      return outer;
-    },
-    'bpmn:IntermediateCatchEvent': as('bpmn:IntermediateEvent'),
-    'bpmn:IntermediateThrowEvent': as('bpmn:IntermediateEvent'),
-
-    'bpmn:Activity': function(parentGfx, element, attrs) {
-
-      attrs = attrs || {};
-
-      if (!('fillOpacity' in attrs)) {
-        attrs.fillOpacity = DEFAULT_FILL_OPACITY;
+      else {
+        return eventIconRenderers[ 'bpmn:MultipleEventDefinition' ](parentGfx, element, attrs, isThrowing);
       }
+    }
 
-      return drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, attrs);
-    },
+    if (isTypedEvent(semantic, 'bpmn:MessageEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:MessageEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-    'bpmn:Task': function(parentGfx, element) {
-      var attrs = {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      };
+    if (isTypedEvent(semantic, 'bpmn:TimerEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:TimerEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      var rect = renderer('bpmn:Activity')(parentGfx, element, attrs);
+    if (isTypedEvent(semantic, 'bpmn:ConditionalEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:ConditionalEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      renderEmbeddedLabel(parentGfx, element, 'center-middle');
-      attachTaskMarkers(parentGfx, element);
+    if (isTypedEvent(semantic, 'bpmn:SignalEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:SignalEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      return rect;
-    },
-    'bpmn:ServiceTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
+    if (isTypedEvent(semantic, 'bpmn:EscalationEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:EscalationEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      var pathDataBG = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
-        abspos: {
-          x: 12,
-          y: 18
-        }
-      });
+    if (isTypedEvent(semantic, 'bpmn:LinkEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:LinkEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      /* service bg */ drawPath(parentGfx, pathDataBG, {
-        strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
+    if (isTypedEvent(semantic, 'bpmn:ErrorEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:ErrorEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      var fillPathData = pathMap.getScaledPath('TASK_TYPE_SERVICE_FILL', {
-        abspos: {
-          x: 17.2,
-          y: 18
-        }
-      });
+    if (isTypedEvent(semantic, 'bpmn:CancelEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:CancelEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      /* service fill */ drawPath(parentGfx, fillPathData, {
-        strokeWidth: 0,
-        fill: getFillColor(element, defaultFillColor)
-      });
+    if (isTypedEvent(semantic, 'bpmn:CompensateEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:CompensateEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      var pathData = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
-        abspos: {
-          x: 17,
-          y: 22
-        }
-      });
+    if (isTypedEvent(semantic, 'bpmn:TerminateEventDefinition')) {
+      return eventIconRenderers[ 'bpmn:TerminateEventDefinition' ](parentGfx, element, attrs, isThrowing);
+    }
 
-      /* service */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
+    return null;
+  }
 
-      return task;
-    },
-    'bpmn:UserTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
+  var taskMarkerRenderers = {
+    'ParticipantMultiplicityMarker': function(parentGfx, element, attrs = {}) {
+      var width = getWidth(element, attrs),
+          height = getHeight(element, attrs);
 
-      var x = 15;
-      var y = 12;
-
-      var pathData = pathMap.getScaledPath('TASK_TYPE_USER_1', {
-        abspos: {
-          x: x,
-          y: y
-        }
-      });
-
-      /* user path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 0.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var pathData2 = pathMap.getScaledPath('TASK_TYPE_USER_2', {
-        abspos: {
-          x: x,
-          y: y
-        }
-      });
-
-      /* user2 path */ drawPath(parentGfx, pathData2, {
-        strokeWidth: 0.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var pathData3 = pathMap.getScaledPath('TASK_TYPE_USER_3', {
-        abspos: {
-          x: x,
-          y: y
-        }
-      });
-
-      /* user3 path */ drawPath(parentGfx, pathData3, {
-        strokeWidth: 0.5,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return task;
-    },
-    'bpmn:ManualTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('TASK_TYPE_MANUAL', {
-        abspos: {
-          x: 17,
-          y: 15
-        }
-      });
-
-      /* manual path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 0.5, // 0.25,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return task;
-    },
-    'bpmn:SendTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('TASK_TYPE_SEND', {
-        xScaleFactor: 1,
-        yScaleFactor: 1,
-        containerWidth: 21,
-        containerHeight: 14,
-        position: {
-          mx: 0.285,
-          my: 0.357
-        }
-      });
-
-      /* send path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getFillColor(element, defaultFillColor)
-      });
-
-      return task;
-    },
-    'bpmn:ReceiveTask' : function(parentGfx, element) {
-      var semantic = getSemantic(element);
-
-      var task = renderer('bpmn:Task')(parentGfx, element);
-      var pathData;
-
-      if (semantic.instantiate) {
-        drawCircle(parentGfx, 28, 28, 20 * 0.22, { strokeWidth: 1 });
-
-        pathData = pathMap.getScaledPath('TASK_TYPE_INSTANTIATING_SEND', {
-          abspos: {
-            x: 7.77,
-            y: 9.52
-          }
-        });
-      } else {
-
-        pathData = pathMap.getScaledPath('TASK_TYPE_SEND', {
-          xScaleFactor: 0.9,
-          yScaleFactor: 0.9,
-          containerWidth: 21,
-          containerHeight: 14,
-          position: {
-            mx: 0.3,
-            my: 0.4
-          }
-        });
-      }
-
-      /* receive path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return task;
-    },
-    'bpmn:ScriptTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('TASK_TYPE_SCRIPT', {
-        abspos: {
-          x: 15,
-          y: 20
-        }
-      });
-
-      /* script path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return task;
-    },
-    'bpmn:BusinessRuleTask': function(parentGfx, element) {
-      var task = renderer('bpmn:Task')(parentGfx, element);
-
-      var headerPathData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_HEADER', {
-        abspos: {
-          x: 8,
-          y: 8
-        }
-      });
-
-      var businessHeaderPath = drawPath(parentGfx, headerPathData);
-      svgAttr(businessHeaderPath, {
-        strokeWidth: 1,
-        fill: getFillColor(element, '#aaaaaa'),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var headerData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_MAIN', {
-        abspos: {
-          x: 8,
-          y: 8
-        }
-      });
-
-      var businessPath = drawPath(parentGfx, headerData);
-      svgAttr(businessPath, {
-        strokeWidth: 1,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return task;
-    },
-    'bpmn:SubProcess': function(parentGfx, element, attrs) {
-      attrs = {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        ...attrs
-      };
-
-      var rect = renderer('bpmn:Activity')(parentGfx, element, attrs);
-
-      var expanded = isExpanded(element);
-
-      if (isEventSubProcess(element)) {
-        svgAttr(rect, {
-          strokeDasharray: '0, 5.5',
-          strokeWidth: 2.5
-        });
-      }
-
-      renderEmbeddedLabel(parentGfx, element, expanded ? 'center-top' : 'center-middle');
-
-      if (expanded) {
-        attachTaskMarkers(parentGfx, element);
-      } else {
-        attachTaskMarkers(parentGfx, element, [ 'SubProcessMarker' ]);
-      }
-
-      return rect;
-    },
-    'bpmn:AdHocSubProcess': function(parentGfx, element) {
-      return renderer('bpmn:SubProcess')(parentGfx, element);
-    },
-    'bpmn:Transaction': function(parentGfx, element) {
-      var outer = renderer('bpmn:SubProcess')(parentGfx, element, { strokeWidth: 1.5 });
-
-      var innerAttrs = styles.style([ 'no-fill', 'no-events' ], {
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeWidth: 1.5
-      });
-
-      /* inner path */ drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS - 3, INNER_OUTER_DIST, innerAttrs);
-
-      return outer;
-    },
-    'bpmn:CallActivity': function(parentGfx, element) {
-      return renderer('bpmn:SubProcess')(parentGfx, element, {
-        strokeWidth: 5
-      });
-    },
-    'bpmn:Participant': function(parentGfx, element) {
-
-      var strokeWidth = 1.5;
-
-      var attrs = {
-        fillOpacity: DEFAULT_FILL_OPACITY,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeWidth
-      };
-
-      var lane = renderer('bpmn:Lane')(parentGfx, element, attrs);
-
-      var expandedPool = isExpanded(element);
-
-      if (expandedPool) {
-        drawLine(parentGfx, [
-          { x: 30, y: 0 },
-          { x: 30, y: element.height }
-        ], {
-          stroke: getStrokeColor(element, defaultStrokeColor),
-          strokeWidth
-        });
-        var text = getSemantic(element).name;
-        renderLaneLabel(parentGfx, text, element);
-      } else {
-
-        // collapsed pool draw text inline
-        var text2 = getSemantic(element).name;
-        renderLabel(parentGfx, text2, {
-          box: element, align: 'center-middle',
-          style: {
-            fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
-          }
-        });
-      }
-
-      var participantMultiplicity = !!(getSemantic(element).participantMultiplicity);
-
-      if (participantMultiplicity) {
-        renderer('ParticipantMultiplicityMarker')(parentGfx, element);
-      }
-
-      return lane;
-    },
-    'bpmn:Lane': function(parentGfx, element, attrs) {
-      var rect = drawRect(parentGfx, element.width, element.height, 0, {
-        fill: getFillColor(element, defaultFillColor),
-        fillOpacity: HIGH_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeWidth: 1.5,
-        ...attrs
-      });
-
-      var semantic = getSemantic(element);
-
-      if (semantic.$type === 'bpmn:Lane') {
-        var text = semantic.name;
-        renderLaneLabel(parentGfx, text, element);
-      }
-
-      return rect;
-    },
-    'bpmn:InclusiveGateway': function(parentGfx, element) {
-      var diamond = renderer('bpmn:Gateway')(parentGfx, element);
-
-      /* circle path */
-      drawCircle(parentGfx, element.width, element.height, element.height * 0.24, {
-        strokeWidth: 2.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return diamond;
-    },
-    'bpmn:ExclusiveGateway': function(parentGfx, element) {
-      var diamond = renderer('bpmn:Gateway')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('GATEWAY_EXCLUSIVE', {
-        xScaleFactor: 0.4,
-        yScaleFactor: 0.4,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0.32,
-          my: 0.3
-        }
-      });
-
-      if ((getDi(element).isMarkerVisible)) {
-        drawPath(parentGfx, pathData, {
-          strokeWidth: 1,
-          fill: getStrokeColor(element, defaultStrokeColor),
-          stroke: getStrokeColor(element, defaultStrokeColor)
-        });
-      }
-
-      return diamond;
-    },
-    'bpmn:ComplexGateway': function(parentGfx, element) {
-      var diamond = renderer('bpmn:Gateway')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('GATEWAY_COMPLEX', {
-        xScaleFactor: 0.5,
-        yScaleFactor:0.5,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0.46,
-          my: 0.26
-        }
-      });
-
-      /* complex path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return diamond;
-    },
-    'bpmn:ParallelGateway': function(parentGfx, element) {
-      var diamond = renderer('bpmn:Gateway')(parentGfx, element);
-
-      var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
-        xScaleFactor: 0.6,
-        yScaleFactor:0.6,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0.46,
-          my: 0.2
-        }
-      });
-
-      /* parallel path */ drawPath(parentGfx, pathData, {
-        strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return diamond;
-    },
-    'bpmn:EventBasedGateway': function(parentGfx, element) {
-
-      var semantic = getSemantic(element);
-
-      var diamond = renderer('bpmn:Gateway')(parentGfx, element);
-
-      /* outer circle path */ drawCircle(parentGfx, element.width, element.height, element.height * 0.20, {
-        strokeWidth: 1,
-        fill: 'none',
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var type = semantic.eventGatewayType;
-      var instantiate = !!semantic.instantiate;
-
-      function drawEvent() {
-
-        var pathData = pathMap.getScaledPath('GATEWAY_EVENT_BASED', {
-          xScaleFactor: 0.18,
-          yScaleFactor: 0.18,
-          containerWidth: element.width,
-          containerHeight: element.height,
-          position: {
-            mx: 0.36,
-            my: 0.44
-          }
-        });
-
-        /* event path */ drawPath(parentGfx, pathData, {
-          strokeWidth: 2,
-          fill: getFillColor(element, 'none'),
-          stroke: getStrokeColor(element, defaultStrokeColor)
-        });
-      }
-
-      if (type === 'Parallel') {
-
-        var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
-          xScaleFactor: 0.4,
-          yScaleFactor:0.4,
-          containerWidth: element.width,
-          containerHeight: element.height,
-          position: {
-            mx: 0.474,
-            my: 0.296
-          }
-        });
-
-        drawPath(parentGfx, pathData, {
-          strokeWidth: 1,
-          fill: 'none'
-        });
-      } else if (type === 'Exclusive') {
-
-        if (!instantiate) {
-          drawCircle(parentGfx, element.width, element.height, element.height * 0.26, {
-            strokeWidth: 1,
-            fill: 'none',
-            stroke: getStrokeColor(element, defaultStrokeColor)
-          });
-        }
-
-        drawEvent();
-      }
-
-
-      return diamond;
-    },
-    'bpmn:Gateway': function(parentGfx, element) {
-      return drawDiamond(parentGfx, element.width, element.height, {
-        fill: getFillColor(element, defaultFillColor),
-        fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-    },
-    'bpmn:SequenceFlow': function(parentGfx, element) {
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
-
-      var path = drawConnectionSegments(parentGfx, element.waypoints, {
-        markerEnd: marker('sequenceflow-end', fill, stroke),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var sequenceFlow = getSemantic(element);
-
-      var source;
-
-      if (element.source) {
-        source = element.source.businessObject;
-
-        // conditional flow marker
-        if (sequenceFlow.conditionExpression && source.$instanceOf('bpmn:Activity')) {
-          svgAttr(path, {
-            markerStart: marker('conditional-flow-marker', fill, stroke)
-          });
-        }
-
-        // default marker
-        if (source.default && (source.$instanceOf('bpmn:Gateway') || source.$instanceOf('bpmn:Activity')) &&
-            source.default === sequenceFlow) {
-          svgAttr(path, {
-            markerStart: marker('conditional-default-flow-marker', fill, stroke)
-          });
-        }
-      }
-
-      return path;
-    },
-    'bpmn:Association': function(parentGfx, element, attrs) {
-
-      var semantic = getSemantic(element);
-
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
-
-      attrs = {
-        strokeDasharray: '0, 5',
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        ...attrs
-      };
-
-      if (semantic.associationDirection === 'One' ||
-          semantic.associationDirection === 'Both') {
-        attrs.markerEnd = marker('association-end', fill, stroke);
-      }
-
-      if (semantic.associationDirection === 'Both') {
-        attrs.markerStart = marker('association-start', fill, stroke);
-      }
-
-      return drawConnectionSegments(parentGfx, element.waypoints, attrs);
-    },
-    'bpmn:DataInputAssociation': function(parentGfx, element) {
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
-
-      return renderer('bpmn:Association')(parentGfx, element, {
-        markerEnd: marker('association-end', fill, stroke)
-      });
-    },
-    'bpmn:DataOutputAssociation': function(parentGfx, element) {
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
-
-      return renderer('bpmn:Association')(parentGfx, element, {
-        markerEnd: marker('association-end', fill, stroke)
-      });
-    },
-    'bpmn:MessageFlow': function(parentGfx, element) {
-
-      var semantic = getSemantic(element),
-          di = getDi(element);
-
-      var fill = getFillColor(element, defaultFillColor),
-          stroke = getStrokeColor(element, defaultStrokeColor);
-
-      var path = drawConnectionSegments(parentGfx, element.waypoints, {
-        markerEnd: marker('messageflow-end', fill, stroke),
-        markerStart: marker('messageflow-start', fill, stroke),
-        strokeDasharray: '10, 11',
-        strokeWidth: 1.5,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      if (semantic.messageRef) {
-        var midPoint = path.getPointAtLength(path.getTotalLength() / 2);
-
-        var markerPathData = pathMap.getScaledPath('MESSAGE_FLOW_MARKER', {
-          abspos: {
-            x: midPoint.x,
-            y: midPoint.y
-          }
-        });
-
-        var messageAttrs = { strokeWidth: 1 };
-
-        if (di.messageVisibleKind === 'initiating') {
-          messageAttrs.fill = 'white';
-          messageAttrs.stroke = black;
-        } else {
-          messageAttrs.fill = '#888';
-          messageAttrs.stroke = 'white';
-        }
-
-        var message = drawPath(parentGfx, markerPathData, messageAttrs);
-
-        var labelText = semantic.messageRef.name;
-        var label = renderLabel(parentGfx, labelText, {
-          align: 'center-top',
-          fitBox: true,
-          style: {
-            fill: getStrokeColor(element, defaultLabelColor, defaultStrokeColor)
-          }
-        });
-
-        var messageBounds = message.getBBox(),
-            labelBounds = label.getBBox();
-
-        var translateX = midPoint.x - labelBounds.width / 2,
-            translateY = midPoint.y + messageBounds.height / 2 + ELEMENT_LABEL_DISTANCE;
-
-        transform(label, translateX, translateY, 0);
-
-      }
-
-      return path;
-    },
-    'bpmn:DataObject': function(parentGfx, element) {
-      var pathData = pathMap.getScaledPath('DATA_OBJECT_PATH', {
-        xScaleFactor: 1,
-        yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0.474,
-          my: 0.296
-        }
-      });
-
-      var elementObject = drawPath(parentGfx, pathData, {
-        fill: getFillColor(element, defaultFillColor),
-        fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var semantic = getSemantic(element);
-
-      if (isCollection(semantic)) {
-        renderDataItemCollection(parentGfx, element);
-      }
-
-      return elementObject;
-    },
-    'bpmn:DataObjectReference': as('bpmn:DataObject'),
-    'bpmn:DataInput': function(parentGfx, element) {
-
-      var arrowPathData = pathMap.getRawPath('DATA_ARROW');
-
-      // page
-      var elementObject = renderer('bpmn:DataObject')(parentGfx, element);
-
-      /* input arrow path */ drawPath(parentGfx, arrowPathData, { strokeWidth: 1 });
-
-      return elementObject;
-    },
-    'bpmn:DataOutput': function(parentGfx, element) {
-      var arrowPathData = pathMap.getRawPath('DATA_ARROW');
-
-      // page
-      var elementObject = renderer('bpmn:DataObject')(parentGfx, element);
-
-      /* output arrow path */ drawPath(parentGfx, arrowPathData, {
-        strokeWidth: 1,
-        fill: black
-      });
-
-      return elementObject;
-    },
-    'bpmn:DataStoreReference': function(parentGfx, element) {
-      var DATA_STORE_PATH = pathMap.getScaledPath('DATA_STORE', {
-        xScaleFactor: 1,
-        yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0,
-          my: 0.133
-        }
-      });
-
-      var elementStore = drawPath(parentGfx, DATA_STORE_PATH, {
-        strokeWidth: 2,
-        fill: getFillColor(element, defaultFillColor),
-        fillOpacity: DEFAULT_FILL_OPACITY,
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      return elementStore;
-    },
-    'bpmn:BoundaryEvent': function(parentGfx, element, options) {
-
-      var semantic = getSemantic(element),
-          cancel = semantic.cancelActivity;
-
-      var attrs = {
-        strokeWidth: 1.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      };
-
-      if (!cancel) {
-        attrs.strokeDasharray = '6';
-      }
-
-      // apply fillOpacity
-      var outerAttrs = {
-        ...attrs,
-        fillOpacity: 1
-      };
-
-      // apply no-fill
-      var innerAttrs = {
-        ...attrs,
-        fill: 'none'
-      };
-
-      var outer = renderer('bpmn:Event')(parentGfx, element, outerAttrs);
-
-      /* inner path */ drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, innerAttrs);
-
-      if (!options || options.renderIcon !== false) {
-        renderEventContent(element, parentGfx);
-      }
-
-      return outer;
-    },
-    'bpmn:Group': function(parentGfx, element) {
-      return drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
-        stroke: getStrokeColor(element, defaultStrokeColor),
-        strokeWidth: 1.5,
-        strokeDasharray: '10,6,0,6',
-        fill: 'none',
-        pointerEvents: 'none'
-      });
-    },
-    'label': function(parentGfx, element) {
-      return renderExternalLabel(parentGfx, element);
-    },
-    'bpmn:TextAnnotation': function(parentGfx, element) {
-      var textElement = drawRect(parentGfx, element.width, element.height, 0, 0, {
-        'fill': 'none',
-        'stroke': 'none'
-      });
-
-      var textPathData = pathMap.getScaledPath('TEXT_ANNOTATION', {
-        xScaleFactor: 1,
-        yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
-        position: {
-          mx: 0.0,
-          my: 0.0
-        }
-      });
-
-      drawPath(parentGfx, textPathData, {
-        stroke: getStrokeColor(element, defaultStrokeColor)
-      });
-
-      var text = getSemantic(element).text || '';
-      renderLabel(parentGfx, text, {
-        box: element,
-        align: 'left-top',
-        padding: 7,
-        style: {
-          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor)
-        }
-      });
-
-      return textElement;
-    },
-    'ParticipantMultiplicityMarker': function(parentGfx, element) {
       var markerPath = pathMap.getScaledPath('MARKER_PARALLEL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: width,
+        containerHeight: height,
         position: {
-          mx: ((element.width / 2) / element.width),
-          my: (element.height - 15) / element.height
+          mx: ((width / 2 - 6) / width),
+          my: (height - 15) / height
         }
       });
 
       drawMarker('participant-multiplicity', parentGfx, markerPath, {
         strokeWidth: 2,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     },
-    'SubProcessMarker': function(parentGfx, element) {
+    'SubProcessMarker': function(parentGfx, element, attrs = {}) {
       var markerRect = drawRect(parentGfx, 14, 14, 0, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
 
-      // Process marker is placed in the middle of the box
-      // therefore fixed values can be used here
       translate(markerRect, element.width / 2 - 7.5, element.height - 20);
 
       var markerPath = pathMap.getScaledPath('MARKER_SUB_PROCESS', {
@@ -1736,109 +834,129 @@ export default function BpmnRenderer(
       });
 
       drawMarker('sub-process', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     },
-    'ParallelMarker': function(parentGfx, element, position) {
+    'ParallelMarker': function(parentGfx, element, attrs) {
+      var width = getWidth(element, attrs),
+          height = getHeight(element, attrs);
+
       var markerPath = pathMap.getScaledPath('MARKER_PARALLEL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: width,
+        containerHeight: height,
         position: {
-          mx: ((element.width / 2 + position.parallel) / element.width),
-          my: (element.height - 20) / element.height
+          mx: ((width / 2 + attrs.parallel) / width),
+          my: (height - 20) / height
         }
       });
 
       drawMarker('parallel', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     },
-    'SequentialMarker': function(parentGfx, element, position) {
+    'SequentialMarker': function(parentGfx, element, attrs) {
       var markerPath = pathMap.getScaledPath('MARKER_SEQUENTIAL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
         containerWidth: element.width,
         containerHeight: element.height,
         position: {
-          mx: ((element.width / 2 + position.seq) / element.width),
+          mx: ((element.width / 2 + attrs.seq) / element.width),
           my: (element.height - 19) / element.height
         }
       });
 
       drawMarker('sequential', parentGfx, markerPath, {
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     },
-    'CompensationMarker': function(parentGfx, element, position) {
+    'CompensationMarker': function(parentGfx, element, attrs) {
       var markerMath = pathMap.getScaledPath('MARKER_COMPENSATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
         containerWidth: element.width,
         containerHeight: element.height,
         position: {
-          mx: ((element.width / 2 + position.compensation) / element.width),
+          mx: ((element.width / 2 + attrs.compensation) / element.width),
           my: (element.height - 13) / element.height
         }
       });
 
       drawMarker('compensation', parentGfx, markerMath, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     },
-    'LoopMarker': function(parentGfx, element, position) {
+    'LoopMarker': function(parentGfx, element, attrs) {
+      var width = getWidth(element, attrs),
+          height = getHeight(element, attrs);
+
       var markerPath = pathMap.getScaledPath('MARKER_LOOP', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: width,
+        containerHeight: height,
         position: {
-          mx: ((element.width / 2 + position.loop) / element.width),
-          my: (element.height - 7) / element.height
+          mx: ((width / 2 + attrs.loop) / width),
+          my: (height - 7) / height
         }
       });
 
       drawMarker('loop', parentGfx, markerPath, {
         strokeWidth: 1.5,
-        fill: getFillColor(element, defaultFillColor),
-        stroke: getStrokeColor(element, defaultStrokeColor),
+        fill: 'none',
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
         strokeMiterlimit: 0.5
       });
     },
-    'AdhocMarker': function(parentGfx, element, position) {
+    'AdhocMarker': function(parentGfx, element, attrs) {
+      var width = getWidth(element, attrs),
+          height = getHeight(element, attrs);
+
       var markerPath = pathMap.getScaledPath('MARKER_ADHOC', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: width,
+        containerHeight: height,
         position: {
-          mx: ((element.width / 2 + position.adhoc) / element.width),
-          my: (element.height - 15) / element.height
+          mx: ((width / 2 + attrs.adhoc) / width),
+          my: (height - 15) / height
         }
       });
 
       drawMarker('adhoc', parentGfx, markerPath, {
         strokeWidth: 1,
-        fill: getStrokeColor(element, defaultStrokeColor),
-        stroke: getStrokeColor(element, defaultStrokeColor)
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
     }
   };
 
-  function attachTaskMarkers(parentGfx, element, taskMarkers) {
-    var obj = getSemantic(element);
+  function renderTaskMarker(type, parentGfx, element, attrs) {
+    taskMarkerRenderers[ type ](parentGfx, element, attrs);
+  }
 
-    var subprocess = taskMarkers && taskMarkers.indexOf('SubProcessMarker') !== -1;
-    var position;
+  function renderTaskMarkers(parentGfx, element, taskMarkers, attrs = {}) {
+    attrs = {
+      fill: attrs.fill,
+      stroke: attrs.stroke,
+      width: getWidth(element, attrs),
+      height: getHeight(element, attrs)
+    };
+
+    var semantic = getSemantic(element);
+
+    var subprocess = taskMarkers && taskMarkers.includes('SubProcessMarker');
 
     if (subprocess) {
-      position = {
+      attrs = {
+        ...attrs,
         seq: -21,
         parallel: -22,
         compensation: -42,
@@ -1846,8 +964,9 @@ export default function BpmnRenderer(
         adhoc: 10
       };
     } else {
-      position = {
-        seq: -3,
+      attrs = {
+        ...attrs,
+        seq: -5,
         parallel: -6,
         compensation: -27,
         loop: 0,
@@ -1856,56 +975,1239 @@ export default function BpmnRenderer(
     }
 
     forEach(taskMarkers, function(marker) {
-      renderer(marker)(parentGfx, element, position);
+      renderTaskMarker(marker, parentGfx, element, attrs);
     });
 
-    if (obj.isForCompensation) {
-      renderer('CompensationMarker')(parentGfx, element, position);
+    if (semantic.get('isForCompensation')) {
+      renderTaskMarker('CompensationMarker', parentGfx, element, attrs);
     }
 
-    if (obj.$type === 'bpmn:AdHocSubProcess') {
-      renderer('AdhocMarker')(parentGfx, element, position);
+    if (is(semantic, 'bpmn:AdHocSubProcess')) {
+      renderTaskMarker('AdhocMarker', parentGfx, element, attrs);
     }
 
-    var loopCharacteristics = obj.loopCharacteristics,
-        isSequential = loopCharacteristics && loopCharacteristics.isSequential;
+    var loopCharacteristics = semantic.get('loopCharacteristics'),
+        isSequential = loopCharacteristics && loopCharacteristics.get('isSequential');
 
     if (loopCharacteristics) {
 
       if (isSequential === undefined) {
-        renderer('LoopMarker')(parentGfx, element, position);
+        renderTaskMarker('LoopMarker', parentGfx, element, attrs);
       }
 
       if (isSequential === false) {
-        renderer('ParallelMarker')(parentGfx, element, position);
+        renderTaskMarker('ParallelMarker', parentGfx, element, attrs);
       }
 
       if (isSequential === true) {
-        renderer('SequentialMarker')(parentGfx, element, position);
+        renderTaskMarker('SequentialMarker', parentGfx, element, attrs);
       }
     }
   }
 
-  function renderDataItemCollection(parentGfx, element) {
+  function renderLabel(parentGfx, label, attrs = {}) {
+    attrs = assign({
+      size: {
+        width: 100
+      }
+    }, attrs);
 
-    var yPosition = (element.height - 18) / element.height;
+    var text = textRenderer.createText(label || '', attrs);
 
-    var pathData = pathMap.getScaledPath('DATA_OBJECT_COLLECTION_PATH', {
+    svgClasses(text).add('djs-label');
+
+    svgAppend(parentGfx, text);
+
+    return text;
+  }
+
+  function renderEmbeddedLabel(parentGfx, element, align, attrs = {}) {
+    var semantic = getSemantic(element);
+
+    var box = getBounds({
+      x: element.x,
+      y: element.y,
+      width: element.width,
+      height: element.height
+    }, attrs);
+
+    return renderLabel(parentGfx, semantic.name, {
+      align,
+      box,
+      padding: 7,
+      style: {
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+      }
+    });
+  }
+
+  function renderExternalLabel(parentGfx, element, attrs = {}) {
+    var box = {
+      width: 90,
+      height: 30,
+      x: element.width / 2 + element.x,
+      y: element.height / 2 + element.y
+    };
+
+    return renderLabel(parentGfx, getLabel(element), {
+      box: box,
+      fitBox: true,
+      style: assign(
+        {},
+        textRenderer.getExternalStyle(),
+        {
+          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+        }
+      )
+    });
+  }
+
+  function renderLaneLabel(parentGfx, text, element, attrs = {}) {
+    var textBox = renderLabel(parentGfx, text, {
+      box: {
+        height: 30,
+        width: getHeight(element, attrs),
+      },
+      align: 'center-middle',
+      style: {
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+      }
+    });
+
+    var top = -1 * getHeight(element, attrs);
+
+    transform(textBox, 0, -top, 270);
+  }
+
+  function renderActivity(parentGfx, element, attrs = {}) {
+    var {
+      width,
+      height
+    } = getBounds(element, attrs);
+
+    return drawRect(parentGfx, width, height, TASK_BORDER_RADIUS, {
+      ...attrs,
+      fill: getFillColor(element, defaultFillColor, attrs.fill),
+      fillOpacity: DEFAULT_OPACITY,
+      stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+    });
+  }
+
+  function renderAssociation(parentGfx, element, attrs = {}) {
+    var semantic = getSemantic(element);
+
+    var fill = getFillColor(element, defaultFillColor, attrs.fill),
+        stroke = getStrokeColor(element, defaultStrokeColor, attrs.stroke);
+
+    if (semantic.get('associationDirection') === 'One' ||
+        semantic.get('associationDirection') === 'Both') {
+      attrs.markerEnd = marker('association-end', fill, stroke);
+    }
+
+    if (semantic.get('associationDirection') === 'Both') {
+      attrs.markerStart = marker('association-start', fill, stroke);
+    }
+
+    attrs = pickAttrs(attrs, [
+      'markerStart',
+      'markerEnd'
+    ]);
+
+    return drawConnectionSegments(parentGfx, element.waypoints, {
+      ...attrs,
+      stroke,
+      strokeDasharray: '0, 5'
+    });
+  }
+
+  function renderDataObject(parentGfx, element, attrs = {}) {
+    var fill = getFillColor(element, defaultFillColor, attrs.fill),
+        stroke = getStrokeColor(element, defaultStrokeColor, attrs.stroke);
+
+    var pathData = pathMap.getScaledPath('DATA_OBJECT_PATH', {
       xScaleFactor: 1,
       yScaleFactor: 1,
       containerWidth: element.width,
       containerHeight: element.height,
       position: {
-        mx: 0.33,
-        my: yPosition
+        mx: 0.474,
+        my: 0.296
       }
     });
 
-    /* collection path */ drawPath(parentGfx, pathData, {
-      strokeWidth: 2
+    var dataObject = drawPath(parentGfx, pathData, {
+      fill,
+      fillOpacity: DEFAULT_OPACITY,
+      stroke
+    });
+
+    var semantic = getSemantic(element);
+
+    if (isCollection(semantic)) {
+      var collectionPathData = pathMap.getScaledPath('DATA_OBJECT_COLLECTION_PATH', {
+        xScaleFactor: 1,
+        yScaleFactor: 1,
+        containerWidth: element.width,
+        containerHeight: element.height,
+        position: {
+          mx: 0.33,
+          my: (element.height - 18) / element.height
+        }
+      });
+
+      drawPath(parentGfx, collectionPathData, {
+        strokeWidth: 2,
+        fill,
+        stroke
+      });
+    }
+
+    return dataObject;
+  }
+
+  function renderEvent(parentGfx, element, attrs = {}) {
+    return drawCircle(parentGfx, element.width, element.height, {
+      fillOpacity: DEFAULT_OPACITY,
+      ...attrs,
+      fill: getFillColor(element, defaultFillColor, attrs.fill),
+      stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
     });
   }
 
+  function renderGateway(parentGfx, element, attrs = {}) {
+    return drawDiamond(parentGfx, element.width, element.height, {
+      fill: getFillColor(element, defaultFillColor, attrs.fill),
+      fillOpacity: DEFAULT_OPACITY,
+      stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+    });
+  }
+
+  function renderLane(parentGfx, element, attrs = {}) {
+    var lane = drawRect(parentGfx, getWidth(element, attrs), getHeight(element, attrs), 0, {
+      fill: getFillColor(element, defaultFillColor, attrs.fill),
+      fillOpacity: attrs.fillOpacity || DEFAULT_OPACITY,
+      stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+      strokeWidth: 1.5
+    });
+
+    var semantic = getSemantic(element);
+
+    if (is(semantic, 'bpmn:Lane')) {
+      var text = semantic.get('name');
+
+      renderLaneLabel(parentGfx, text, element, attrs);
+    }
+
+    return lane;
+  }
+
+  function renderSubProcess(parentGfx, element, attrs = {}) {
+    var activity = renderActivity(parentGfx, element, attrs);
+
+    if (isEventSubProcess(element)) {
+      svgAttr(activity, {
+        strokeDasharray: '0, 5.5',
+        strokeWidth: 2.5
+      });
+    }
+
+    var expanded = isExpanded(element);
+
+    renderEmbeddedLabel(parentGfx, element, expanded ? 'center-top' : 'center-middle', attrs);
+
+    if (expanded) {
+      renderTaskMarkers(parentGfx, element, undefined, attrs);
+    } else {
+      renderTaskMarkers(parentGfx, element, [ 'SubProcessMarker' ], attrs);
+    }
+
+    return activity;
+  }
+
+  function renderTask(parentGfx, element, attrs = {}) {
+    var activity = renderActivity(parentGfx, element, attrs);
+
+    renderEmbeddedLabel(parentGfx, element, 'center-middle', attrs);
+
+    renderTaskMarkers(parentGfx, element, undefined, attrs);
+
+    return activity;
+  }
+
+  var handlers = this.handlers = {
+    'bpmn:AdHocSubProcess': function(parentGfx, element, attrs = {}) {
+      if (isExpanded(element)) {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke',
+          'width',
+          'height'
+        ]);
+      } else {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke'
+        ]);
+      }
+
+      return renderSubProcess(parentGfx, element, attrs);
+    },
+    'bpmn:Association': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderAssociation(parentGfx, element, attrs);
+    },
+    'bpmn:BoundaryEvent': function(parentGfx, element, attrs = {}) {
+      var { renderIcon = true } = attrs;
+
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var semantic = getSemantic(element),
+          cancelActivity = semantic.get('cancelActivity');
+
+      attrs = {
+        strokeWidth: 1.5,
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        fillOpacity: FULL_OPACITY,
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+      };
+
+      if (!cancelActivity) {
+        attrs.strokeDasharray = '6';
+      }
+
+      var event = renderEvent(parentGfx, element, attrs);
+
+      drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, {
+        ...attrs,
+        fill: 'none'
+      });
+
+      if (renderIcon) {
+        renderEventIcon(element, parentGfx, attrs);
+      }
+
+      return event;
+    },
+    'bpmn:BusinessRuleTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var headerData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_MAIN', {
+        abspos: {
+          x: 8,
+          y: 8
+        }
+      });
+
+      var businessPath = drawPath(parentGfx, headerData);
+
+      svgAttr(businessPath, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      var headerPathData = pathMap.getScaledPath('TASK_TYPE_BUSINESS_RULE_HEADER', {
+        abspos: {
+          x: 8,
+          y: 8
+        }
+      });
+
+      var businessHeaderPath = drawPath(parentGfx, headerPathData);
+
+      svgAttr(businessHeaderPath, {
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return task;
+    },
+    'bpmn:CallActivity': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderSubProcess(parentGfx, element, {
+        strokeWidth: 5,
+        ...attrs
+      });
+    },
+    'bpmn:ComplexGateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var gateway = renderGateway(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('GATEWAY_COMPLEX', {
+        xScaleFactor: 0.5,
+        yScaleFactor:0.5,
+        containerWidth: element.width,
+        containerHeight: element.height,
+        position: {
+          mx: 0.46,
+          my: 0.26
+        }
+      });
+
+      drawPath(parentGfx, pathData, {
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return gateway;
+    },
+    'bpmn:DataInput': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var arrowPathData = pathMap.getRawPath('DATA_ARROW');
+
+      var dataObject = renderDataObject(parentGfx, element, attrs);
+
+      drawPath(parentGfx, arrowPathData, {
+        fill: 'none',
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return dataObject;
+    },
+    'bpmn:DataInputAssociation': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderAssociation(parentGfx, element, {
+        ...attrs,
+        markerEnd: marker('association-end', getFillColor(element, defaultFillColor, attrs.fill), getStrokeColor(element, defaultStrokeColor, attrs.stroke))
+      });
+    },
+    'bpmn:DataObject': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderDataObject(parentGfx, element, attrs);
+    },
+    'bpmn:DataObjectReference': as('bpmn:DataObject'),
+    'bpmn:DataOutput': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var arrowPathData = pathMap.getRawPath('DATA_ARROW');
+
+      var dataObject = renderDataObject(parentGfx, element, attrs);
+
+      drawPath(parentGfx, arrowPathData, {
+        strokeWidth: 1,
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+      });
+
+      return dataObject;
+    },
+    'bpmn:DataOutputAssociation': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderAssociation(parentGfx, element, {
+        ...attrs,
+        markerEnd: marker('association-end', getFillColor(element, defaultFillColor, attrs.fill), getStrokeColor(element, defaultStrokeColor, attrs.stroke))
+      });
+    },
+    'bpmn:DataStoreReference': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var dataStorePath = pathMap.getScaledPath('DATA_STORE', {
+        xScaleFactor: 1,
+        yScaleFactor: 1,
+        containerWidth: element.width,
+        containerHeight: element.height,
+        position: {
+          mx: 0,
+          my: 0.133
+        }
+      });
+
+      return drawPath(parentGfx, dataStorePath, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        fillOpacity: DEFAULT_OPACITY,
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 2
+      });
+    },
+    'bpmn:EndEvent': function(parentGfx, element, attrs = {}) {
+      var { renderIcon = true } = attrs;
+
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var event = renderEvent(parentGfx, element, {
+        ...attrs,
+        strokeWidth: 4
+      });
+
+      if (renderIcon) {
+        renderEventIcon(element, parentGfx, attrs);
+      }
+
+      return event;
+    },
+    'bpmn:EventBasedGateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var semantic = getSemantic(element);
+
+      var diamond = renderGateway(parentGfx, element, attrs);
+
+      drawCircle(parentGfx, element.width, element.height, element.height * 0.20, {
+        fill: getFillColor(element, 'none', attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      var type = semantic.get('eventGatewayType'),
+          instantiate = !!semantic.get('instantiate');
+
+      function drawEvent() {
+
+        var pathData = pathMap.getScaledPath('GATEWAY_EVENT_BASED', {
+          xScaleFactor: 0.18,
+          yScaleFactor: 0.18,
+          containerWidth: element.width,
+          containerHeight: element.height,
+          position: {
+            mx: 0.36,
+            my: 0.44
+          }
+        });
+
+        drawPath(parentGfx, pathData, {
+          fill: 'none',
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          strokeWidth: 2
+        });
+      }
+
+      if (type === 'Parallel') {
+        var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
+          xScaleFactor: 0.4,
+          yScaleFactor: 0.4,
+          containerWidth: element.width,
+          containerHeight: element.height,
+          position: {
+            mx: 0.474,
+            my: 0.296
+          }
+        });
+
+        drawPath(parentGfx, pathData, {
+          fill: 'none',
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          strokeWidth: 1
+        });
+      } else if (type === 'Exclusive') {
+        if (!instantiate) {
+          drawCircle(parentGfx, element.width, element.height, element.height * 0.26, {
+            fill: 'none',
+            stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+            strokeWidth: 1
+          });
+        }
+
+        drawEvent();
+      }
+
+
+      return diamond;
+    },
+    'bpmn:ExclusiveGateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var gateway = renderGateway(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('GATEWAY_EXCLUSIVE', {
+        xScaleFactor: 0.4,
+        yScaleFactor: 0.4,
+        containerWidth: element.width,
+        containerHeight: element.height,
+        position: {
+          mx: 0.32,
+          my: 0.3
+        }
+      });
+
+      var di = getDi(element);
+
+      if (di.get('isMarkerVisible')) {
+        drawPath(parentGfx, pathData, {
+          fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          strokeWidth: 1
+        });
+      }
+
+      return gateway;
+    },
+    'bpmn:Gateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderGateway(parentGfx, element, attrs);
+    },
+    'bpmn:Group': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke',
+        'width',
+        'height'
+      ]);
+
+      return drawRect(parentGfx, element.width, element.height, TASK_BORDER_RADIUS, {
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1.5,
+        strokeDasharray: '10, 6, 0, 6',
+        fill: 'none',
+        pointerEvents: 'none',
+        width: getWidth(element, attrs),
+        height: getHeight(element, attrs)
+      });
+    },
+    'bpmn:InclusiveGateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var gateway = renderGateway(parentGfx, element, attrs);
+
+      drawCircle(parentGfx, element.width, element.height, element.height * 0.24, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 2.5
+      });
+
+      return gateway;
+    },
+    'bpmn:IntermediateEvent': function(parentGfx, element, attrs = {}) {
+      var { renderIcon = true } = attrs;
+
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var outer = renderEvent(parentGfx, element, {
+        ...attrs,
+        strokeWidth: 1.5
+      });
+
+      drawCircle(parentGfx, element.width, element.height, INNER_OUTER_DIST, {
+        fill: 'none',
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1.5
+      });
+
+      if (renderIcon) {
+        renderEventIcon(element, parentGfx, attrs);
+      }
+
+      return outer;
+    },
+    'bpmn:IntermediateCatchEvent': as('bpmn:IntermediateEvent'),
+    'bpmn:IntermediateThrowEvent': as('bpmn:IntermediateEvent'),
+    'bpmn:Lane': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke',
+        'width',
+        'height'
+      ]);
+
+      return renderLane(parentGfx, element, {
+        ...attrs,
+        fillOpacity: LOW_OPACITY
+      });
+    },
+    'bpmn:ManualTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('TASK_TYPE_MANUAL', {
+        abspos: {
+          x: 17,
+          y: 15
+        }
+      });
+
+      drawPath(parentGfx, pathData, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 0.5
+      });
+
+      return task;
+    },
+    'bpmn:MessageFlow': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var semantic = getSemantic(element),
+          di = getDi(element);
+
+      var fill = getFillColor(element, defaultFillColor, attrs.fill),
+          stroke = getStrokeColor(element, defaultStrokeColor, attrs.stroke);
+
+      var path = drawConnectionSegments(parentGfx, element.waypoints, {
+        markerEnd: marker('messageflow-end', fill, stroke),
+        markerStart: marker('messageflow-start', fill, stroke),
+        stroke,
+        strokeDasharray: '10, 11',
+        strokeWidth: 1.5
+      });
+
+      if (semantic.get('messageRef')) {
+        var midPoint = path.getPointAtLength(path.getTotalLength() / 2);
+
+        var markerPathData = pathMap.getScaledPath('MESSAGE_FLOW_MARKER', {
+          abspos: {
+            x: midPoint.x,
+            y: midPoint.y
+          }
+        });
+
+        var messageAttrs = {
+          strokeWidth: 1
+        };
+
+        if (di.get('messageVisibleKind') === 'initiating') {
+          messageAttrs.fill = fill;
+          messageAttrs.stroke = stroke;
+        } else {
+          messageAttrs.fill = stroke;
+          messageAttrs.stroke = fill;
+        }
+
+        var message = drawPath(parentGfx, markerPathData, messageAttrs);
+
+        var messageRef = semantic.get('messageRef'),
+            name = messageRef.get('name');
+
+        var label = renderLabel(parentGfx, name, {
+          align: 'center-top',
+          fitBox: true,
+          style: {
+            fill: stroke
+          }
+        });
+
+        var messageBounds = message.getBBox(),
+            labelBounds = label.getBBox();
+
+        var translateX = midPoint.x - labelBounds.width / 2,
+            translateY = midPoint.y + messageBounds.height / 2 + ELEMENT_LABEL_DISTANCE;
+
+        transform(label, translateX, translateY, 0);
+      }
+
+      return path;
+    },
+    'bpmn:ParallelGateway': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var diamond = renderGateway(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('GATEWAY_PARALLEL', {
+        xScaleFactor: 0.6,
+        yScaleFactor: 0.6,
+        containerWidth: element.width,
+        containerHeight: element.height,
+        position: {
+          mx: 0.46,
+          my: 0.2
+        }
+      });
+
+      drawPath(parentGfx, pathData, {
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return diamond;
+    },
+    'bpmn:Participant': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke',
+        'width',
+        'height'
+      ]);
+
+      var participant = renderLane(parentGfx, element, attrs);
+
+      var expandedParticipant = isExpanded(element);
+
+      var semantic = getSemantic(element),
+          name = semantic.get('name');
+
+      if (expandedParticipant) {
+        drawLine(parentGfx, [
+          {
+            x: 30,
+            y: 0
+          },
+          {
+            x: 30,
+            y: getHeight(element, attrs)
+          }
+        ], {
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          strokeWidth: PARTICIPANT_STROKE_WIDTH
+        });
+
+        renderLaneLabel(parentGfx, name, element, attrs);
+      } else {
+        renderLabel(parentGfx, name, {
+          box: getBounds(element, attrs),
+          align: 'center-middle',
+          style: {
+            fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+          }
+        });
+      }
+
+      if (semantic.get('participantMultiplicity')) {
+        renderTaskMarker('ParticipantMultiplicityMarker', parentGfx, element, attrs);
+      }
+
+      return participant;
+    },
+    'bpmn:ReceiveTask' : function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var semantic = getSemantic(element);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var pathData;
+
+      if (semantic.get('instantiate')) {
+        drawCircle(parentGfx, 28, 28, 20 * 0.22, {
+          fill: getFillColor(element, defaultFillColor, attrs.fill),
+          stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+          strokeWidth: 1
+        });
+
+        pathData = pathMap.getScaledPath('TASK_TYPE_INSTANTIATING_SEND', {
+          abspos: {
+            x: 7.77,
+            y: 9.52
+          }
+        });
+      } else {
+        pathData = pathMap.getScaledPath('TASK_TYPE_SEND', {
+          xScaleFactor: 0.9,
+          yScaleFactor: 0.9,
+          containerWidth: 21,
+          containerHeight: 14,
+          position: {
+            mx: 0.3,
+            my: 0.4
+          }
+        });
+      }
+
+      drawPath(parentGfx, pathData, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return task;
+    },
+    'bpmn:ScriptTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('TASK_TYPE_SCRIPT', {
+        abspos: {
+          x: 15,
+          y: 20
+        }
+      });
+
+      drawPath(parentGfx, pathData, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return task;
+    },
+    'bpmn:SendTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var pathData = pathMap.getScaledPath('TASK_TYPE_SEND', {
+        xScaleFactor: 1,
+        yScaleFactor: 1,
+        containerWidth: 21,
+        containerHeight: 14,
+        position: {
+          mx: 0.285,
+          my: 0.357
+        }
+      });
+
+      drawPath(parentGfx, pathData, {
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getFillColor(element, defaultFillColor, attrs.fill),
+        strokeWidth: 1
+      });
+
+      return task;
+    },
+    'bpmn:SequenceFlow': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var fill = getFillColor(element, defaultFillColor, attrs.fill),
+          stroke = getStrokeColor(element, defaultStrokeColor, attrs.stroke);
+
+      var connection = drawConnectionSegments(parentGfx, element.waypoints, {
+        markerEnd: marker('sequenceflow-end', fill, stroke),
+        stroke
+      });
+
+      var semantic = getSemantic(element);
+
+      var { source } = element;
+
+      if (source) {
+        var sourceSemantic = getSemantic(source);
+
+        // conditional flow marker
+        if (semantic.get('conditionExpression') && is(sourceSemantic, 'bpmn:Activity')) {
+          svgAttr(connection, {
+            markerStart: marker('conditional-flow-marker', fill, stroke)
+          });
+        }
+
+        // default marker
+        if (sourceSemantic.get('default') && (is(sourceSemantic, 'bpmn:Gateway') || is(sourceSemantic, 'bpmn:Activity')) &&
+            sourceSemantic.get('default') === semantic) {
+          svgAttr(connection, {
+            markerStart: marker('conditional-default-flow-marker', fill, stroke)
+          });
+        }
+      }
+
+      return connection;
+    },
+    'bpmn:ServiceTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      drawCircle(parentGfx, 10, 10, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: 'none',
+        transform: 'translate(6, 6)'
+      });
+
+      var pathDataService1 = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
+        abspos: {
+          x: 12,
+          y: 18
+        }
+      });
+
+      drawPath(parentGfx, pathDataService1, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      drawCircle(parentGfx, 10, 10, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: 'none',
+        transform: 'translate(11, 10)'
+      });
+
+      var pathDataService2 = pathMap.getScaledPath('TASK_TYPE_SERVICE', {
+        abspos: {
+          x: 17,
+          y: 22
+        }
+      });
+
+      drawPath(parentGfx, pathDataService2, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1
+      });
+
+      return task;
+    },
+    'bpmn:StartEvent': function(parentGfx, element, attrs = {}) {
+      var { renderIcon = true } = attrs;
+
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var semantic = getSemantic(element);
+
+      if (!semantic.get('isInterrupting')) {
+        attrs = {
+          ...attrs,
+          strokeDasharray: '6'
+        };
+      }
+
+      var event = renderEvent(parentGfx, element, attrs);
+
+      if (renderIcon) {
+        renderEventIcon(element, parentGfx, attrs);
+      }
+
+      return event;
+    },
+    'bpmn:SubProcess': function(parentGfx, element, attrs = {}) {
+      if (isExpanded(element)) {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke',
+          'width',
+          'height'
+        ]);
+      } else {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke'
+        ]);
+      }
+
+      return renderSubProcess(parentGfx, element, attrs);
+    },
+    'bpmn:Task': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      return renderTask(parentGfx, element, attrs);
+    },
+    'bpmn:TextAnnotation': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke',
+        'width',
+        'height'
+      ]);
+
+      var {
+        width,
+        height
+      } = getBounds(element, attrs);
+
+      var textElement = drawRect(parentGfx, width, height, 0, 0, {
+        fill: 'none',
+        stroke: 'none'
+      });
+
+      var textPathData = pathMap.getScaledPath('TEXT_ANNOTATION', {
+        xScaleFactor: 1,
+        yScaleFactor: 1,
+        containerWidth: width,
+        containerHeight: height,
+        position: {
+          mx: 0.0,
+          my: 0.0
+        }
+      });
+
+      drawPath(parentGfx, textPathData, {
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
+      });
+
+      var semantic = getSemantic(element),
+          text = semantic.get('text') || '';
+
+      renderLabel(parentGfx, text, {
+        align: 'left-top',
+        box: getBounds(element, attrs),
+        padding: 7,
+        style: {
+          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+        }
+      });
+
+      return textElement;
+    },
+    'bpmn:Transaction': function(parentGfx, element, attrs = {}) {
+      if (isExpanded(element)) {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke',
+          'width',
+          'height'
+        ]);
+      } else {
+        attrs = pickAttrs(attrs, [
+          'fill',
+          'stroke'
+        ]);
+      }
+
+      var outer = renderSubProcess(parentGfx, element, {
+        strokeWidth: 1.5,
+        ...attrs
+      });
+
+      var innerAttrs = styles.style([ 'no-fill', 'no-events' ], {
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 1.5
+      });
+
+      var expanded = isExpanded(element);
+
+      if (!expanded) {
+        attrs = {};
+      }
+
+      drawRect(
+        parentGfx,
+        getWidth(element, attrs),
+        getHeight(element, attrs),
+        TASK_BORDER_RADIUS - INNER_OUTER_DIST,
+        INNER_OUTER_DIST,
+        innerAttrs
+      );
+
+      return outer;
+    },
+    'bpmn:UserTask': function(parentGfx, element, attrs = {}) {
+      attrs = pickAttrs(attrs, [
+        'fill',
+        'stroke'
+      ]);
+
+      var task = renderTask(parentGfx, element, attrs);
+
+      var x = 15;
+      var y = 12;
+
+      var pathDataUser1 = pathMap.getScaledPath('TASK_TYPE_USER_1', {
+        abspos: {
+          x: x,
+          y: y
+        }
+      });
+
+      drawPath(parentGfx, pathDataUser1, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 0.5
+      });
+
+      var pathDataUser2 = pathMap.getScaledPath('TASK_TYPE_USER_2', {
+        abspos: {
+          x: x,
+          y: y
+        }
+      });
+
+      drawPath(parentGfx, pathDataUser2, {
+        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 0.5
+      });
+
+      var pathDataUser3 = pathMap.getScaledPath('TASK_TYPE_USER_3', {
+        abspos: {
+          x: x,
+          y: y
+        }
+      });
+
+      drawPath(parentGfx, pathDataUser3, {
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
+        strokeWidth: 0.5
+      });
+
+      return task;
+    },
+    'label': function(parentGfx, element, attrs = {}) {
+      return renderExternalLabel(parentGfx, element, attrs);
+    }
+  };
 
   // extension API, use at your own risk
   this._drawPath = drawPath;
@@ -1940,15 +2242,16 @@ BpmnRenderer.prototype.canRender = function(element) {
  *
  * @param {SVGElement} parentGfx
  * @param {Element} element
+ * @param {Attrs} [attrs]
  *
  * @return {SVGElement} mainGfx
  */
-BpmnRenderer.prototype.drawShape = function(parentGfx, element) {
-  var type = element.type;
-  var h = this._renderer(type);
+BpmnRenderer.prototype.drawShape = function(parentGfx, element, attrs = {}) {
+  var { type } = element;
 
-  /* jshint -W040 */
-  return h(parentGfx, element);
+  var handler = this._renderer(type);
+
+  return handler(parentGfx, element, attrs);
 };
 
 /**
@@ -1956,15 +2259,16 @@ BpmnRenderer.prototype.drawShape = function(parentGfx, element) {
  *
  * @param {SVGElement} parentGfx
  * @param {Element} element
+ * @param {Attrs} [attrs]
  *
  * @return {SVGElement} mainGfx
  */
-BpmnRenderer.prototype.drawConnection = function(parentGfx, element) {
-  var type = element.type;
-  var h = this._renderer(type);
+BpmnRenderer.prototype.drawConnection = function(parentGfx, element, attrs = {}) {
+  var { type } = element;
 
-  /* jshint -W040 */
-  return h(parentGfx, element);
+  var handler = this._renderer(type);
+
+  return handler(parentGfx, element, attrs);
 };
 
 /**
@@ -1975,7 +2279,6 @@ BpmnRenderer.prototype.drawConnection = function(parentGfx, element) {
  * @return {string} path
  */
 BpmnRenderer.prototype.getShapePath = function(element) {
-
   if (is(element, 'bpmn:Event')) {
     return getCirclePath(element);
   }
@@ -1990,3 +2293,21 @@ BpmnRenderer.prototype.getShapePath = function(element) {
 
   return getRectPath(element);
 };
+
+/**
+ * Pick attributes if they exist.
+ *
+ * @param {Object} attrs
+ * @param {string[]} keys
+ *
+ * @returns {Object}
+ */
+function pickAttrs(attrs, keys = []) {
+  return keys.reduce((pickedAttrs, key) => {
+    if (attrs[ key ]) {
+      pickedAttrs[ key ] = attrs[ key ];
+    }
+
+    return pickedAttrs;
+  }, {});
+}

--- a/lib/features/append-preview/AppendPreview.js
+++ b/lib/features/append-preview/AppendPreview.js
@@ -1,0 +1,109 @@
+import {
+  assign,
+  isNil
+} from 'min-dash';
+
+const round = Math.round;
+
+/**
+ * @typedef {import('diagram-js/lib/features/complex-preview/ComplexPreview').default} ComplexPreview
+ * @typedef {import('diagram-js/lib/layout/ConnectionDocking').default} ConnectionDocking
+ * @typedef {import('../modeling/ElementFactory').default} ElementFactory
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('diagram-js/lib/layout/ManhattanLayout').default} ManhattanLayout
+ * @typedef {import('diagram-js/lib/features/rules/Rules').default} Rules
+ *
+ * @typedef {import('../../model/Types').Shape} Shape
+ */
+
+/**
+ * A preview for appending.
+ *
+ * @param {ComplexPreview} complexPreview
+ * @param {ConnectionDocking} connectionDocking
+ * @param {ElementFactory} elementFactory
+ * @param {EventBus} eventBus
+ * @param {ManhattanLayout} layouter
+ * @param {Rules} rules
+ */
+export default function AppendPreview(complexPreview, connectionDocking, elementFactory, eventBus, layouter, rules) {
+  this._complexPreview = complexPreview;
+  this._connectionDocking = connectionDocking;
+  this._elementFactory = elementFactory;
+  this._eventBus = eventBus;
+  this._layouter = layouter;
+  this._rules = rules;
+}
+
+/**
+ * Create a preview of appending a shape of the given type to the given source.
+ *
+ * @param {Shape} source
+ * @param {string} type
+ * @param {Partial<Shape>} options
+ */
+AppendPreview.prototype.create = function(source, type, options) {
+  const complexPreview = this._complexPreview,
+        connectionDocking = this._connectionDocking,
+        elementFactory = this._elementFactory,
+        eventBus = this._eventBus,
+        layouter = this._layouter,
+        rules = this._rules;
+
+  const shape = elementFactory.createShape(assign({ type }, options));
+
+  const position = eventBus.fire('autoPlace', {
+    source,
+    shape
+  });
+
+  if (!position) {
+    return;
+  }
+
+  assign(shape, {
+    x: position.x - round(shape.width / 2),
+    y: position.y - round(shape.height / 2)
+  });
+
+  const connectionCreateAllowed = rules.allowed('connection.create', {
+    source,
+    target: shape,
+    hints: {
+      targetParent: source.parent
+    }
+  });
+
+  let connection = null;
+
+  if (connectionCreateAllowed) {
+    connection = elementFactory.createConnection(connectionCreateAllowed);
+
+    connection.waypoints = layouter.layoutConnection(connection, {
+      source,
+      target: shape
+    });
+
+    connection.waypoints = connectionDocking.getCroppedWaypoints(connection, source, shape);
+  }
+
+  complexPreview.create({
+    created: [
+      shape,
+      connection
+    ].filter((element) => !isNil(element))
+  });
+};
+
+AppendPreview.prototype.cleanUp = function() {
+  this._complexPreview.cleanUp();
+};
+
+AppendPreview.$inject = [
+  'complexPreview',
+  'connectionDocking',
+  'elementFactory',
+  'eventBus',
+  'layouter',
+  'rules'
+];

--- a/lib/features/append-preview/index.js
+++ b/lib/features/append-preview/index.js
@@ -1,0 +1,15 @@
+import AutoPlaceModule from '../auto-place';
+import ComplexPreviewModule from 'diagram-js/lib/features/complex-preview';
+import ModelingModule from '../modeling';
+
+import AppendPreview from './AppendPreview';
+
+export default {
+  __depends__: [
+    AutoPlaceModule,
+    ComplexPreviewModule,
+    ModelingModule
+  ],
+  __init__: [ 'appendPreview' ],
+  appendPreview: [ 'type', AppendPreview ]
+};

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -71,7 +71,7 @@ export default function ContextPadProvider(
     config, injector, eventBus,
     contextPad, modeling, elementFactory,
     connect, create, popupMenu,
-    canvas, rules, translate) {
+    canvas, rules, translate, appendPreview) {
 
   config = config || {};
 
@@ -88,6 +88,8 @@ export default function ContextPadProvider(
   this._canvas = canvas;
   this._rules = rules;
   this._translate = translate;
+  this._eventBus = eventBus;
+  this._appendPreview = appendPreview;
 
   if (config.autoPlace !== false) {
     this._autoPlace = injector.get('autoPlace', false);
@@ -121,7 +123,8 @@ ContextPadProvider.$inject = [
   'popupMenu',
   'canvas',
   'rules',
-  'translate'
+  'translate',
+  'appendPreview'
 ];
 
 /**
@@ -180,14 +183,14 @@ ContextPadProvider.prototype._isDeleteAllowed = function(elements) {
 ContextPadProvider.prototype.getContextPadEntries = function(element) {
   var contextPad = this._contextPad,
       modeling = this._modeling,
-
       elementFactory = this._elementFactory,
       connect = this._connect,
       create = this._create,
       popupMenu = this._popupMenu,
       rules = this._rules,
       autoPlace = this._autoPlace,
-      translate = this._translate;
+      translate = this._translate,
+      appendPreview = this._appendPreview;
 
   var actions = {};
 
@@ -241,18 +244,33 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     function appendStart(event, element) {
 
       var shape = elementFactory.createShape(assign({ type: type }, options));
+
       create.start(event, shape, {
         source: element
       });
+
+      appendPreview.cleanUp();
     }
 
-
-    var append = autoPlace ? function(event, element) {
+    var append = autoPlace ? function(_, element) {
       var shape = elementFactory.createShape(assign({ type: type }, options));
 
       autoPlace.append(element, shape);
+
+      appendPreview.cleanUp();
     } : appendStart;
 
+    var previewAppend = autoPlace ? function(_, element) {
+
+      // mouseover
+      appendPreview.create(element, type, options);
+
+      return () => {
+
+        // mouseout
+        appendPreview.cleanUp();
+      };
+    } : null;
 
     return {
       group: 'model',
@@ -260,7 +278,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       title: title,
       action: {
         dragstart: appendStart,
-        click: append
+        click: append,
+        hover: previewAppend
       }
     };
   }

--- a/lib/features/context-pad/index.js
+++ b/lib/features/context-pad/index.js
@@ -1,3 +1,4 @@
+import AppendPreviewModule from '../append-preview';
 import DirectEditingModule from 'diagram-js-direct-editing';
 import ContextPadModule from 'diagram-js/lib/features/context-pad';
 import SelectionModule from 'diagram-js/lib/features/selection';
@@ -9,6 +10,7 @@ import ContextPadProvider from './ContextPadProvider';
 
 export default {
   __depends__: [
+    AppendPreviewModule,
     DirectEditingModule,
     ContextPadModule,
     SelectionModule,

--- a/test/fixtures/bpmn/kitchen-sink.bpmn
+++ b/test/fixtures/bpmn/kitchen-sink.bpmn
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0qv7gjd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:category id="Category_1tbggvc">
+    <bpmn:categoryValue id="CategoryValue_19ltlrt" value="Tasks" />
+  </bpmn:category>
+  <bpmn:category id="Category_0jku76b">
+    <bpmn:categoryValue id="CategoryValue_1e5k8u4" value="Gateways" />
+  </bpmn:category>
+  <bpmn:category id="Category_0m97nlo">
+    <bpmn:categoryValue id="CategoryValue_1yjf52e" value="Events" />
+  </bpmn:category>
+  <bpmn:collaboration id="Collaboration_02tkzm4">
+    <bpmn:participant id="Participant_1pudv9f" name="Participant" processRef="Process_0k3ryf8" />
+    <bpmn:participant id="Participant_0tuweou" name="Participant">
+      <bpmn:participantMultiplicity />
+    </bpmn:participant>
+    <bpmn:messageFlow id="Flow_0mefziq" sourceRef="Participant_1pudv9f" targetRef="Participant_0tuweou" messageRef="Message_1" />
+    <bpmn:messageFlow id="Flow_14s7yr5" sourceRef="Participant_0tuweou" targetRef="Participant_1pudv9f" />
+    <bpmn:group id="Group_0306c6g" categoryValueRef="CategoryValue_19ltlrt" />
+    <bpmn:group id="Group_06zgfh5" categoryValueRef="CategoryValue_1e5k8u4" />
+    <bpmn:group id="Group_1uodo9r" categoryValueRef="CategoryValue_1yjf52e" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0k3ryf8" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_0566jog">
+      <bpmn:lane id="Lane_1cofr07">
+        <bpmn:flowNodeRef>Activity_1ketqts</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1aw7nq3</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_09glvdf</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0w4fbsk</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0lwqw3q</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0im7nvs</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1gp70qr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_088fmm5</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0m5cdgr</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1vk962b</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0pzvbay</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1njhrf7</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0az045q</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0rd4z0d</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_00twu86</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1faweyu</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_01o5kun</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0a3nmhs</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0nn7qi2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0cvqzwg</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0jf1q45</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0d3edlz</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0mf406j</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1tb0m8u</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1folo0q</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1lhkn4m</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0tlcssq</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1d1oeak</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1bjbr5h</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0djfr8f</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_08egzqv</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1125q3g</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1ldvx66</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_011s9cd</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1a96i3e</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0e5q7rs</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1la6tas</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_01lyed4</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1ks0id1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0j90wfw</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0ikqxya</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1x9von4</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_13xao98</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1pdjezb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1ks4j21</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0ncmtxn</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_01qiiyi</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1cax1xl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1o9cjfb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0t86sxc</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_11fzkjc</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1vakzes" name="Lane">
+        <bpmn:flowNodeRef>Activity_0hcpwc9</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0vheewc</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1sosl74</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0brc3us</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0238ieb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0pfhghz</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0gi9n9o</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1ivfc6a</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1ndsz41</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0g37k20</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_0r6ceyw</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_137lgd1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_1fi82ot</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_11sdw9z</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:businessRuleTask id="Activity_1ketqts" name="Business Rule Task" />
+    <bpmn:manualTask id="Activity_1aw7nq3" />
+    <bpmn:receiveTask id="Activity_09glvdf" />
+    <bpmn:exclusiveGateway id="Gateway_0w4fbsk" name="Exclusive Gateway" />
+    <bpmn:inclusiveGateway id="Gateway_0lwqw3q" />
+    <bpmn:complexGateway id="Gateway_0im7nvs" />
+    <bpmn:eventBasedGateway id="Gateway_1gp70qr" />
+    <bpmn:subProcess id="Activity_088fmm5" name="Event-Subprocess" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_1l5ozbh">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1digjva" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1h3k36g" isInterrupting="false">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1ilob41" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1p4tub5">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1bg6z6t" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_16k3ggm" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1ji0j4r" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_139t55w">
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1kitwxn">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1q5v0sf" isInterrupting="false">
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_02cyrya">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1g4mqp3">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1jigagb" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1f81cds" isInterrupting="false">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_0smt1cj" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_19ahha0">
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1h5lmci" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_00h2mai">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1n1jtk8" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_0eql2pf" isInterrupting="false">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0hilmhu" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_09uyr4s">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_08fcqrr" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="Event_0m5cdgr" name="Start Event">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_09axst2" messageRef="Message_1" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_1vk962b">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1wqfsoo" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:subProcess id="Activity_0pzvbay" name="Subprocess">
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:subProcess>
+    <bpmn:intermediateThrowEvent id="Event_1njhrf7">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1x65mcp" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:startEvent id="Event_0az045q">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1ups2va" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_0rd4z0d">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_071dkih" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_00twu86">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1rjms9w" />
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_1faweyu">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_19su4pq">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_01o5kun">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_160s4nq">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0a3nmhs">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0eu3m1j" name="" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_0nn7qi2">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0xn074p" name="" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_0cvqzwg">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1yy1u3c" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="Event_0jf1q45">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_17493ur" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_0d3edlz">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1hgl68h" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_0mf406j">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1o7kcql" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1tb0m8u">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0lnltwf" />
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_1folo0q">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_18btf0r" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_1lhkn4m">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0wu33ji" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0tlcssq">
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_0qzb9lz" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1d1oeak">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_04gpe8z" />
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_1bjbr5h">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1dpuxy8" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:transaction id="Activity_0djfr8f" name="Transaction">
+      <bpmn:multiInstanceLoopCharacteristics />
+      <bpmn:endEvent id="Event_1cutsq6">
+        <bpmn:cancelEventDefinition id="CancelEventDefinition_0fr4bjf" />
+      </bpmn:endEvent>
+    </bpmn:transaction>
+    <bpmn:boundaryEvent id="Event_11fzkjc" attachedToRef="Activity_0djfr8f">
+      <bpmn:cancelEventDefinition id="CancelEventDefinition_1q9o9vy" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0t86sxc" attachedToRef="Activity_0pzvbay">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_00rw9ri" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1o9cjfb" cancelActivity="false" attachedToRef="Activity_0pzvbay">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_07fctt8" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1cax1xl" attachedToRef="Activity_0pzvbay">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0tj2w4d" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_01qiiyi" attachedToRef="Activity_0pzvbay">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1y2eafx" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0ncmtxn" cancelActivity="false" attachedToRef="Activity_0pzvbay">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_04gift3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1ks4j21" attachedToRef="Activity_0pzvbay">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1xvs6nt" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1pdjezb" cancelActivity="false" attachedToRef="Activity_0pzvbay">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1ulkndr">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_13xao98" attachedToRef="Activity_0pzvbay">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_0wkuo44">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1x9von4" cancelActivity="false" attachedToRef="Activity_0pzvbay">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1gysdks" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0ikqxya" attachedToRef="Activity_0pzvbay">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0kct1ik" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0j90wfw" cancelActivity="false" attachedToRef="Activity_0pzvbay">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0mkmbes" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1ks0id1" attachedToRef="Activity_0pzvbay">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0a4jz6j" />
+    </bpmn:boundaryEvent>
+    <bpmn:dataStoreReference id="DataStoreReference_1wvmfek" name="Data Store Reference" />
+    <bpmn:dataStoreReference id="DataStoreReference_1gynygb" />
+    <bpmn:task id="Activity_0hcpwc9">
+      <bpmn:incoming>Flow_0802uvc</bpmn:incoming>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" />
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0802uvc" sourceRef="Activity_1sosl74" targetRef="Activity_0hcpwc9" />
+    <bpmn:task id="Activity_0vheewc">
+      <bpmn:property id="Property_0bs4ymr" name="__targetRef_placeholder" />
+      <bpmn:dataInputAssociation id="DataInputAssociation_0i6cauf">
+        <bpmn:sourceRef>DataStoreReference_1gynygb</bpmn:sourceRef>
+        <bpmn:targetRef>Property_0bs4ymr</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+      <bpmn:dataInputAssociation id="DataInputAssociation_1xidkdu">
+        <bpmn:sourceRef>DataObjectReference_0v2e6m7</bpmn:sourceRef>
+        <bpmn:targetRef>Property_0bs4ymr</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+    </bpmn:task>
+    <bpmn:dataObjectReference id="DataObjectReference_0v2e6m7" dataObjectRef="DataObject_00ce2uh" />
+    <bpmn:dataObject id="DataObject_00ce2uh" />
+    <bpmn:task id="Activity_1sosl74">
+      <bpmn:outgoing>Flow_0802uvc</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:task id="Activity_0brc3us">
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_1dph7uw">
+        <bpmn:targetRef>DataStoreReference_1wvmfek</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_14ddyds">
+        <bpmn:targetRef>DataObjectReference_05ngfcy</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+      <bpmn:standardLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:dataObjectReference id="DataObjectReference_05ngfcy" name="Data Object Reference" dataObjectRef="DataObject_13ulk9j" />
+    <bpmn:dataObject id="DataObject_13ulk9j" isCollection="true" />
+    <bpmn:adHocSubProcess id="Activity_08egzqv" name="Ad-Hoc Subprocess">
+      <bpmn:standardLoopCharacteristics />
+    </bpmn:adHocSubProcess>
+    <bpmn:exclusiveGateway id="Gateway_0238ieb" default="Flow_0a4nevl">
+      <bpmn:outgoing>Flow_0a4nevl</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0a4nevl" sourceRef="Gateway_0238ieb" targetRef="Activity_0pfhghz" />
+    <bpmn:task id="Activity_0pfhghz">
+      <bpmn:incoming>Flow_0a4nevl</bpmn:incoming>
+      <bpmn:outgoing>Flow_16zflj8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Activity_0gi9n9o">
+      <bpmn:incoming>Flow_16zflj8</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_16zflj8" sourceRef="Activity_0pfhghz" targetRef="Activity_0gi9n9o">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" />
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="Activity_1ivfc6a">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:standardLoopCharacteristics />
+    </bpmn:callActivity>
+    <bpmn:boundaryEvent id="Event_11sdw9z" attachedToRef="Activity_0vheewc">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_04l674p" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Activity_1ndsz41" isForCompensation="true" />
+    <bpmn:subProcess id="Activity_0g37k20" />
+    <bpmn:sendTask id="Activity_1125q3g" />
+    <bpmn:serviceTask id="Activity_1ldvx66" />
+    <bpmn:scriptTask id="Activity_011s9cd" />
+    <bpmn:userTask id="Activity_1a96i3e" />
+    <bpmn:receiveTask id="Activity_0e5q7rs" instantiate="true" />
+    <bpmn:eventBasedGateway id="Gateway_1la6tas" instantiate="true" />
+    <bpmn:eventBasedGateway id="Gateway_01lyed4" eventGatewayType="Parallel" />
+    <bpmn:adHocSubProcess id="Activity_0r6ceyw" />
+    <bpmn:transaction id="Activity_137lgd1" />
+    <bpmn:subProcess id="Activity_1fi82ot" triggeredByEvent="true" />
+    <bpmn:textAnnotation id="TextAnnotation_1xqm9d8">
+      <bpmn:text>Textannotation</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_057v11v" sourceRef="Activity_1sosl74" targetRef="TextAnnotation_1xqm9d8" />
+    <bpmn:association id="Association_1n0wnaa" associationDirection="One" sourceRef="Event_11sdw9z" targetRef="Activity_1ndsz41" />
+  </bpmn:process>
+  <bpmn:message id="Message_1" name="Message" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_02tkzm4">
+      <bpmndi:BPMNShape id="Participant_1pudv9f_di" bpmnElement="Participant_1pudv9f" isHorizontal="true">
+        <dc:Bounds x="140" y="60" width="1280" height="1500" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1vakzes_di" bpmnElement="Lane_1vakzes" isHorizontal="true">
+        <dc:Bounds x="170" y="1220" width="1250" height="340" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1cofr07_di" bpmnElement="Lane_1cofr07" isHorizontal="true">
+        <dc:Bounds x="170" y="60" width="1250" height="1160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01mo9pp_di" bpmnElement="Activity_1ketqts">
+        <dc:Bounds x="220" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hidovz_di" bpmnElement="Activity_1aw7nq3">
+        <dc:Bounds x="370" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ikz49h_di" bpmnElement="Activity_09glvdf">
+        <dc:Bounds x="520" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0w4fbsk_di" bpmnElement="Gateway_0w4fbsk" isMarkerVisible="true">
+        <dc:Bounds x="245" y="295" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="246" y="352" width="48" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tgejt4_di" bpmnElement="Gateway_0lwqw3q">
+        <dc:Bounds x="395" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_16hyhp9_di" bpmnElement="Gateway_0im7nvs">
+        <dc:Bounds x="545" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bn5u03_di" bpmnElement="Gateway_1gp70qr">
+        <dc:Bounds x="695" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15puyrp_di" bpmnElement="Activity_088fmm5" isExpanded="true">
+        <dc:Bounds x="340" y="430" width="310" height="600" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14dcyxe_di" bpmnElement="Event_1l5ozbh">
+        <dc:Bounds x="402" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ehuivh_di" bpmnElement="Event_1h3k36g">
+        <dc:Bounds x="552" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dovk1s_di" bpmnElement="Event_1p4tub5">
+        <dc:Bounds x="402" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1blrlze_di" bpmnElement="Event_16k3ggm">
+        <dc:Bounds x="552" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q9fgnx_di" bpmnElement="Event_139t55w">
+        <dc:Bounds x="402" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1anq0sn_di" bpmnElement="Event_1q5v0sf">
+        <dc:Bounds x="552" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05w0dyh_di" bpmnElement="Event_1g4mqp3">
+        <dc:Bounds x="402" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1558ky5_di" bpmnElement="Event_1f81cds">
+        <dc:Bounds x="552" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r4brhv_di" bpmnElement="Event_19ahha0">
+        <dc:Bounds x="402" y="772" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zs1a5m_di" bpmnElement="Event_00h2mai">
+        <dc:Bounds x="402" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10cel4r_di" bpmnElement="Event_0eql2pf">
+        <dc:Bounds x="552" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wnz45q_di" bpmnElement="Event_09uyr4s">
+        <dc:Bounds x="402" y="952" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_113y379_di" bpmnElement="Event_0m5cdgr">
+        <dc:Bounds x="252" y="472" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="243" y="515" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ocn95s_di" bpmnElement="Event_1vk962b">
+        <dc:Bounds x="702" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pzvbay_di" bpmnElement="Activity_0pzvbay" isExpanded="true">
+        <dc:Bounds x="870" y="430" width="150" height="600" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0qhdt4c_di" bpmnElement="Event_1njhrf7">
+        <dc:Bounds x="1152" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cnrcjh_di" bpmnElement="Event_0az045q">
+        <dc:Bounds x="252" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rh3u8m_di" bpmnElement="Event_0rd4z0d">
+        <dc:Bounds x="702" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0s0bfzr_di" bpmnElement="Event_00twu86">
+        <dc:Bounds x="1302" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00bxzao_di" bpmnElement="Event_1faweyu">
+        <dc:Bounds x="252" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ceu8ke_di" bpmnElement="Event_01o5kun">
+        <dc:Bounds x="702" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1peubqp_di" bpmnElement="Event_0a3nmhs">
+        <dc:Bounds x="702" y="652" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u7yxnj_di" bpmnElement="Event_0nn7qi2">
+        <dc:Bounds x="1152" y="652" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mgz9qb_di" bpmnElement="Event_0cvqzwg">
+        <dc:Bounds x="702" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1czxrsk_di" bpmnElement="Event_0jf1q45">
+        <dc:Bounds x="252" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0m7cya2_di" bpmnElement="Event_0d3edlz">
+        <dc:Bounds x="1152" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02l7dnu_di" bpmnElement="Event_0mf406j">
+        <dc:Bounds x="1302" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1gojfpq_di" bpmnElement="Event_1tb0m8u">
+        <dc:Bounds x="1302" y="772" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ha64fc_di" bpmnElement="Event_1folo0q">
+        <dc:Bounds x="1152" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wlidtb_di" bpmnElement="Event_1lhkn4m">
+        <dc:Bounds x="1302" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ritd0j_di" bpmnElement="Event_0tlcssq">
+        <dc:Bounds x="1302" y="892" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wtzvuy_di" bpmnElement="Event_1d1oeak">
+        <dc:Bounds x="1302" y="952" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14q825i_di" bpmnElement="Event_1bjbr5h">
+        <dc:Bounds x="1152" y="952" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09bhoe2_di" bpmnElement="Activity_0djfr8f" isExpanded="true">
+        <dc:Bounds x="870" y="1050" width="500" height="120" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0une4rb_di" bpmnElement="Event_1cutsq6">
+        <dc:Bounds x="1302" y="1092" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_1wvmfek_di" bpmnElement="DataStoreReference_1wvmfek">
+        <dc:Bounds x="196" y="1265" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="197" y="1322" width="54" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1xoymf7" bpmnElement="DataStoreReference_1gynygb">
+        <dc:Bounds x="196" y="1365" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hcpwc9_di" bpmnElement="Activity_0hcpwc9">
+        <dc:Bounds x="920" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kz9py6" bpmnElement="Activity_0vheewc">
+        <dc:Bounds x="353" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0axixfr" bpmnElement="DataObjectReference_0v2e6m7">
+        <dc:Bounds x="565" y="1365" width="36" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sosl74_di" bpmnElement="Activity_1sosl74">
+        <dc:Bounds x="713" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0brc3us_di" bpmnElement="Activity_0brc3us">
+        <dc:Bounds x="353" y="1250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_05ngfcy_di" bpmnElement="DataObjectReference_05ngfcy">
+        <dc:Bounds x="565" y="1265" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="554" y="1322" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0avyupr_di" bpmnElement="Activity_08egzqv" isExpanded="true">
+        <dc:Bounds x="340" y="1050" width="310" height="120" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0238ieb_di" bpmnElement="Gateway_0238ieb" isMarkerVisible="true">
+        <dc:Bounds x="738" y="1475" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pfhghz_di" bpmnElement="Activity_0pfhghz">
+        <dc:Bounds x="920" y="1460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gi9n9o_di" bpmnElement="Activity_0gi9n9o">
+        <dc:Bounds x="1160" y="1460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1rx7qci_di" bpmnElement="Activity_1ivfc6a">
+        <dc:Bounds x="1160" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ndsz41_di" bpmnElement="Activity_1ndsz41">
+        <dc:Bounds x="530" y="1460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15v9195_di" bpmnElement="Activity_0g37k20">
+        <dc:Bounds x="1160" y="1250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0unvxpf_di" bpmnElement="Activity_1125q3g">
+        <dc:Bounds x="820" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bjari0_di" bpmnElement="Activity_1ldvx66">
+        <dc:Bounds x="970" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bqlir6_di" bpmnElement="Activity_011s9cd">
+        <dc:Bounds x="1120" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hulhoi_di" bpmnElement="Activity_1a96i3e">
+        <dc:Bounds x="1270" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qbuker_di" bpmnElement="Activity_0e5q7rs">
+        <dc:Bounds x="670" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0cr60ph_di" bpmnElement="Gateway_1la6tas">
+        <dc:Bounds x="845" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0t2p1hd_di" bpmnElement="Gateway_01lyed4">
+        <dc:Bounds x="995" y="295" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_128ea86_di" bpmnElement="Activity_0r6ceyw">
+        <dc:Bounds x="1280" y="1250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_145p4eg_di" bpmnElement="Activity_137lgd1">
+        <dc:Bounds x="1280" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1xqm9d8_di" bpmnElement="TextAnnotation_1xqm9d8">
+        <dc:Bounds x="800" y="1270" width="99.98694034205708" height="29.992818085003794" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ssrgjf_di" bpmnElement="Activity_1fi82ot">
+        <dc:Bounds x="1280" y="1460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19lz4a4_di" bpmnElement="Event_11sdw9z">
+        <dc:Bounds x="435" y="1412" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08k4l1q_di" bpmnElement="Event_1ks0id1">
+        <dc:Bounds x="852" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1revq16_di" bpmnElement="Event_0j90wfw">
+        <dc:Bounds x="1002" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1bbkws3_di" bpmnElement="Event_0ikqxya">
+        <dc:Bounds x="852" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jugyc0_di" bpmnElement="Event_1x9von4">
+        <dc:Bounds x="1002" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a3l00n_di" bpmnElement="Event_13xao98">
+        <dc:Bounds x="852" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bn3zw5_di" bpmnElement="Event_1pdjezb">
+        <dc:Bounds x="1002" y="592" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1amf1mc_di" bpmnElement="Event_1ks4j21">
+        <dc:Bounds x="852" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zefk00_di" bpmnElement="Event_0ncmtxn">
+        <dc:Bounds x="1002" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0cv9d2f_di" bpmnElement="Event_01qiiyi">
+        <dc:Bounds x="852" y="772" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0qt7y3u_di" bpmnElement="Event_1cax1xl">
+        <dc:Bounds x="852" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_001oe0g_di" bpmnElement="Event_1o9cjfb">
+        <dc:Bounds x="1002" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tpwr9f_di" bpmnElement="Event_0t86sxc">
+        <dc:Bounds x="852" y="952" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebrnw6_di" bpmnElement="Event_11fzkjc">
+        <dc:Bounds x="852" y="1092" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0802uvc_di" bpmnElement="Flow_0802uvc">
+        <di:waypoint x="813" y="1390" />
+        <di:waypoint x="920" y="1390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a4nevl_di" bpmnElement="Flow_0a4nevl">
+        <di:waypoint x="788" y="1500" />
+        <di:waypoint x="920" y="1500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16zflj8_di" bpmnElement="Flow_16zflj8">
+        <di:waypoint x="1020" y="1500" />
+        <di:waypoint x="1160" y="1500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_057v11v_di" bpmnElement="Association_057v11v">
+        <di:waypoint x="796" y="1350" />
+        <di:waypoint x="838" y="1300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1n0wnaa_di" bpmnElement="Association_1n0wnaa">
+        <di:waypoint x="453" y="1448" />
+        <di:waypoint x="453" y="1500" />
+        <di:waypoint x="530" y="1500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0q26pjx_di" bpmnElement="Participant_0tuweou" isHorizontal="true">
+        <dc:Bounds x="140" y="1640" width="1280" height="60" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0306c6g_di" bpmnElement="Group_0306c6g">
+        <dc:Bounds x="190" y="80" width="1210" height="150" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="781" y="87" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_06zgfh5_di" bpmnElement="Group_06zgfh5">
+        <dc:Bounds x="190" y="250" width="1210" height="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="770" y="257" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1uodo9r_di" bpmnElement="Group_1uodo9r">
+        <dc:Bounds x="190" y="390" width="1210" height="810" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="778" y="397" width="35" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataInputAssociation_0i6cauf_di" bpmnElement="DataInputAssociation_0i6cauf">
+        <di:waypoint x="246" y="1390" />
+        <di:waypoint x="353" y="1390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataInputAssociation_1xidkdu_di" bpmnElement="DataInputAssociation_1xidkdu">
+        <di:waypoint x="565" y="1390" />
+        <di:waypoint x="453" y="1390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_1dph7uw_di" bpmnElement="DataOutputAssociation_1dph7uw">
+        <di:waypoint x="353" y="1290" />
+        <di:waypoint x="246" y="1290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_14ddyds_di" bpmnElement="DataOutputAssociation_14ddyds">
+        <di:waypoint x="453" y="1290" />
+        <di:waypoint x="565" y="1290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mefziq_di" bpmnElement="Flow_0mefziq">
+        <di:waypoint x="276" y="1560" />
+        <di:waypoint x="276" y="1640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14s7yr5_di" bpmnElement="Flow_14s7yr5">
+        <di:waypoint x="400" y="1640" />
+        <di:waypoint x="400" y="1560" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0gk5o24">
+    <bpmndi:BPMNPlane id="BPMNPlane_1p3nz9z" bpmnElement="Activity_0g37k20" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="Activity_0r6ceyw" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="Activity_137lgd1" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="Activity_1fi82ot" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -806,11 +806,6 @@ describe('draw - bpmn renderer', function() {
 
   });
 
-});
-
-
-
-describe('draw - bpmn renderer - integration', function() {
 
   describe('custom icons', function() {
 

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -5,6 +5,7 @@ import {
 } from 'test/TestHelper';
 
 import {
+  attr as svgAttr,
   create as svgCreate
 } from 'tiny-svg';
 
@@ -13,13 +14,22 @@ import rendererModule from 'lib/draw';
 import modelingModule from 'lib/features/modeling';
 
 import {
-  query as domQuery
+  query as domQuery,
+  queryAll as domQueryAll
 } from 'min-dom';
+
+import { getVisual } from 'diagram-js/lib/util/GraphicsUtil';
 
 import { isAny } from 'lib/features/modeling/util/ModelingUtil';
 
+import { isExpanded } from 'lib/util/DiUtil';
+
+import { isPlane } from 'lib/util/DrilldownUtil';
+
 import {
-  getDi
+  getDi,
+  black,
+  white
 } from 'lib/draw/BpmnRenderUtil';
 
 import customRendererModule from './custom-renderer';
@@ -659,6 +669,143 @@ describe('draw - bpmn renderer', function() {
 
   });
 
+
+  describe('attrs', function() {
+
+    describe('colors', function() {
+
+      const diagramXML = require('../../fixtures/bpmn/kitchen-sink.bpmn');
+
+      class CustomColors {
+        constructor(eventBus) {
+          eventBus.on([ 'render.shape', 'render.connection' ], 100000, (_, context) => {
+            context.attrs = {
+              fill: 'yellow',
+              fillOpacity: 0.1, // should be ignored
+              stroke: 'blue',
+              strokeDasharray: '0, 10', // should be ignored
+              strokeWidth: 10 // should be ignored
+            };
+          });
+        }
+      }
+
+      CustomColors.$inject = [ 'eventBus' ];
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        bpmnRenderer: {
+          defaultFillColor: 'cyan',
+          defaultStrokeColor: 'red'
+        },
+        additionalModules: [
+          {
+            __init__: [ 'customColors' ],
+            customColors: [ 'type', CustomColors ]
+          }
+        ]
+      }));
+
+
+      it('should override colors', inject(function(canvas) {
+
+        // then
+        var container = canvas.getContainer();
+
+        // expect fill and stroke overridden
+        domQueryAll('.djs-visual *', container).forEach(element => {
+          expect(svgAttr(element, 'fill')).not.to.equal('cyan');
+          expect(svgAttr(element, 'fill')).not.to.equal(white);
+          expect(svgAttr(element, 'stroke')).not.to.equal('red');
+          expect(svgAttr(element, 'stroke')).not.to.equal(black);
+        });
+
+        // expect all others not overridden
+        domQueryAll('.djs-visual *', container).forEach(element => {
+          expect(svgAttr(element, 'stroke-dasharray')).not.to.equal('0, 9000');
+          expect(svgAttr(element, 'stroke-width')).not.to.equal('9000');
+        });
+      }));
+
+    });
+
+
+    describe('bounds', function() {
+
+      const diagramXML = require('../../fixtures/bpmn/kitchen-sink.bpmn');
+
+      class CustomBounds {
+        constructor(eventBus) {
+          eventBus.on('render.shape', 100000, (_, context) => {
+            context.attrs = {
+              width: 200,
+              height: 100,
+              fillOpacity: 0.1, // should be ignored
+              strokeDasharray: '0, 9000', // should be ignored
+              strokeWidth: 9000 // should be ignored
+            };
+          });
+        }
+      }
+
+      CustomBounds.$inject = [ 'eventBus' ];
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        additionalModules: [
+          {
+            __init__: [ 'customBounds' ],
+            customBounds: [ 'type', CustomBounds ]
+          }
+        ]
+      }));
+
+
+      it('should override bounds', inject(function(canvas, elementRegistry) {
+
+        // then
+        var container = canvas.getContainer();
+
+        // expect width and height overridden
+        elementRegistry.filter(element => {
+          return isAny(element, [
+            'bpmn:AdHocSubProcess',
+            'bpmn:Group',
+            'bpmn:Lane',
+            'bpmn:Participant',
+            'bpmn:SubProcess',
+            'bpmn:TextAnnotation',
+            'bpmn:Transaction'
+          ]);
+        }).forEach(element => {
+          if (isPlane(element)) {
+            return;
+          }
+
+          var visual = getVisual(elementRegistry.getGraphics(element));
+
+          var rect = domQuery('rect', visual);
+
+          if (rect) {
+
+            if (isCollapsedSubProcess(element)) {
+              expect(svgAttr(rect, 'width')).to.equal('100');
+              expect(svgAttr(rect, 'height')).to.equal('80');
+            } else {
+              expect(svgAttr(rect, 'width')).to.equal('200');
+              expect(svgAttr(rect, 'height')).to.equal('100');
+            }
+          }
+        });
+
+        // expect all others not overridden
+        domQueryAll('.djs-visual *', container).forEach(element => {
+          expect(svgAttr(element, 'stroke-dasharray')).not.to.equal('0, 9000');
+          expect(svgAttr(element, 'stroke-width')).not.to.equal('9000');
+        });
+      }));
+    });
+
+  });
+
 });
 
 
@@ -697,3 +844,11 @@ describe('draw - bpmn renderer - integration', function() {
   });
 
 });
+
+function isCollapsedSubProcess(element) {
+  return isAny(element, [
+    'bpmn:SubProcess',
+    'bpmn:AdHocSubProcess',
+    'bpmn:Transaction'
+  ]) && !isExpanded(element);
+}

--- a/test/spec/features/append-preview/AppendPreview.bpmn
+++ b/test/spec/features/append-preview/AppendPreview.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0sp5wo7" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/append-preview/AppendPreviewSpec.js
+++ b/test/spec/features/append-preview/AppendPreviewSpec.js
@@ -1,0 +1,56 @@
+import { queryAll as domQueryAll } from 'min-dom';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import appendPreviewModule from 'lib/features/append-preview';
+import coreModule from 'lib/core';
+
+describe('features/append-preview', function() {
+
+  var diagramXML = require('./AppendPreview.bpmn');
+
+  before(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      appendPreviewModule
+    ]
+  }));
+
+
+  it('should create', inject(function(appendPreview, canvas, elementRegistry) {
+
+    // given
+    var startEvent = elementRegistry.get('StartEvent_1');
+
+    // when
+    appendPreview.create(startEvent, 'bpmn:Task');
+
+    // then
+    expect(canvas.getLayer('complex-preview')).to.exist;
+    expect(domQueryAll('.djs-dragger', canvas.getLayer('complex-preview'))).to.have.length(2);
+  }));
+
+
+  it('should clean up', inject(function(appendPreview, canvas, elementRegistry) {
+
+    // given
+    var startEvent = elementRegistry.get('StartEvent_1');
+
+    // when
+    appendPreview.create(startEvent, 'bpmn:Task');
+
+    // assume
+    expect(canvas.getLayer('complex-preview')).to.exist;
+    expect(domQueryAll('.djs-dragger', canvas.getLayer('complex-preview'))).to.have.length(2);
+
+    // when
+    appendPreview.cleanUp();
+
+    // then
+    expect(domQueryAll('.djs-dragger', canvas.getLayer('complex-preview'))).to.be.empty;
+  }));
+
+});

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -681,6 +681,36 @@ describe('features - context-pad', function() {
 
   });
 
+
+  describe('preview', function() {
+
+    var diagramXML = require('../../../fixtures/bpmn/simple.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules.concat(autoPlaceModule)
+    }));
+
+
+    it('should preview append', inject(function(canvas, elementRegistry, contextPad) {
+
+      // given
+      var element = elementRegistry.get('Task_1');
+
+      contextPad.open(element);
+
+      // mock event
+      var event = padEvent('append.gateway');
+
+      // when
+      contextPad.trigger('hover', event);
+
+      // then
+      expect(canvas.getLayer('complex-preview')).to.exist;
+      expect(domQueryAll('.djs-dragger', canvas.getLayer('complex-preview'))).to.have.length(2);
+    }));
+
+  });
+
 });
 
 

--- a/test/spec/features/modeling/behavior/ReplaceElementBehaviourSpec.js
+++ b/test/spec/features/modeling/behavior/ReplaceElementBehaviourSpec.js
@@ -246,7 +246,7 @@ describe('features/modeling - replace element behavior', function() {
 
             // then
             expect(transaction.children).to.have.length(1);
-            expect(endEventAfter.businessObject.eventDefinitions).to.exist;
+            expect(endEventAfter.businessObject.get('eventDefinitions')).not.to.be.empty;
           })
         );
 
@@ -273,7 +273,7 @@ describe('features/modeling - replace element behavior', function() {
 
             // then
             expect(transaction.children).to.have.length(0);
-            expect(endEventAfter.businessObject.eventDefinitions).not.to.exist;
+            expect(endEventAfter.businessObject.get('eventDefinitions')).to.be.empty;
           })
         );
 
@@ -302,7 +302,7 @@ describe('features/modeling - replace element behavior', function() {
 
             // then
             expect(transaction.children).to.have.length(1);
-            expect(endEventAfter.businessObject.eventDefinitions).to.exist;
+            expect(endEventAfter.businessObject.get('eventDefinitions')).not.to.be.empty;
           })
         );
 
@@ -358,7 +358,7 @@ describe('features/modeling - replace element behavior', function() {
             })[0];
 
             // then
-            expect(afterBoundaryEvent.businessObject.eventDefinitions).exist;
+            expect(afterBoundaryEvent.businessObject.get('eventDefinitions')).not.to.be.empty;
             expect(afterBoundaryEvent.businessObject.attachedToRef).to.equal(transaction.businessObject);
             expect(transaction.attachers).to.have.length(1);
           })
@@ -387,7 +387,7 @@ describe('features/modeling - replace element behavior', function() {
             })[0];
 
             // then
-            expect(movedBoundaryEvent.businessObject.eventDefinitions).not.to.exist;
+            expect(movedBoundaryEvent.businessObject.get('eventDefinitions')).to.be.empty;
             expect(movedBoundaryEvent.businessObject.attachedToRef).to.equal(subProcess.businessObject);
             expect(movedBoundaryEvent.parent).to.equal(process);
 
@@ -421,7 +421,7 @@ describe('features/modeling - replace element behavior', function() {
             })[0];
 
             // then
-            expect(movedBoundaryEvent.businessObject.eventDefinitions).to.exist;
+            expect(movedBoundaryEvent.businessObject.get('eventDefinitions')).not.to.be.empty;
             expect(movedBoundaryEvent.businessObject.attachedToRef).to.equal(transaction.businessObject);
 
             expect(movedBoundaryEvent.host).to.equal(transaction);
@@ -524,7 +524,7 @@ describe('features/modeling - replace element behavior', function() {
         var createdEvent = elementRegistry.get(id);
 
         expect(createdEvent).to.exist;
-        expect(createdEvent.businessObject.eventDefinitions).to.not.exist;
+        expect(createdEvent.businessObject.get('eventDefinitions')).to.be.empty;
       })
     );
 
@@ -546,9 +546,9 @@ describe('features/modeling - replace element behavior', function() {
         var createdEvent = elementRegistry.get(id);
 
         expect(createdEvent).to.eql(startEvent);
-        expect(createdEvent.businessObject.eventDefinitions).to.have.lengthOf(1);
+        expect(createdEvent.businessObject.get('eventDefinitions')).to.have.lengthOf(1);
         expect(
-          is(createdEvent.businessObject.eventDefinitions[0], 'bpmn:TimerEventDefinition')
+          is(createdEvent.businessObject.get('eventDefinitions')[0], 'bpmn:TimerEventDefinition')
         ).to.be.true;
       })
     );
@@ -573,7 +573,7 @@ describe('features/modeling - replace element behavior', function() {
         var createdEvent = elementRegistry.get(id);
 
         expect(createdEvent).to.exist;
-        expect(createdEvent.businessObject.eventDefinitions).not.to.exist;
+        expect(createdEvent.businessObject.get('eventDefinitions')).to.be.empty;
         expect(createdEvent.businessObject.get('isInterrupting')).to.be.true;
       })
     );

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -304,7 +304,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     describe('active attribute', function() {
 
-      it('should be true for parallel marker', inject(function(bpmnReplace, elementRegistry) {
+      it('should be true for parallel marker', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('ParallelTask'),
@@ -324,7 +324,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should be true for sequential marker', inject(function(bpmnReplace, elementRegistry) {
+      it('should be true for sequential marker', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask'),
@@ -342,7 +342,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should be true for loop marker', inject(function(bpmnReplace, elementRegistry) {
+      it('should be true for loop marker', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask'),
@@ -360,7 +360,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should be true for ad hoc marker', inject(function(bpmnReplace, elementRegistry) {
+      it('should be true for ad hoc marker', inject(function(elementRegistry) {
 
         // given
         var AdHocSubProcess = elementRegistry.get('AdHocSubProcess');
@@ -377,7 +377,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     describe('exclusive toggle buttons', function() {
 
-      it('should not toggle non exclusive buttons off', inject(function(bpmnReplace, elementRegistry) {
+      it('should not toggle non exclusive buttons off', inject(function(elementRegistry) {
         var subProcess = elementRegistry.get('AdHocSubProcess');
 
         openPopup(subProcess);
@@ -397,7 +397,7 @@ describe('features/popup-menu - replace menu provider', function() {
     describe('non exclusive toggle buttons', function() {
 
       it('should not toggle exclusive buttons off',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var subProcess = elementRegistry.get('SubProcess');
@@ -431,7 +431,7 @@ describe('features/popup-menu - replace menu provider', function() {
     describe('parallel toggle button', function() {
 
       it('should toggle parallel marker off',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var task = elementRegistry.get('ParallelTask');
@@ -452,7 +452,7 @@ describe('features/popup-menu - replace menu provider', function() {
       );
 
 
-      it('should toggle parallel marker on', inject(function(bpmnReplace, elementRegistry) {
+      it('should toggle parallel marker on', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('Task');
@@ -473,7 +473,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set sequential button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set sequential button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask');
@@ -492,7 +492,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set loop button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set loop button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask');
@@ -511,7 +511,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set loop characteristics type', inject(function(bpmnReplace, elementRegistry) {
+      it('should set loop characteristics type', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask'),
@@ -557,7 +557,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     describe('sequential toggle button', function() {
 
-      it('should toggle sequential marker off', inject(function(bpmnReplace, elementRegistry) {
+      it('should toggle sequential marker off', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask');
@@ -577,7 +577,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should toggle sequential marker on', inject(function(bpmnReplace, elementRegistry) {
+      it('should toggle sequential marker on', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('Task');
@@ -598,7 +598,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set loop button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set loop button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask');
@@ -617,7 +617,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set parallel button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set parallel button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('ParallelTask');
@@ -636,7 +636,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set loop characteristics type', inject(function(bpmnReplace, elementRegistry) {
+      it('should set loop characteristics type', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask'),
@@ -682,7 +682,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     describe('loop toggle button', function() {
 
-      it('should toggle loop marker off', inject(function(bpmnReplace, elementRegistry) {
+      it('should toggle loop marker off', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('LoopTask');
@@ -702,7 +702,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should toggle loop marker on', inject(function(bpmnReplace, elementRegistry) {
+      it('should toggle loop marker on', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('Task');
@@ -722,7 +722,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set sequential button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set sequential button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask');
@@ -741,7 +741,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set parallel button inactive', inject(function(bpmnReplace, elementRegistry) {
+      it('should set parallel button inactive', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('ParallelTask');
@@ -760,7 +760,7 @@ describe('features/popup-menu - replace menu provider', function() {
       }));
 
 
-      it('should set loop characteristics type', inject(function(bpmnReplace, elementRegistry) {
+      it('should set loop characteristics type', inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask'),
@@ -852,7 +852,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     beforeEach(bootstrapModeler(diagramXMLMarkers, { modules: testModules }));
 
-    it('should retain the loop characteristics', inject(function(bpmnReplace, elementRegistry) {
+    it('should retain the loop characteristics', inject(function(elementRegistry) {
 
       // given
       var task = elementRegistry.get('SequentialTask');
@@ -871,7 +871,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should retain the loop characteristics for call activites',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var task = elementRegistry.get('SequentialTask');
@@ -891,7 +891,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should retain expanded status for sub processes',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var subProcess = elementRegistry.get('SubProcess');
@@ -909,7 +909,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should replace sub processes -> event sub process',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var subProcess = elementRegistry.get('SubProcess');
@@ -927,7 +927,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should replace event sub processes -> sub process',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var eventSubProcess = elementRegistry.get('EventSubProcess');
@@ -945,7 +945,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should retain the loop characteristics and the expanded status for transactions',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var transaction = elementRegistry.get('Transaction');
@@ -963,12 +963,16 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should not retain the loop characteristics morphing to an event sub process',
-      inject(function(bpmnReplace, elementRegistry, modeling) {
+      inject(function(bpmnFactory, elementRegistry, modeling) {
 
         // given
         var transaction = elementRegistry.get('Transaction');
 
-        modeling.updateProperties(transaction, { loopCharacteristics: { isparallel: true } });
+        modeling.updateProperties(transaction, {
+          loopCharacteristics: bpmnFactory.create('bpmn:MultiInstanceLoopCharacteristics', {
+            isParallel: true
+          })
+        });
 
         openPopup(transaction);
 
@@ -983,7 +987,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
     it('should retain the expanded property morphing to an event sub processes',
-      inject(function(bpmnReplace, elementRegistry) {
+      inject(function(elementRegistry) {
 
         // given
         var transaction = elementRegistry.get('Transaction');
@@ -1009,7 +1013,7 @@ describe('features/popup-menu - replace menu provider', function() {
       beforeEach(bootstrapModeler(diagramXMLReplace, { modules: testModules }));
 
       it('should contain all except the current one',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var startEvent = elementRegistry.get('StartEvent_1');
@@ -1025,7 +1029,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       it('should contain all start events inside event sub process except the current one',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var startEvent = elementRegistry.get('StartEvent_3');
@@ -1066,7 +1070,7 @@ describe('features/popup-menu - replace menu provider', function() {
       );
 
       it('should contain only start event, end event and intermediate throw event inside sub process except the current one',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var startEvent = elementRegistry.get('StartEvent_2');
@@ -1085,7 +1089,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       it('should contain all intermediate events except the current one',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var intermediateEvent = elementRegistry.get('IntermediateThrowEvent_1');
@@ -1102,7 +1106,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       it('should contain all end events except the current one',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var endEvent = elementRegistry.get('EndEvent_1');
@@ -1259,7 +1263,7 @@ describe('features/popup-menu - replace menu provider', function() {
       beforeEach(bootstrapModeler(diagramXMLReplace, { modules: testModules }));
 
       it('should contain all boundary events (except for cancel and currently active) for an interrupting boundary event',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var boundaryEvent = elementRegistry.get('BoundaryEvent_1');
@@ -1276,7 +1280,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       it('should contain all boundary events (except for cancel and currently active) for a non interrupting boundary event',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var boundaryEvent = elementRegistry.get('BoundaryEvent_2');
@@ -1293,7 +1297,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       it('should contain compensation boundary event',
-        inject(function(bpmnReplace, elementRegistry) {
+        inject(function(elementRegistry) {
 
           // given
           var boundaryEvent = elementRegistry.get('BoundaryEvent_1');

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -1943,7 +1943,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       [
-        'bpmn:Activity',
+        'bpmn:Task',
         'bpmn:EndEvent',
         'bpmn:IntermediateThrowEvent',
         'bpmn:IntermediateCatchEvent'
@@ -2242,7 +2242,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
 
       [
-        'bpmn:Activity',
+        'bpmn:Task',
         'bpmn:EndEvent',
         'bpmn:IntermediateThrowEvent',
         'bpmn:IntermediateCatchEvent'

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -181,7 +181,7 @@ describe('features/replace - bpmn replace', function() {
                 eventDefinitionType: 'bpmn:TimerEventDefinition'
               };
 
-          var eventDefinitions = boundaryBo.eventDefinitions.slice();
+          var eventDefinitions = boundaryBo.get('eventDefinitions').slice();
 
           // when
           var newElement = bpmnReplace.replaceElement(boundaryEvent, newElementData);
@@ -192,7 +192,7 @@ describe('features/replace - bpmn replace', function() {
 
           expect(is(newBo, 'bpmn:BoundaryEvent')).to.be.true;
 
-          expect(newBo.eventDefinitions).to.jsonEqual(eventDefinitions, skipId);
+          expect(newBo.get('eventDefinitions')).to.jsonEqual(eventDefinitions, skipId);
 
           expect(newBo.cancelActivity).to.be.true;
         })
@@ -211,7 +211,7 @@ describe('features/replace - bpmn replace', function() {
                 cancelActivity: false
               };
 
-          var eventDefinitions = boundaryBo.eventDefinitions.slice();
+          var eventDefinitions = boundaryBo.get('eventDefinitions').slice();
 
           // when
           var newElement = bpmnReplace.replaceElement(boundaryEvent, newElementData);
@@ -222,7 +222,7 @@ describe('features/replace - bpmn replace', function() {
 
           expect(is(newBo, 'bpmn:BoundaryEvent')).to.be.true;
 
-          expect(newBo.eventDefinitions).to.jsonEqual(eventDefinitions, skipId);
+          expect(newBo.get('eventDefinitions')).to.jsonEqual(eventDefinitions, skipId);
 
           expect(newBo.cancelActivity).to.be.false;
         })
@@ -244,7 +244,7 @@ describe('features/replace - bpmn replace', function() {
           var newElement = bpmnReplace.replaceElement(boundaryEvent, newElementData);
 
           var newBo = newElement.businessObject;
-          var newEventDefinitions = newBo.eventDefinitions;
+          var newEventDefinitions = newBo.get('eventDefinitions');
           var newEventDefinition = newEventDefinitions[0];
 
           // then
@@ -273,7 +273,7 @@ describe('features/replace - bpmn replace', function() {
           var newElement = bpmnReplace.replaceElement(boundaryEvent, newElementData);
 
           var newBo = newElement.businessObject;
-          var newEventDefinitions = newBo.eventDefinitions;
+          var newEventDefinitions = newBo.get('eventDefinitions');
           var newEventDefinition = newEventDefinitions[0];
 
           // then
@@ -1220,7 +1220,7 @@ describe('features/replace - bpmn replace', function() {
         })[0];
 
         // then
-        expect(startEventAfter.businessObject.eventDefinitions).not.to.exist;
+        expect(startEventAfter.businessObject.get('eventDefinitions')).is.empty;
       })
     );
 
@@ -1240,7 +1240,7 @@ describe('features/replace - bpmn replace', function() {
         })[0];
 
         // then
-        expect(startEventAfter.businessObject.eventDefinitions[0].$type).to.equal('bpmn:MessageEventDefinition');
+        expect(startEventAfter.businessObject.get('eventDefinitions')[0].$type).to.equal('bpmn:MessageEventDefinition');
       })
     );
 
@@ -1642,7 +1642,7 @@ describe('features/replace - bpmn replace', function() {
           eventDefinitionType: 'bpmn:MessageEventDefinition'
         });
 
-        var parent = messageEvent.businessObject.eventDefinitions[0].$parent;
+        var parent = messageEvent.businessObject.get('eventDefinitions')[0].$parent;
 
         expect(parent).to.exist;
         expect(parent).to.equal(messageEvent.businessObject);
@@ -1662,7 +1662,7 @@ describe('features/replace - bpmn replace', function() {
           eventDefinitionType: 'bpmn:ConditionalEventDefinition'
         });
 
-        var definition = messageEvent.businessObject.eventDefinitions[0];
+        var definition = messageEvent.businessObject.get('eventDefinitions')[0];
 
         // then
         expect(definition.condition).to.exist;


### PR DESCRIPTION
![brave_LhiZ5ATZjp](https://github.com/bpmn-io/bpmn-js/assets/7633572/de791b9d-ac20-45e0-9fe0-56b998d8319d)

## Changes

* context pad
  * preview append on hover
* renderer
  * `fill`, `stroke`, `width` and `height` can be overridden
  * no other attributes can be overridden
  * public API only exposes renderers for actual BPMN elements

## Follow-Ups

* https://github.com/bpmn-io/diagram-js/issues/816

---

Closes https://github.com/bpmn-io/bpmn-js/issues/1990