### PR TITLE
feat(modeling): keep interrupting config when replacing elements

### DIFF
--- a/lib/features/modeling/behavior/NonInterruptingBehavior.js
+++ b/lib/features/modeling/behavior/NonInterruptingBehavior.js
@@ -1,0 +1,41 @@
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import inherits from 'inherits-browser';
+
+import { canBeNonInterrupting, getInterruptingProperty } from './util/NonInterruptingUtil';
+import { getBusinessObject } from '../../../util/ModelUtil';
+
+export default function NonInterruptingBehavior(injector, modeling) {
+  injector.invoke(CommandInterceptor, this);
+
+  this.postExecuted('shape.replace', function(event) {
+    const oldShape = event.context.oldShape;
+    const newShape = event.context.newShape;
+    const hints = event.context.hints;
+
+    if (!canBeNonInterrupting(newShape)) {
+      return;
+    }
+
+    const property = getInterruptingProperty(newShape);
+    const isExplicitChange = hints.targetElement && hints.targetElement[property] !== undefined;
+
+    if (isExplicitChange) {
+      return;
+    }
+
+    const isOldInterrupting = getBusinessObject(oldShape).get(property);
+    const isNewInterruptingDefault = getBusinessObject(newShape).get(property);
+
+    if (isOldInterrupting === isNewInterruptingDefault) {
+      return;
+    }
+
+    modeling.updateProperties(newShape, {
+      [property]: isOldInterrupting
+    });
+  });
+}
+
+NonInterruptingBehavior.$inject = [ 'injector', 'modeling' ];
+
+inherits(NonInterruptingBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -19,6 +19,7 @@ import IsHorizontalFix from './IsHorizontalFix';
 import LabelBehavior from './LabelBehavior';
 import LayoutConnectionBehavior from './LayoutConnectionBehavior';
 import MessageFlowBehavior from './MessageFlowBehavior';
+import NonInterruptingBehavior from './NonInterruptingBehavior';
 import RemoveEmbeddedLabelBoundsBehavior from './RemoveEmbeddedLabelBoundsBehavior';
 import RemoveElementBehavior from './RemoveElementBehavior';
 import RemoveParticipantBehavior from './RemoveParticipantBehavior';
@@ -62,6 +63,7 @@ export default {
     'labelBehavior',
     'layoutConnectionBehavior',
     'messageFlowBehavior',
+    'nonInterruptingBehavior',
     'removeElementBehavior',
     'removeEmbeddedLabelBoundsBehavior',
     'removeParticipantBehavior',
@@ -100,6 +102,7 @@ export default {
   labelBehavior: [ 'type', LabelBehavior ],
   layoutConnectionBehavior: [ 'type', LayoutConnectionBehavior ],
   messageFlowBehavior: [ 'type', MessageFlowBehavior ],
+  nonInterruptingBehavior: [ 'type', NonInterruptingBehavior ],
   removeElementBehavior: [ 'type', RemoveElementBehavior ],
   removeEmbeddedLabelBoundsBehavior: [ 'type', RemoveEmbeddedLabelBoundsBehavior ],
   removeParticipantBehavior: [ 'type', RemoveParticipantBehavior ],

--- a/lib/features/modeling/behavior/util/NonInterruptingUtil.js
+++ b/lib/features/modeling/behavior/util/NonInterruptingUtil.js
@@ -1,0 +1,33 @@
+import { isEventSubProcess } from '../../../../util/DiUtil';
+import { getBusinessObject, is } from '../../../../util/ModelUtil';
+
+export const NON_INTERRUPTING_EVENT_TYPES = [
+  'bpmn:MessageEventDefinition',
+  'bpmn:TimerEventDefinition',
+  'bpmn:EscalationEventDefinition',
+  'bpmn:ConditionalEventDefinition',
+  'bpmn:SignalEventDefinition'
+];
+
+export function canBeNonInterrupting(shape) {
+
+  const businessObject = getBusinessObject(shape);
+
+  if (
+    !is(businessObject, 'bpmn:BoundaryEvent') &&
+    !(is(businessObject, 'bpmn:StartEvent') && isEventSubProcess(businessObject.$parent))
+  ) {
+    return false;
+  }
+
+  const eventDefinitions = businessObject.get('eventDefinitions');
+  if (!eventDefinitions || !eventDefinitions.length) {
+    return false;
+  }
+
+  return NON_INTERRUPTING_EVENT_TYPES.some(event => is(eventDefinitions[0], event));
+}
+
+export function getInterruptingProperty(shape) {
+  return is(shape, 'bpmn:BoundaryEvent') ? 'cancelActivity' : 'isInterrupting';
+}

--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -19,6 +19,8 @@ import {
 } from 'min-dash';
 
 import * as replaceOptions from '../replace/ReplaceOptions';
+import { canBeNonInterrupting, getInterruptingProperty } from '../modeling/behavior/util/NonInterruptingUtil';
+import Icons from './util/Icons';
 
 /**
  * @typedef {import('../modeling/BpmnFactory').default} BpmnFactory
@@ -312,6 +314,13 @@ ReplaceMenuProvider.prototype.getPopupMenuHeaderEntries = function(target) {
     headerEntries = {
       ...headerEntries,
       ...this._getAdHocHeaderEntries(target)
+    };
+  }
+
+  if (canBeNonInterrupting(target)) {
+    headerEntries = {
+      ...headerEntries,
+      ...this._getNonInterruptingHeaderEntries(target)
     };
   }
 
@@ -639,6 +648,32 @@ ReplaceMenuProvider.prototype._getAdHocHeaderEntries = function(element) {
             layoutConnection: false
           });
         }
+      }
+    }
+  };
+};
+
+
+ReplaceMenuProvider.prototype._getNonInterruptingHeaderEntries = function(element) {
+  const translate = this._translate;
+  const businessObject = getBusinessObject(element);
+  const self = this;
+
+  const interruptingProperty = getInterruptingProperty(element);
+
+  const icon = is(element, 'bpmn:BoundaryEvent') ? Icons['intermediate-event-non-interrupting'] : Icons['start-event-non-interrupting'];
+
+  const isNonInterrupting = !businessObject[interruptingProperty];
+
+  return {
+    'toggle-non-interrupting': {
+      imageHtml: icon,
+      title: translate('Toggle Non-Interrupting'),
+      active: isNonInterrupting,
+      action: function() {
+        self._modeling.updateProperties(element, {
+          [interruptingProperty]: !!isNonInterrupting
+        });
       }
     }
   };

--- a/lib/features/popup-menu/util/Icons.js
+++ b/lib/features/popup-menu/util/Icons.js
@@ -1,0 +1,15 @@
+export default {
+  'start-event-non-interrupting': `
+  <svg viewBox="0 0 2048 2048" xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(0 995.64)">
+      <path d="m1899 28.357c21.545 567.43-598.38 1023.5-1133.6 835.92-548.09-147.21-801.57-873.95-463.59-1330 302.62-480.3 1071.7-507.54 1407.6-49.847 122.14 153.12 190.07 348.07 189.59 543.91z" fill="none" stroke="currentColor" stroke-dasharray="418.310422, 361.2328165" stroke-linecap="round" stroke-width="100"/>
+    </g>
+  </svg>`,
+  'intermediate-event-non-interrupting': `
+  <svg viewBox="0 0 2048 2048" xmlns="http://www.w3.org/2000/svg">
+     <g transform="translate(0 995.64)" fill="none" stroke="currentColor" stroke-linecap="round">
+        <circle cx="1024" cy="28.357" r="875" stroke-dasharray="418.310422, 361.2328165" stroke-width="100"/>
+        <circle cx="1024" cy="28.357" r="685" stroke-dasharray="348.31044857,261.23283643" stroke-dashoffset="500" stroke-width="100"/>
+     </g>
+  </svg>`
+};

--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -321,7 +321,7 @@ export default function BpmnReplace(
       newElement.x = element.x + (element.width - newElement.width) / 2;
     }
 
-    return replace.replaceElement(element, newElement, hints);
+    return replace.replaceElement(element, newElement, { ...hints, targetElement });
   }
 
   this.replaceElement = replaceElement;

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -611,7 +611,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-message',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -620,7 +621,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-timer',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -629,7 +631,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-escalation',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -638,7 +641,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-condition',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -647,7 +651,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-error',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition'
+      eventDefinitionType: 'bpmn:ErrorEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -656,7 +661,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-cancel',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CancelEventDefinition'
+      eventDefinitionType: 'bpmn:CancelEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -665,7 +671,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-signal',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -674,7 +681,8 @@ export var BOUNDARY_EVENT = [
     className: 'bpmn-icon-intermediate-event-catch-compensation',
     target: {
       type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
+      eventDefinitionType: 'bpmn:CompensateEventDefinition',
+      cancelActivity: true
     }
   },
   {
@@ -739,7 +747,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-message',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -748,7 +757,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-timer',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -757,7 +767,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-condition',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -766,7 +777,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-signal',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -775,7 +787,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-error',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition'
+      eventDefinitionType: 'bpmn:ErrorEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -784,7 +797,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-escalation',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      isInterrupting: true
     }
   },
   {
@@ -793,7 +807,8 @@ export var EVENT_SUB_PROCESS_START_EVENT = [
     className: 'bpmn-icon-start-event-compensation',
     target: {
       type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
+      eventDefinitionType: 'bpmn:CompensateEventDefinition',
+      isInterrupting: true
     }
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^8.0.1",
-        "diagram-js": "^12.6.0",
+        "diagram-js": "^12.7.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.6.0.tgz",
-      "integrity": "sha512-dl6AC7wLgL689Z63jIE3mBMixZVpLHfXE2peMcsjT23BM5jyQ6T7vrBRKtk+Hl/hFkXc+8xqqTMafVX6lDBBkw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.0.tgz",
+      "integrity": "sha512-w/FGYFEpA6QqBBUah2mrJkTKpxxWCeH+fW4kV7vEQLPj0ChNwm49gbKVX+0zRhJhakBmjgbX2zfpvEJbEcuU2g==",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^2.0.0",
@@ -16494,9 +16494,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.6.0.tgz",
-      "integrity": "sha512-dl6AC7wLgL689Z63jIE3mBMixZVpLHfXE2peMcsjT23BM5jyQ6T7vrBRKtk+Hl/hFkXc+8xqqTMafVX6lDBBkw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.0.tgz",
+      "integrity": "sha512-w/FGYFEpA6QqBBUah2mrJkTKpxxWCeH+fW4kV7vEQLPj0ChNwm49gbKVX+0zRhJhakBmjgbX2zfpvEJbEcuU2g==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^8.0.1",
-    "diagram-js": "^12.6.0",
+    "diagram-js": "^12.7.0",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.5",
     "inherits-browser": "^0.1.0",

--- a/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AttachEventBehaviorSpec.js
@@ -181,12 +181,12 @@ describe('features/modeling/behavior - attach events', function() {
 
           ids.forEach(function(id) {
 
-            it('should copy event definition', inject(function(elementRegistry, modeling) {
+            it('should copy event definition ' + id, inject(function(elementRegistry, modeling) {
 
               // given
               var element = elementRegistry.get(id),
                   elementBo = getBusinessObject(element),
-                  eventDefinitions = elementBo.eventDefinitions,
+                  eventDefinitions = elementBo.get('eventDefinitions'),
                   task = elementRegistry.get('Task_1');
 
               // when

--- a/test/spec/features/modeling/behavior/NonInterruptingBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/NonInterruptingBehavior.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0y57lde" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.16.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_0jdll32" isExecutable="true">
+    <bpmn:subProcess id="Activity_1szoedm" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_interrupting">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1hnz3qy" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="StartEvent_nonInterrupting" isInterrupting="false">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0ba7a8k" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_interrupting" attachedToRef="Task_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0fe1m2n" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_nonInterrupting" cancelActivity="false" attachedToRef="Task_1">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1f5jywk" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jdll32">
+      <bpmndi:BPMNShape id="Activity_1nblmk5_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ptz4rb_di" bpmnElement="Activity_1szoedm" isExpanded="true">
+        <dc:Bounds x="160" y="200" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19plmrz_di" bpmnElement="StartEvent_interrupting">
+        <dc:Bounds x="200" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tnq080_di" bpmnElement="StartEvent_nonInterrupting">
+        <dc:Bounds x="262" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18h0ja5_di" bpmnElement="BoundaryEvent_interrupting">
+        <dc:Bounds x="172" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xogxo6_di" bpmnElement="BoundaryEvent_nonInterrupting">
+        <dc:Bounds x="212" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/NonInterruptingBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/NonInterruptingBehaviorSpec.js
@@ -1,0 +1,217 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+
+
+describe('features/modeling - non interrupting behavior', function() {
+
+  const testModules = [ coreModule, modelingModule ];
+
+  const processDiagramXML = require('./NonInterruptingBehavior.bpmn');
+
+  beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+  let event;
+
+  describe('start events', function() {
+
+    describe('interrupting', function() {
+
+      beforeEach(inject(function(elementRegistry) {
+        event = elementRegistry.get('StartEvent_interrupting');
+      }));
+
+
+      it('should stay interrupting when replacing',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.isInterrupting).to.be.true;
+        })
+      );
+
+
+      it('should become non-interrupting when explicitly replacing with non-interrupting event',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition',
+            isInterrupting: false
+          });
+
+          // then
+          expect(newEvent.businessObject.isInterrupting).to.be.false;
+        })
+      );
+
+    });
+
+
+    describe('non-interrupting', function() {
+
+      beforeEach(inject(function(elementRegistry) {
+        event = elementRegistry.get('StartEvent_nonInterrupting');
+      }));
+
+
+      it('should stay non-interrupting when replacing',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.isInterrupting).to.be.false;
+        })
+      );
+
+
+      it('should become interrupting when explicitly replacing with interrupting event',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition',
+            isInterrupting: true
+          });
+
+          // then
+          expect(newEvent.businessObject.isInterrupting).to.be.true;
+        })
+      );
+
+
+      it('should become interrupting when replacing with interrupting event type',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:StartEvent',
+            eventDefinitionType: 'bpmn:ErrorEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.isInterrupting).to.be.true;
+        })
+      );
+
+    });
+
+  });
+
+
+  describe('boundary events', function() {
+
+    describe('interrupting', function() {
+
+      beforeEach(inject(function(elementRegistry) {
+        event = elementRegistry.get('BoundaryEvent_interrupting');
+      }));
+
+
+      it('should stay interrupting when replacing',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:BoundaryEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.cancelActivity).to.be.true;
+        })
+      );
+
+
+      it('should become non-interrupting when explicitly replacing with non-interrupting event',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:BoundaryEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition',
+            cancelActivity: false
+          });
+
+          // then
+          expect(newEvent.businessObject.cancelActivity).to.be.false;
+        })
+      );
+
+    });
+
+
+    describe('non-interrupting', function() {
+
+      beforeEach(inject(function(elementRegistry) {
+        event = elementRegistry.get('BoundaryEvent_nonInterrupting');
+      }));
+
+
+      it('should stay non-interrupting when replacing',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:BoundaryEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.cancelActivity).to.be.false;
+        })
+      );
+
+
+      it('should become interrupting when explicitly replacing with interrupting event',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:BoundaryEvent',
+            eventDefinitionType: 'bpmn:TimerEventDefinition',
+            cancelActivity: true
+          });
+
+          // then
+          expect(newEvent.businessObject.cancelActivity).to.be.true;
+        })
+      );
+
+
+      it('should become interrupting when replacing with interrupting event type',
+        inject(function(bpmnReplace) {
+
+          // when
+          const newEvent = bpmnReplace.replaceElement(event, {
+            type: 'bpmn:BoundaryEvent',
+            eventDefinitionType: 'bpmn:ErrorEventDefinition'
+          });
+
+          // then
+          expect(newEvent.businessObject.cancelActivity).to.be.true;
+        })
+      );
+
+    });
+
+  });
+
+});

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -780,6 +780,104 @@ describe('features/popup-menu - replace menu provider', function() {
     });
 
 
+    describe('non-interrupting toggle', function() {
+      beforeEach(bootstrapModeler(diagramXMLReplace,{
+        modules: Object.assign(testModules, camundaModdleModule),
+        moddleExtensions: {
+          camunda: camundaPackage
+        }
+      }));
+
+      describe('start events', function() {
+
+        it('should toggle non-interrupting marker off', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var event = elementRegistry.get('StartEvent_3');
+
+          openPopup(event);
+
+          // when
+          triggerAction('toggle-non-interrupting');
+
+          openPopup(event);
+
+          var nonInterruptingEntry = queryEntry('toggle-non-interrupting');
+
+          // then
+          expect(event.businessObject.isInterrupting).to.be.true;
+          expect(domClasses(nonInterruptingEntry).has('active')).to.be.false;
+        }));
+
+
+        it('should toggle non-interrupting marker on', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var event = elementRegistry.get('StartEvent_6');
+
+          openPopup(event);
+
+          // when
+          triggerAction('toggle-non-interrupting');
+
+          openPopup(event);
+
+          var nonInterruptingEntry = queryEntry('toggle-non-interrupting');
+
+          // then
+          expect(event.businessObject.isInterrupting).to.be.false;
+          expect(domClasses(nonInterruptingEntry).has('active')).to.be.true;
+        }));
+
+      });
+
+
+      describe('boundary events', function() {
+
+        it('should toggle non-interrupting marker off', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var event = elementRegistry.get('BoundaryEvent_1');
+
+          openPopup(event);
+
+          // when
+          triggerAction('toggle-non-interrupting');
+
+          openPopup(event);
+
+          var nonInterruptingEntry = queryEntry('toggle-non-interrupting');
+
+          // then
+          expect(event.businessObject.cancelActivity).to.be.true;
+          expect(domClasses(nonInterruptingEntry).has('active')).to.be.false;
+        }));
+
+
+        it('should toggle non-interrupting marker on', inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var event = elementRegistry.get('BoundaryEvent_2');
+
+          openPopup(event);
+
+          // when
+          triggerAction('toggle-non-interrupting');
+
+          openPopup(event);
+
+          var nonInterruptingEntry = queryEntry('toggle-non-interrupting');
+
+          // then
+          expect(event.businessObject.cancelActivity).to.be.false;
+          expect(domClasses(nonInterruptingEntry).has('active')).to.be.true;
+        }));
+
+      });
+
+    });
+
+
     describe('integration', function() {
 
       it('should toggle sequential -> undo to parallel', inject(function(elementRegistry, commandStack) {
@@ -1023,7 +1121,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
           // then
           expect(queryEntry('replace-with-none-start')).to.be.null;
-          expect(queryEntries()).to.have.length(6);
+          expect(queryBodyEntries()).to.have.length(6);
         })
       );
 
@@ -1041,7 +1139,7 @@ describe('features/popup-menu - replace menu provider', function() {
           expect(queryEntry('replace-with-non-interrupting-message-start')).to.be.null;
           expect(queryEntry('replace-with-message-start')).to.exist;
 
-          expect(queryEntries()).to.have.length(11);
+          expect(queryBodyEntries()).to.have.length(11);
         })
       );
 
@@ -1065,9 +1163,59 @@ describe('features/popup-menu - replace menu provider', function() {
           expect(queryEntry('replace-with-conditional-start')).to.exist;
           expect(queryEntry('replace-with-non-interrupting-conditional-start')).to.be.null;
 
-          expect(queryEntries()).to.have.length(11);
+          expect(queryBodyEntries()).to.have.length(11);
         })
       );
+
+
+      it('should include non-interrupting toggle for non interrupting start event',
+        inject(function(elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_3');
+
+          // when
+          openPopup(startEvent);
+
+          // then
+          expect(queryEntry('toggle-non-interrupting')).to.exist;
+        })
+      );
+
+
+      it('should include non-interrupting toggle for interrupting start event',
+        inject(function(elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_6');
+
+          // when
+          openPopup(startEvent);
+
+          // then
+          expect(queryEntry('toggle-non-interrupting')).to.exist;
+        })
+      );
+
+
+      it('should NOT include non-interrupting toggle for start events that must be interrupting',
+        inject(function(bpmnReplace, elementRegistry) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent_3');
+
+          var newElement = bpmnReplace.replaceElement(startEvent, {
+            type: 'bpmn:StartEvent'
+          });
+
+          // when
+          openPopup(newElement);
+
+          // then
+          expect(queryEntry('toggle-non-interrupting')).not.to.exist;
+        })
+      );
+
 
       it('should contain only start event, end event and intermediate throw event inside sub process except the current one',
         inject(function(elementRegistry) {
@@ -1083,7 +1231,7 @@ describe('features/popup-menu - replace menu provider', function() {
           expect(queryEntry('replace-with-none-end')).to.exist;
           expect(queryEntry('replace-with-none-intermediate-throwing')).to.exist;
 
-          expect(queryEntries()).to.have.length(2);
+          expect(queryBodyEntries()).to.have.length(2);
         })
       );
 
@@ -1100,7 +1248,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // then
           expect(queryEntry('replace-with-none-intermediate-throw')).to.be.null;
 
-          expect(queryEntries()).to.have.length(12);
+          expect(queryBodyEntries()).to.have.length(12);
         })
       );
 
@@ -1117,7 +1265,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // then
           expect(queryEntry('replace-with-none-end')).to.be.null;
 
-          expect(queryEntries()).to.have.length(8);
+          expect(queryBodyEntries()).to.have.length(8);
         })
       );
 
@@ -1159,7 +1307,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(endEvent);
 
             // then
-            expect(queryEntries()).to.have.length(9);
+            expect(queryBodyEntries()).to.have.length(9);
 
             expect(queryEntry('replace-with-cancel-end')).to.exist;
           })
@@ -1176,7 +1324,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(endEvent);
 
             // then
-            expect(queryEntries()).to.have.length(9);
+            expect(queryBodyEntries()).to.have.length(9);
             expect(queryEntry('replace-with-cancel-end')).to.be.null;
           })
         );
@@ -1192,7 +1340,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(endEvent);
 
             // then
-            expect(queryEntries()).to.have.length(8);
+            expect(queryBodyEntries()).to.have.length(8);
 
             expect(queryEntry('replace-with-cancel-end')).to.be.null;
           })
@@ -1213,7 +1361,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(boundaryEvent);
 
             // then
-            expect(queryEntries()).to.have.length(13);
+            expect(queryBodyEntries()).to.have.length(13);
 
             expect(queryEntry('replace-with-cancel-boundary')).to.exist;
           })
@@ -1230,7 +1378,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(boundaryEvent);
 
             // then
-            expect(queryEntries()).to.have.length(12);
+            expect(queryBodyEntries()).to.have.length(12);
 
             expect(queryEntry('replace-with-cancel-boundary')).to.be.null;
           })
@@ -1247,7 +1395,7 @@ describe('features/popup-menu - replace menu provider', function() {
             openPopup(boundaryEvent);
 
             // then
-            expect(queryEntries()).to.have.length(12);
+            expect(queryBodyEntries()).to.have.length(12);
 
             expect(queryEntry('replace-with-cancel-boundary')).to.be.null;
           })
@@ -1274,7 +1422,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // then
           expect(queryEntry('replace-with-conditional-intermediate-catch')).to.be.null;
           expect(queryEntry('replace-with-cancel-boundary')).to.be.null;
-          expect(queryEntries()).to.have.length(11);
+          expect(queryBodyEntries()).to.have.length(11);
         })
       );
 
@@ -1291,7 +1439,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // then
           expect(queryEntry('replace-with-non-interrupting-message-intermediate-catch')).to.be.null;
           expect(queryEntry('replace-with-cancel-boundary')).to.be.null;
-          expect(queryEntries()).to.have.length(11);
+          expect(queryBodyEntries()).to.have.length(11);
         })
       );
 
@@ -1331,7 +1479,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(sequenceFlow);
 
         // then
-        expect(queryEntries()).to.have.length(1);
+        expect(queryBodyEntries()).to.have.length(1);
       }));
 
 
@@ -1344,7 +1492,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(sequenceFlow);
 
         // then
-        expect(queryEntries()).to.have.length(2);
+        expect(queryBodyEntries()).to.have.length(2);
       }));
 
 
@@ -1357,7 +1505,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(sequenceFlow);
 
         // then
-        expect(queryEntries()).to.have.length(0);
+        expect(queryBodyEntries()).to.have.length(0);
       }));
 
     });
@@ -1475,7 +1623,7 @@ describe('features/popup-menu - replace menu provider', function() {
         // then
         expect(conditionalFlowEntry).to.exist;
 
-        expect(queryEntries()).to.have.length(2);
+        expect(queryBodyEntries()).to.have.length(2);
       }));
 
 
@@ -1488,7 +1636,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(sequenceFlow);
 
         // then
-        expect(queryEntries()).to.have.length(0);
+        expect(queryBodyEntries()).to.have.length(0);
       }));
 
     });
@@ -1599,7 +1747,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(dataObjectReference);
 
         // then
-        expect(queryEntries()).to.have.length(2);
+        expect(queryBodyEntries()).to.have.length(1);
         expect(queryEntry('toggle-is-collection')).to.exist;
         expect(queryEntry('replace-with-data-store-reference')).to.exist;
         expect(queryEntry('replace-with-data-object-reference')).to.be.null;
@@ -1635,7 +1783,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(dataStoreReference);
 
         // then
-        expect(queryEntries()).to.have.length(1);
+        expect(queryBodyEntries()).to.have.length(1);
         expect(queryEntry('toggle-is-collection')).to.be.null;
         expect(queryEntry('replace-with-data-store-reference')).to.be.null;
         expect(queryEntry('replace-with-data-object-reference')).to.exist;
@@ -1671,7 +1819,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(dataStoreReferenceWithinParticipant);
 
         // then
-        expect(queryEntries()).to.have.length(1);
+        expect(queryBodyEntries()).to.have.length(1);
         expect(queryEntry('replace-with-data-object-reference')).to.exist;
       }));
 
@@ -1685,7 +1833,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(dataStoreReferenceOutsideParticipant);
 
         // then
-        expect(queryEntries()).to.have.length(0);
+        expect(queryBodyEntries()).to.have.length(0);
         expect(queryEntry('replace-with-data-object-reference')).to.be.null;
       }));
 
@@ -2485,7 +2633,7 @@ describe('features/popup-menu - replace menu provider', function() {
       openPopup(startEvent);
 
       // then
-      expect(queryEntries()).to.have.length.above(0);
+      expect(queryBodyEntries()).to.have.length.above(0);
     }));
 
 
@@ -2503,7 +2651,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(startEvent);
 
         // then
-        expect(queryEntries()).to.have.length.above(0);
+        expect(queryBodyEntries()).to.have.length.above(0);
       })
     );
 
@@ -2522,7 +2670,7 @@ describe('features/popup-menu - replace menu provider', function() {
         openPopup(startEvent);
 
         // then
-        expect(queryEntries()).to.have.length(0);
+        expect(queryBodyEntries()).to.have.length(0);
       })
     );
 
@@ -2588,10 +2736,10 @@ function queryEntry(id) {
   return domQuery('.djs-popup [data-id="' + id + '"]', container);
 }
 
-function queryEntries() {
+function queryBodyEntries() {
   var container = getMenuContainer();
 
-  return domQueryAll('.djs-popup .entry', container);
+  return domQueryAll('.djs-popup .djs-popup-body .entry', container);
 }
 
 function queryEntryLabel(id) {

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -178,7 +178,8 @@ describe('features/replace - bpmn replace', function() {
               boundaryBo = boundaryEvent.businessObject,
               newElementData = {
                 type: 'bpmn:BoundaryEvent',
-                eventDefinitionType: 'bpmn:TimerEventDefinition'
+                eventDefinitionType: 'bpmn:TimerEventDefinition',
+                cancelActivity: true
               };
 
           var eventDefinitions = boundaryBo.get('eventDefinitions').slice();


### PR DESCRIPTION
This PR adds 2 new features:

 - Keep the interrupting state when replacing elements, when the interrupting state is not explicitly set. This is used when element-templates are applied to events  
![Recording 2023-11-01 at 13 24 20](https://github.com/bpmn-io/bpmn-js/assets/21984219/9b294a0a-f951-4184-8fb2-864d3e435f8f)

- Add a toggle header button to non-interrupting events
![image](https://github.com/bpmn-io/bpmn-js/assets/21984219/8e1c01d9-59d8-4642-94ff-661a7b78ab8d)


related to https://github.com/bpmn-io/bpmn-js-element-templates/issues/20
You can try out the integration with element templates here: https://marstamm.github.io/non-interrupting-modeling-demo/