### PR TITLE
Render Vertical Participants and Lanes

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -10,6 +10,7 @@ import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
 
 import {
   isExpanded,
+  isHorizontal,
   isEventSubProcess
 } from '../util/DiUtil';
 
@@ -1063,10 +1064,12 @@ export default function BpmnRenderer(
   }
 
   function renderLaneLabel(parentGfx, text, element, attrs = {}) {
+    var isHorizontalLane = isHorizontal(element);
+
     var textBox = renderLabel(parentGfx, text, {
       box: {
         height: 30,
-        width: getHeight(element, attrs),
+        width: isHorizontalLane ? getHeight(element, attrs) : getWidth(element, attrs),
       },
       align: 'center-middle',
       style: {
@@ -1074,9 +1077,10 @@ export default function BpmnRenderer(
       }
     });
 
-    var top = -1 * getHeight(element, attrs);
-
-    transform(textBox, 0, -top, 270);
+    if (isHorizontalLane) {
+      var top = -1 * getHeight(element, attrs);
+      transform(textBox, 0, -top, 270);
+    }
   }
 
   function renderActivity(parentGfx, element, attrs = {}) {
@@ -1794,12 +1798,13 @@ export default function BpmnRenderer(
       var participant = renderLane(parentGfx, element, attrs);
 
       var expandedParticipant = isExpanded(element);
+      var horizontalParticipant = isHorizontal(element);
 
       var semantic = getSemantic(element),
           name = semantic.get('name');
 
       if (expandedParticipant) {
-        drawLine(parentGfx, [
+        var waypoints = horizontalParticipant ? [
           {
             x: 30,
             y: 0
@@ -1808,20 +1813,43 @@ export default function BpmnRenderer(
             x: 30,
             y: getHeight(element, attrs)
           }
-        ], {
+        ] : [
+          {
+            x: 0,
+            y: 30
+          },
+          {
+            x: getWidth(element, attrs),
+            y: 30
+          }
+        ];
+
+        drawLine(parentGfx, waypoints, {
           stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
           strokeWidth: PARTICIPANT_STROKE_WIDTH
         });
 
         renderLaneLabel(parentGfx, name, element, attrs);
       } else {
-        renderLabel(parentGfx, name, {
-          box: getBounds(element, attrs),
+        var bounds = getBounds(element, attrs);
+
+        if (!horizontalParticipant) {
+          bounds.height = getWidth(element, attrs);
+          bounds.width = getHeight(element, attrs);
+        }
+
+        var textBox = renderLabel(parentGfx, name, {
+          box: bounds,
           align: 'center-middle',
           style: {
             fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
           }
         });
+
+        if (!horizontalParticipant) {
+          var top = -1 * getHeight(element, attrs);
+          transform(textBox, 0, -top, 270);
+        }
       }
 
       if (semantic.get('participantMultiplicity')) {

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -11,7 +11,11 @@ import {
 } from '../../util/ModelUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
-import { isExpanded } from '../../util/DiUtil';
+
+import {
+  isExpanded,
+  isHorizontal
+} from '../../util/DiUtil';
 
 import {
   getExternalLabelMid,
@@ -277,13 +281,19 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
 
   // adjust for expanded pools AND lanes
   if (is(element, 'bpmn:Lane') || isExpandedPool(element)) {
+    var isHorizontalLane = isHorizontal(element);
 
-    assign(bounds, {
+    var laneBounds = isHorizontalLane ? {
       width: bbox.height,
       height: 30 * zoom,
       x: bbox.x - bbox.height / 2 + (15 * zoom),
       y: mid.y - (30 * zoom) / 2
-    });
+    } : {
+      width: bbox.width,
+      height: 30 * zoom
+    };
+
+    assign(bounds, laneBounds);
 
     assign(style, {
       fontSize: defaultFontSize + 'px',
@@ -292,15 +302,42 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
       paddingBottom: (7 * zoom) + 'px',
       paddingLeft: (5 * zoom) + 'px',
       paddingRight: (5 * zoom) + 'px',
-      transform: 'rotate(-90deg)'
+      transform: isHorizontalLane ? 'rotate(-90deg)' : null
     });
   }
 
 
-  // internal labels for tasks and collapsed call activities,
-  // sub processes and participants
+  // internal labels for collapsed participants
+  if (isCollapsedPool(element)) {
+    var isHorizontalPool = isHorizontal(element);
+
+    var poolBounds = isHorizontalPool ? {
+      width: bbox.width,
+      height: bbox.height
+    } : {
+      width: bbox.height,
+      height: bbox.width,
+      x: mid.x - bbox.height / 2,
+      y: mid.y - bbox.width / 2
+    };
+
+    assign(bounds, poolBounds);
+
+    assign(style, {
+      fontSize: defaultFontSize + 'px',
+      lineHeight: defaultLineHeight,
+      paddingTop: (7 * zoom) + 'px',
+      paddingBottom: (7 * zoom) + 'px',
+      paddingLeft: (5 * zoom) + 'px',
+      paddingRight: (5 * zoom) + 'px',
+      transform: isHorizontalPool ? null : 'rotate(-90deg)'
+    });
+  }
+
+
+  // internal labels for tasks and collapsed call activities
+  // and sub processes
   if (isAny(element, [ 'bpmn:Task', 'bpmn:CallActivity' ]) ||
-      isCollapsedPool(element) ||
       isCollapsedSubProcess(element)) {
 
     assign(bounds, {

--- a/lib/features/modeling/behavior/IsHorizontalFix.js
+++ b/lib/features/modeling/behavior/IsHorizontalFix.js
@@ -35,10 +35,15 @@ export default function IsHorizontalFix(eventBus) {
         bo = getBusinessObject(shape),
         di = getDi(shape);
 
-    if (isAny(bo, elementTypesToUpdate) && !di.get('isHorizontal')) {
+    if (isAny(bo, elementTypesToUpdate)) {
+      var isHorizontal = di.get('isHorizontal');
+
+      if (isHorizontal === undefined) {
+        isHorizontal = true;
+      }
 
       // set attribute directly to avoid modeling#updateProperty side effects
-      di.set('isHorizontal', true);
+      di.set('isHorizontal', isHorizontal);
     }
   });
 

--- a/lib/util/DiUtil.js
+++ b/lib/util/DiUtil.js
@@ -47,6 +47,26 @@ export function isExpanded(element, di) {
  *
  * @return {boolean}
  */
+export function isHorizontal(element) {
+
+  if (!is(element, 'bpmn:Participant') && !is(element, 'bpmn:Lane')) {
+    return undefined;
+  }
+
+  var isHorizontal = getDi(element).isHorizontal;
+
+  if (isHorizontal === undefined) {
+    return true;
+  }
+
+  return isHorizontal;
+}
+
+/**
+ * @param {Element} element
+ *
+ * @return {boolean}
+ */
 export function isInterrupting(element) {
   return element && getBusinessObject(element).isInterrupting !== false;
 }

--- a/test/fixtures/bpmn/draw/vertical-pools.bpmn
+++ b/test/fixtures/bpmn/draw/vertical-pools.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="Camunda Modeler" exporterVersion="5.16.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+  <collaboration id="Collaboration_0m9vq4y">
+    <participant id="Participant_00h09d6" name="Collapsed Pool" />
+    <participant id="Participant_1wpkruh" name="Extended Pool" processRef="Process_01t5csh" />
+    <participant id="Participant_1xkqrsy" name="Pool with Lanes" processRef="Process_10fpr09" />
+  </collaboration>
+  <process id="Process_01t5csh" isExecutable="false" />
+  <process id="Process_10fpr09" isExecutable="false">
+    <laneSet id="LaneSet_1cmncwp">
+      <lane id="Lane_07czuri" name="Single Lane" />
+      <lane id="Lane_1tqhum3" name="Lane with Sublane">
+        <childLaneSet id="LaneSet_1xtuknm">
+          <lane id="Lane_0amfnv8" name="Sublane" />
+          <lane id="Lane_0juuif9" name="Sublane 2" />
+        </childLaneSet>
+      </lane>
+    </laneSet>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0m9vq4y">
+      <bpmndi:BPMNShape id="Participant_050dim5_di" bpmnElement="Participant_00h09d6" isHorizontal="false">
+        <omgdc:Bounds y="160" x="57" height="600" width="60" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_1wpkruh_di" bpmnElement="Participant_1wpkruh" isHorizontal="false">
+        <omgdc:Bounds y="160" x="165" height="600" width="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_1xkqrsy_di" bpmnElement="Participant_1xkqrsy" isHorizontal="false">
+        <omgdc:Bounds y="160" x="460" height="600" width="400" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_07czuri_di" bpmnElement="Lane_07czuri" isHorizontal="false">
+        <omgdc:Bounds y="190" x="460" height="570" width="130" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1tqhum3_di" bpmnElement="Lane_1tqhum3" isHorizontal="false">
+        <omgdc:Bounds y="190" x="590" height="570" width="270" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0amfnv8_di" bpmnElement="Lane_0amfnv8" isHorizontal="false">
+        <omgdc:Bounds y="220" x="590" height="540" width="140" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0juuif9_di" bpmnElement="Lane_0juuif9" isHorizontal="false">
+        <omgdc:Bounds y="220" x="730" height="540" width="130" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -214,6 +214,15 @@ describe('draw - bpmn renderer', function() {
   });
 
 
+  it('should render vertical pools', function() {
+    var xml = require('../../fixtures/bpmn/draw/vertical-pools.bpmn');
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      checkErrors(result.error, result.warnings);
+    });
+  });
+
+
   it('should render pool collection marker', function() {
     var xml = require('../../fixtures/bpmn/draw/pools-with-collection-marker.bpmn');
     return bootstrapViewer(xml).call(this).then(function(result) {

--- a/test/spec/features/label-editing/LabelEditing.bpmn
+++ b/test/spec/features/label-editing/LabelEditing.bpmn
@@ -3,6 +3,8 @@
   <bpmn:collaboration id="Collaboration_1o0amh9">
     <bpmn:participant id="Participant_1" name="FOO BAR" processRef="Process_1" />
     <bpmn:participant id="Participant_2" />
+    <bpmn:participant id="Participant_3" name="VER" processRef="Process_3" />
+    <bpmn:participant id="Participant_4" name="CAL" />
     <bpmn:messageFlow id="MessageFlow_1" name="FOO" sourceRef="Task_1fo1fvh" targetRef="Participant_2" />
     <bpmn:textAnnotation id="TextAnnotation_1">    <bpmn:text>FOO</bpmn:text>
 </bpmn:textAnnotation>
@@ -75,6 +77,12 @@
   <bpmn:category id="Category_1">
     <bpmn:categoryValue id="CategoryValue_1" value="FOO" />
   </bpmn:category>
+  <bpmn:process id="Process_3" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_0qq17vw">
+      <bpmn:lane id="Vertical_Lane_2" name="TI" />
+      <bpmn:lane id="Vertical_Lane_1" />
+    </bpmn:laneSet>
+  </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1o0amh9">
       <bpmndi:BPMNShape id="Participant_15tkgjw_di" bpmnElement="Participant_1">
@@ -192,6 +200,21 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Participant_0kzj58d_di" bpmnElement="Participant_2">
         <dc:Bounds x="161" y="646" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_09pdsq3_di" bpmnElement="Participant_3" isHorizontal="false">
+        <dc:Bounds x="900" y="122" width="250" height="600" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1ja5e3n_di" bpmnElement="Vertical_Lane_2" isHorizontal="false">
+        <dc:Bounds x="1025" y="152" width="125" height="570" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0u3fowr_di" bpmnElement="Vertical_Lane_1" isHorizontal="false">
+        <dc:Bounds x="900" y="152" width="125" height="570" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_03y1uz8_di" bpmnElement="Participant_4" isHorizontal="false">
+        <dc:Bounds x="1178" y="122" width="60" height="600" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataOutput_di" bpmnElement="DataOutput">
         <dc:Bounds x="265" y="150" width="34" height="40" />

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -500,6 +500,10 @@ describe('features - label-editing', function() {
 
       it('pool, collapsed', directEdit('Participant_2'));
 
+      it('vertical pool', directEdit('Participant_3'));
+
+      it('vertical pool, collapsed', directEdit('Participant_4'));
+
 
       it('lane with label', directEdit('Lane_1'));
 
@@ -926,6 +930,182 @@ describe('features - label-editing', function() {
               y: mid.y - (30 * zoom) / 2,
               width: bounds.height,
               height: 30 * zoom
+            });
+          }
+        ));
+
+      });
+
+
+      describe('collapsed pools', function() {
+
+        it('[zoom 1] should have width/height of element', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_2');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: bounds.x,
+              y: bounds.y,
+              width: bounds.width,
+              height: bounds.height
+            });
+          }
+        ));
+
+
+        it('[zoom 1.5] should have width/height of element', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1.5;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_2');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: bounds.x,
+              y: bounds.y,
+              width: bounds.width,
+              height: bounds.height
+            });
+          }
+        ));
+
+      });
+
+
+      describe('vertical pools/lanes', function() {
+
+        it('[zoom 1] should have width of element width, height of 30', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_3');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: bounds.x,
+              y: bounds.y,
+              width: bounds.width,
+              height: 30 * zoom
+            });
+          }
+        ));
+
+
+        it('[zoom 1.5] should have width of element width, height of 30', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1.5;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_3');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: bounds.x,
+              y: bounds.y,
+              width: bounds.width,
+              height: 30 * zoom
+            });
+          }
+        ));
+
+      });
+
+
+      describe('vertical collapsed pools', function() {
+
+        it('[zoom 1] should have width/height of element', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_4');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+            var mid = {
+              x: bounds.x + bounds.width / 2,
+              y: bounds.y + bounds.height / 2
+            };
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: mid.x - bounds.height / 2,
+              y: mid.y - bounds.width / 2,
+              width: bounds.height,
+              height: bounds.width
+            });
+          }
+        ));
+
+
+        it('[zoom 1.5] should have width/height of element', inject(
+          function(canvas, directEditing, elementRegistry) {
+
+            // given
+            var zoom = 1.5;
+
+            canvas.zoom(zoom);
+
+            var pool = elementRegistry.get('Participant_4');
+
+            var bounds = canvas.getAbsoluteBBox(pool);
+            var mid = {
+              x: bounds.x + bounds.width / 2,
+              y: bounds.y + bounds.height / 2
+            };
+
+            // when
+            directEditing.activate(pool);
+
+            // then
+            expectBounds(directEditing._textbox.parent, {
+              x: mid.x - bounds.height / 2,
+              y: mid.y - bounds.width / 2,
+              width: bounds.height,
+              height: bounds.width
             });
           }
         ));

