### PR TITLE
ci: update examples lock file POST_RELEASE

### DIFF
--- a/tasks/stages/update-examples
+++ b/tasks/stages/update-examples
@@ -22,6 +22,9 @@ echo "Updating toolkit version to $TOOLKIT_VERSION"
 sed -i -E "s#(\"bpmn-js\": )\"[^\"]+\"#\1\"^$TOOLKIT_VERSION\"#" **/package.json
 sed -i -E "s#/bpmn-js@[^/]+/#/bpmn-js@$TOOLKIT_VERSION/#" **/*.{html,md}
 
+# install dependencies (fixes up lock file)
+npm install
+
 if [[ "x$SKIP_COMMIT" = "x" ]]; then
 
   git config user.email "$BPMN_IO_EMAIL"


### PR DESCRIPTION
This ensures that the examples is in an installable state after we updated it.

Closes https://github.com/bpmn-io/bpmn-js/issues/2059