### PR TITLE
fix: do not remove association that was just created

### DIFF
--- a/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
@@ -45,12 +45,13 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
    * Add `isForCompensation` property and make sure only a single compensation activity is connected.
    */
   function handleNewConnection(context) {
-    const source = context.source,
+    const connection = context.connection,
+          source = context.source,
           target = context.target;
 
-    if (isCompensationBoundaryEvent(source) && canBeForCompensation(target)) {
+    if (isCompensationBoundaryEvent(source) && isForCompensationAllowed(target)) {
       addIsForCompensationProperty(target);
-      removeExistingAssociation(source);
+      removeExistingAssociations(source, [ connection ]);
     }
   }
 
@@ -69,7 +70,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
       }
 
       // newTarget perspective
-      if (isCompensationBoundaryEvent(source) && canBeForCompensation(newTarget)) {
+      if (isCompensationBoundaryEvent(source) && isForCompensationAllowed(newTarget)) {
         addIsForCompensationProperty(newTarget);
       }
     }
@@ -81,7 +82,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
     if (isForCompensation(element)) {
       removeDisallowedConnections(element);
       removeAttachments(element);
-    } else if (canBeForCompensation(element)) {
+    } else if (isForCompensationAllowed(element)) {
       removeIncomingCompensationAssociations(element);
     }
   }
@@ -115,7 +116,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
       targetElement.type === 'bpmn:BoundaryEvent'
     ) {
       const targetConnection = oldShape.outgoing.find(
-        ({ target }) => canBeForCompensation(target)
+        ({ target }) => isForCompensationAllowed(target)
       );
 
       if (targetConnection && targetConnection.target) {
@@ -157,9 +158,11 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
     }
   }
 