--- a/test/spec/features/modeling/behavior/IsHorizontalFix.bpmn
+++ b/test/spec/features/modeling/behavior/IsHorizontalFix.bpmn
@@ -2,8 +2,10 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0f2kqle" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.2.4">
   <bpmn:collaboration id="Collaboration_08digmd">
     <bpmn:participant id="Participant" processRef="Process_1" />
+    <bpmn:participant id="Horizontal_Participant" processRef="Process_2" />
+    <bpmn:participant id="Vertical_Participant" processRef="Process_3" />
   </bpmn:collaboration>
-  <bpmn:process id="Process_1">
+  <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:laneSet id="LaneSet_13y425u">
       <bpmn:lane id="Lane">
         <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
@@ -21,19 +23,61 @@
       </bpmn:extensionElements>
     </bpmn:startEvent>
   </bpmn:process>
+  <bpmn:process id="Process_2" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_0s4fms0">
+      <bpmn:lane id="Horizontal_Lane_2" />
+      <bpmn:lane id="Horizontal_Lane">
+        <bpmn:flowNodeRef>Event_01335ir</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="Event_01335ir" />
+  </bpmn:process>
+  <bpmn:process id="Process_3" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_1ub8mw3">
+      <bpmn:lane id="Vertical_Lane">
+        <bpmn:flowNodeRef>Event_02alkvt</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Vertical_Lane_2" />
+    </bpmn:laneSet>
+    <bpmn:startEvent id="Event_02alkvt" />
+  </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_08digmd">
       <bpmndi:BPMNShape id="Participant_di" bpmnElement="Participant">
         <dc:Bounds x="123" y="82" width="600" height="370" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="173" y="102" width="36" height="36" />
