### PR TITLE
Update `diagram-js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
-## 15.1.2 
+## 15.1.3
+
+* `FIX`: revert `djs-dragging` CSS class changes ([#2016](https://github.com/bpmn-io/bpmn-js/pull/2016))
+* `FIX`: clear context pad hover timeout on close ([#2016](https://github.com/bpmn-io/bpmn-js/pull/2016))
+* `DEPS`: update to `diagram-js@12.7.2`
+
+## 15.1.2
 
 * `FIX`: revert selection outline removal for connections ([#2011](https://github.com/bpmn-io/bpmn-js/pull/2011))
 * `DEPS`: update to `diagram-js@12.7.1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^8.0.1",
-        "diagram-js": "^12.7.1",
+        "diagram-js": "^12.7.2",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.1.tgz",
-      "integrity": "sha512-g5TqtbrTTIMepyrIXuRy7xS6paHnvnQajclm/rMJxGZp7/9kAK5zxELmvS0r+Z2S18h17eaDRxtsmosBVuOTcQ==",
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.2.tgz",
+      "integrity": "sha512-2s3JDdy3ccMnKRMTN9kmEnJ6g7EcsqH87KbutNKf25c7txCH+Xg8JPhc0DSzWZylorJVmCF6svezt55Sx2G3Ag==",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^2.0.0",
@@ -16494,9 +16494,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.1.tgz",
-      "integrity": "sha512-g5TqtbrTTIMepyrIXuRy7xS6paHnvnQajclm/rMJxGZp7/9kAK5zxELmvS0r+Z2S18h17eaDRxtsmosBVuOTcQ==",
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-12.7.2.tgz",
+      "integrity": "sha512-2s3JDdy3ccMnKRMTN9kmEnJ6g7EcsqH87KbutNKf25c7txCH+Xg8JPhc0DSzWZylorJVmCF6svezt55Sx2G3Ag==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.2",
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^8.0.1",
-    "diagram-js": "^12.7.1",
+    "diagram-js": "^12.7.2",
     "diagram-js-direct-editing": "^2.0.0",
     "ids": "^1.0.5",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
# Changes

* `FIX`: revert `djs-dragging` CSS class changes ([#2016](https://github.com/bpmn-io/bpmn-js/pull/2016))
* `FIX`: clear context pad hover timeout on close ([#2016](https://github.com/bpmn-io/bpmn-js/pull/2016))
* `DEPS`: update to `diagram-js@12.7.2`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