-  function removeExistingAssociation(boundaryEvent) {
+  function removeExistingAssociations(boundaryEvent, ignoredAssociations) {
     const associations = boundaryEvent.outgoing.filter(connection => is(connection, 'bpmn:Association'));
-    const associationsToRemove = associations.filter(association => isForCompensation(association.target));
+    const associationsToRemove = associations.filter(association => {
+      return isForCompensation(association.target) && !ignoredAssociations.includes(association);
+    });
 
     // remove existing associations
     associationsToRemove.forEach(association => modeling.removeConnection(association));
@@ -212,6 +215,6 @@ function isCompensationBoundaryEvent(element) {
     hasEventDefinition(element, 'bpmn:CompensateEventDefinition');
 }
 
-function canBeForCompensation(element) {
+function isForCompensationAllowed(element) {
   return element && is(element, 'bpmn:Activity') && !isEventSubProcess(element);
 }

--- a/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
@@ -78,7 +78,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
     const { element } = context;
 
     if (isForCompensation(element)) {
-      removeIllegalConnections(element);
+      removeDisallowedConnections(element);
       removeAttachments(element);
     } else if (canBeForCompensation(element)) {
       removeIncomingCompensationAssociations(element);
@@ -141,7 +141,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
     modeling.updateProperties(target, { isForCompensation: undefined });
   }
 
-  function removeIllegalConnections(element) {
+  function removeDisallowedConnections(element) {
 
     for (const connection of element.incoming) {
       if (!bpmnRules.canConnect(connection.source, element)) {

--- a/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
+++ b/lib/features/modeling/behavior/CompensateBoundaryEventBehavior.js
@@ -11,7 +11,8 @@ import { hasEventDefinition, isEventSubProcess } from '../../../util/DiUtil';
  */
 
 /**
- *
+ * Behavior ensuring that only a single compensation activity is connected to a
+ * compensation boundary event when connecting, reconnecting or replacing shapes.
  *
  * @param {import('diagram-js/lib/core/EventBus').default} eventBus
  * @param {import('../Modeling').default} modeling
@@ -29,7 +30,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
   this.postExecuted('element.updateProperties', handlePropertiesUpdate, true);
 
   /**
-   * Given a connection from boundary event is removed, remove the forCompensation property.
+   * Given a connection from boundary event is removed, remove the `isForCompensation` property.
    */
   function handleConnectionRemoval(context) {
     const source = context.source,
@@ -41,7 +42,7 @@ export default function CompensateBoundaryEventBehavior(eventBus, modeling, bpmn
   }
 
   /**
-   * Add forCompensation property and make sure only a single compensation activity is connected.
+   * Add `isForCompensation` property and make sure only a single compensation activity is connected.
    */
   function handleNewConnection(context) {
     const source = context.source,

--- a/test/spec/features/modeling/behavior/CompensateBoundaryEventBehavior.bpmn
+++ b/test/spec/features/modeling/behavior/CompensateBoundaryEventBehavior.bpmn
@@ -18,18 +18,18 @@
       <incoming>NoneFlow</incoming>
     </task>
     <sequenceFlow id="NoneFlow" sourceRef="NoneEvent" targetRef="NoneActivity" />
-    <task id="IllegalConnections">
+    <task id="Task_DisallowedConnections">
       <incoming>Flow_1czca1o</incoming>
       <outgoing>Flow_0ma72c1</outgoing>
     </task>
     <task id="Activity_1rlhhtg">
       <incoming>Flow_0ma72c1</incoming>
     </task>
-    <sequenceFlow id="Flow_0ma72c1" sourceRef="IllegalConnections" targetRef="Activity_1rlhhtg" />
+    <sequenceFlow id="Flow_0ma72c1" sourceRef="Task_DisallowedConnections" targetRef="Activity_1rlhhtg" />
     <task id="AnotherTask">
       <outgoing>Flow_1czca1o</outgoing>
     </task>
-    <sequenceFlow id="Flow_1czca1o" sourceRef="AnotherTask" targetRef="IllegalConnections" />
+    <sequenceFlow id="Flow_1czca1o" sourceRef="AnotherTask" targetRef="Task_DisallowedConnections" />
     <task id="Activity_0ibho72" />
     <boundaryEvent id="MultiOutgoing" attachedToRef="Activity_0ibho72">
       <outgoing>Flow_1t3tgme</outgoing>
@@ -93,7 +93,7 @@
       <bpmndi:BPMNShape id="Activity_0g6v5lh_di" bpmnElement="NoneActivity">
         <omgdc:Bounds x="470" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1h9z7j0_di" bpmnElement="IllegalConnections">
+      <bpmndi:BPMNShape id="Activity_1h9z7j0_di" bpmnElement="Task_DisallowedConnections">
         <omgdc:Bounds x="360" y="510" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1rlhhtg_di" bpmnElement="Activity_1rlhhtg">

--- a/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
@@ -101,6 +101,7 @@ describe('features/modeling/behavior - compensation boundary event', function() 
       expect(task.businessObject.isForCompensation).to.be.true;
       expect(is(task.incoming[0], 'bpmn:Association')).to.be.true;
     }));
+
   });
 
 
@@ -123,7 +124,7 @@ describe('features/modeling/behavior - compensation boundary event', function() 
     }));
 
 
-    it('on delete connection', inject(function(elementRegistry, modeling) {
+    it('on remove connection', inject(function(elementRegistry, modeling) {
 
       // given
       const taskShape = elementRegistry.get('Task_Compensation');
@@ -265,6 +266,7 @@ describe('features/modeling/behavior - compensation boundary event', function() 
         expect(compensationActivity.incoming[0].source).to.eql(event);
       }
     ));
+
   });
 
 
@@ -309,6 +311,7 @@ describe('features/modeling/behavior - compensation boundary event', function() 
         expect(task.businessObject.isForCompensation).to.be.false;
       }
     }));
+
   });
 
 
@@ -378,4 +381,5 @@ describe('features/modeling/behavior - compensation boundary event', function() 
       expect(action).not.to.throw();
     }
   ));
+
 });