+      <bpmndi:BPMNShape id="Lane_2_di" bpmnElement="Lane_2">
+        <dc:Bounds x="153" y="332" width="570" height="120" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_di" bpmnElement="Lane">
         <dc:Bounds x="153" y="82" width="570" height="250" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_2_di" bpmnElement="Lane_2">
-        <dc:Bounds x="153" y="332" width="570" height="120" />
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Horizontal_Participant_di" bpmnElement="Horizontal_Participant" isHorizontal="true">
+        <dc:Bounds x="770" y="82" width="600" height="370" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Horizontal_Lane_2_di" bpmnElement="Horizontal_Lane_2" isHorizontal="true">
+        <dc:Bounds x="800" y="332" width="570" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Horizontal_Lane_di" bpmnElement="Horizontal_Lane" isHorizontal="true">
+        <dc:Bounds x="800" y="82" width="570" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1muvki3" bpmnElement="Event_01335ir">
+        <dc:Bounds x="820" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Vertical_Participant_di" bpmnElement="Vertical_Participant" isHorizontal="false">
+        <dc:Bounds x="123" y="500" width="370" height="600" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Vertical_Lane_2_di" bpmnElement="Vertical_Lane_2" isHorizontal="false">
+        <dc:Bounds x="373" y="530" width="120" height="570" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Vertical_Lane_di" bpmnElement="Vertical_Lane" isHorizontal="false">
+        <dc:Bounds x="123" y="530" width="250" height="570" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1eta6o5" bpmnElement="Event_02alkvt">
+        <dc:Bounds x="143" y="550" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/IsHorizontalFixSpec.js
+++ b/test/spec/features/modeling/behavior/IsHorizontalFixSpec.js
@@ -94,6 +94,40 @@ describe('features/modeling/behavior - IsHorizontalFix', function() {
     );
 
 
+    it('should keep isHorizontal=true when participant is moved',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        var participant = elementRegistry.get('Horizontal_Participant');
+
+        // when
+        modeling.moveElements([ participant ], { x: 0, y: 0 });
+
+        // then
+        var isHorizontal = getDi(participant).get('isHorizontal');
+
+        expect(isHorizontal).to.be.true;
+      })
+    );
+
+
+    it('should keep isHorizontal=false when participant is moved',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        var participant = elementRegistry.get('Vertical_Participant');
+
+        // when
+        modeling.moveElements([ participant ], { x: 0, y: 0 });
+
+        // then
+        var isHorizontal = getDi(participant).get('isHorizontal');
+
+        expect(isHorizontal).to.be.false;
+      })
+    );
+
+
     it('should set isHorizontal=true when lane is moved',
       inject(function(elementRegistry, modeling) {
 
@@ -107,6 +141,40 @@ describe('features/modeling/behavior - IsHorizontalFix', function() {
         var isHorizontal = getDi(lane).get('isHorizontal');
 
         expect(isHorizontal).to.be.true;
+      })
+    );
+
+
+    it('should keep isHorizontal=true when lane is moved',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        var lane = elementRegistry.get('Horizontal_Lane');
+
+        // when
+        modeling.moveElements([ lane ], { x: 0, y: 0 });
+
+        // then
+        var isHorizontal = getDi(lane).get('isHorizontal');
+
+        expect(isHorizontal).to.be.true;
+      })
+    );
+
+
+    it('should keep isHorizontal=false when lane is moved',
+      inject(function(elementRegistry, modeling) {
+
+        // given
+        var lane = elementRegistry.get('Vertical_Lane');
+
+        // when
+        modeling.moveElements([ lane ], { x: 0, y: 0 });
+
+        // then
+        var isHorizontal = getDi(lane).get('isHorizontal');
+
+        expect(isHorizontal).to.be.false;
       })
     );
 


### PR DESCRIPTION
Hi there,

I propose an implementation for rendering vertical pools and lanes.
Fixes #57 

The labels of vertical pools and lanes as well as the pool label separator are now correctly rendered on top.
Labels of vertical black-box pools are rotated.

The spec implies that horizontal is the default and I adhere to that, i.e. a missing isHorizontal attribute defaults to true.

Could you please provide some information how I can test this?
I thought about adding a vertical version of https://github.com/bpmn-io/bpmn-js/blob/7aee439f47cf0daebcb6131e84f0f9a9d2a51544/test/fixtures/bpmn/draw/pools.bpmn
...but I'm not quite sure if that'll do it.

Kind regards

<details>
<summary>Showcase</summary>

![showcase](https://github.com/bpmn-io/bpmn-js/assets/150448993/8a13f9f4-e2fb-4ac2-a6c1-d156e97ee5ac)

</details>
