### PR TITLE
fix(outline): end event

### DIFF
--- a/lib/features/outline/OutlineProvider.js
+++ b/lib/features/outline/OutlineProvider.js
@@ -86,6 +86,19 @@ OutlineProvider.prototype.getOutline = function(element) {
       height: element.height + DEFAULT_OFFSET * 2
     }, OUTLINE_STYLE));
 
+  } else if (is(element, 'bpmn:EndEvent')) {
+
+    outline = svgCreate('circle');
+
+    // Extra 1px offset needed due to increased stroke-width of end event
+    // which makes it bigger than other events.
+
+    svgAttr(outline, assign({
+      cx: element.width / 2,
+      cy: element.height / 2,
+      r: element.width / 2 + DEFAULT_OFFSET + 1
+    }, OUTLINE_STYLE));
+
   } else if (is(element, 'bpmn:Event')) {
     outline = svgCreate('circle');
 


### PR DESCRIPTION
Closes #2015

This happens because the events all have the same diameter but end even has a thicker stroke.