--- a/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
@@ -196,10 +196,10 @@ describe('features/modeling/behavior - compensation boundary event', function() 
 
   describe('remove connections', function() {
 
-    it('should remove illegal connections on connect', inject(function(modeling, elementRegistry) {
+    it('should remove disallowed connections on connect', inject(function(modeling, elementRegistry) {
 
       // given
-      const task = elementRegistry.get('IllegalConnections');
+      const task = elementRegistry.get('Task_DisallowedConnections');
       const event = elementRegistry.get('Attached_Event');
 
       expect(task.incoming).to.have.length(1);
@@ -214,10 +214,10 @@ describe('features/modeling/behavior - compensation boundary event', function() 
     }));
 
 
-    it('should remove illegal connections on reconnect', inject(function(modeling, elementRegistry) {
+    it('should remove disallowed connections on reconnect', inject(function(modeling, elementRegistry) {
 
       // given
-      const task = elementRegistry.get('IllegalConnections');
+      const task = elementRegistry.get('Task_DisallowedConnections');
       const connection = elementRegistry.get('Association');
 
       // when
@@ -270,9 +270,9 @@ describe('features/modeling/behavior - compensation boundary event', function() 
   });
 
 
-  describe('remove attachments', function() {
+  describe('remove attachers', function() {
 
-    it('should remove element\'s attachments', inject(function(elementRegistry, modeling) {
+    it('should remove attachers of compensation activity', inject(function(elementRegistry, modeling) {
 
       // given
       const event = elementRegistry.get('Attached_Event'),
@@ -287,7 +287,7 @@ describe('features/modeling/behavior - compensation boundary event', function() 
     }));
 
 
-    it('should NOT remove attachments of non-compensation activity', inject(function(elementRegistry, bpmnReplace) {
+    it('should NOT remove attachers of non-compensation activity', inject(function(elementRegistry, bpmnReplace) {
 
       // given
       let event = elementRegistry.get('MultiBoundary'),

--- a/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CompensateBoundaryEventBehaviorSpec.js
@@ -3,16 +3,22 @@ import {
   inject
 } from 'test/TestHelper';
 
-import modelingModule from 'lib/features/modeling';
-import coreModule from 'lib/core';
 import { is } from 'lib/util/ModelUtil';
+
+import copyPasteModule from 'lib/features/copy-paste';
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
 
 import diagramXML from './CompensateBoundaryEventBehavior.bpmn';
 
 
 describe('features/modeling/behavior - compensation boundary event', function() {
 
-  const testModules = [ coreModule, modelingModule ];
+  const testModules = [
+    copyPasteModule,
+    coreModule,
+    modelingModule
+  ];
 
   beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
@@ -381,5 +387,34 @@ describe('features/modeling/behavior - compensation boundary event', function() 
       expect(action).not.to.throw();
     }
   ));
+
+
+  describe('copy and paste', function() {
+
+    it('should NOT break on copy and paste', inject(function(canvas, copyPaste, elementRegistry) {
+
+      // given
+      copyPaste.copy([
+        elementRegistry.get('Task_BoundaryEvent2'),
+        elementRegistry.get('Task_Compensation')
+      ]);
+
+      // when
+      var copiedElements = copyPaste.paste({
+        element: canvas.getRootElement(),
+        point: {
+          x: 100,
+          y: 100
+        }
+      });
+
+      // then
+      expect(copiedElements).to.have.lengthOf(4);
+      expect(copiedElements.filter(element => is(element, 'bpmn:Association'))).to.have.length(1);
+      expect(copiedElements.filter(element => is(element, 'bpmn:BoundaryEvent'))).to.have.length(1);
+      expect(copiedElements.filter(element => is(element, 'bpmn:Task'))).to.have.length(2);
+    }));
+
+  });
 
 });


### PR DESCRIPTION
Event though we are removing existing associations during `preExecute` when creating a connection in the case of copy and paste the new connection can already be connected to source and target so we have to make sure we're not trying to remove that connection.

Closes #2068

![brave_hr8468rmJD](https://github.com/bpmn-io/bpmn-js/assets/7633572/829c1359-adf3-4bf7-b8c0-831cc3606ea9)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
