### PR TITLE
feat: adjust TextAnnotations behavior

### DIFF
--- a/lib/features/modeling/behavior/FixHoverBehavior.js
+++ b/lib/features/modeling/behavior/FixHoverBehavior.js
@@ -1,8 +1,6 @@
 import { getLanesRoot } from '../util/LaneUtil';
 
-import { is } from '../../../util/ModelUtil';
-
-import { isAny } from '../util/ModelingUtil';
+import { is, isAny } from '../../../util/ModelUtil';
 
 /**
  * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
@@ -48,7 +46,7 @@ export default function FixHoverBehavior(elementRegistry, eventBus, canvas) {
 
     // ensure bpmn:Group and label elements are dropped
     // always onto the root
-    if (hover !== rootElement && (shape.labelTarget || is(shape, 'bpmn:Group'))) {
+    if (hover !== rootElement && (shape.labelTarget || isAny(shape, [ 'bpmn:Group', 'bpmn:TextAnnotation' ]))) {
       event.hover = rootElement;
       event.hoverGfx = elementRegistry.getGraphics(event.hover);
     }

--- a/lib/features/modeling/behavior/TextAnnotationBehavior.js
+++ b/lib/features/modeling/behavior/TextAnnotationBehavior.js
@@ -12,6 +12,19 @@ export default function TextAnnotationBehavior(eventBus) {
 
   CommandInterceptor.call(this, eventBus);
 
+  // On Append, TextAnnotations will be created on the Root.
+  // The default for connections will create the connection in the parent of
+  // the source element, so we overwrite the parent here.
+  this.preExecute('connection.create', function(context) {
+    const { target } = context;
+
+    if (!is(target, 'bpmn:TextAnnotation')) {
+      return;
+    }
+
+    context.parent = target.parent;
+  }, true);
+
   this.preExecute([ 'shape.create', 'shape.resize', 'elements.move' ], function(context) {
     const shapes = context.shapes || [ context.shape ];
 

--- a/lib/features/modeling/behavior/TextAnnotationBehavior.js
+++ b/lib/features/modeling/behavior/TextAnnotationBehavior.js
@@ -1,0 +1,30 @@
+import inherits from 'inherits-browser';
+
+import { is } from '../../../util/ModelUtil';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+/**
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ */
+
+export default function TextAnnotationBehavior(eventBus) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  this.preExecute([ 'shape.create', 'shape.resize', 'elements.move' ], function(context) {
+    const shapes = context.shapes || [ context.shape ];
+
+    if (shapes.length === 1 && is(shapes[0], 'bpmn:TextAnnotation')) {
+      context.hints = context.hints || {};
+
+      context.hints.autoResize = false;
+    }
+  }, true);
+}
+
+inherits(TextAnnotationBehavior, CommandInterceptor);
+
+TextAnnotationBehavior.$inject = [
+  'eventBus'
+];

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -32,6 +32,7 @@ import RootElementReferenceBehavior from './RootElementReferenceBehavior';
 import SpaceToolBehavior from './SpaceToolBehavior';
 import SubProcessPlaneBehavior from './SubProcessPlaneBehavior';
 import SubProcessStartEventBehavior from './SubProcessStartEventBehavior';
+import TextAnnotationBehavior from './TextAnnotationBehavior';
 import ToggleCollapseConnectionBehaviour from './ToggleCollapseConnectionBehaviour';
 import ToggleElementCollapseBehaviour from './ToggleElementCollapseBehaviour';
 import UnclaimIdBehavior from './UnclaimIdBehavior';
@@ -77,6 +78,7 @@ export default {
     'spaceToolBehavior',
     'subProcessPlaneBehavior',
     'subProcessStartEventBehavior',
+    'textAnnotationBehavior',
     'toggleCollapseConnectionBehaviour',
     'toggleElementCollapseBehaviour',
     'unclaimIdBehavior',
@@ -117,6 +119,7 @@ export default {
   spaceToolBehavior: [ 'type', SpaceToolBehavior ],
   subProcessPlaneBehavior: [ 'type', SubProcessPlaneBehavior ],
   subProcessStartEventBehavior: [ 'type', SubProcessStartEventBehavior ],
+  textAnnotationBehavior: [ 'type', TextAnnotationBehavior ],
   toggleCollapseConnectionBehaviour: [ 'type', ToggleCollapseConnectionBehaviour ],
   toggleElementCollapseBehaviour : [ 'type', ToggleElementCollapseBehaviour ],
   unclaimIdBehavior: [ 'type', UnclaimIdBehavior ],

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -55,6 +55,12 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
       }
     },
     {
+      type: 'bpmn:TextAnnotation',
+      order: {
+        level: 9
+      }
+    },
+    {
       type: 'bpmn:MessageFlow', order: {
         level: 9,
         containers: [ 'bpmn:Collaboration' ]

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -3,6 +3,7 @@ import inherits from 'inherits-browser';
 import OrderingProvider from 'diagram-js/lib/features/ordering/OrderingProvider';
 
 import {
+  is,
   isAny
 } from '../modeling/util/ModelingUtil';
 
@@ -142,8 +143,8 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
 
   this.getOrdering = function(element, newParent) {
 
-    // render labels always on top
-    if (element.labelTarget) {
+    // render labels and text annotations always on top
+    if (element.labelTarget || is(element, 'bpmn:TextAnnotation')) {
       return {
         parent: canvas.findRoot(newParent) || canvas.getRootElement(),
         index: -1

--- a/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCopyPasteSpec.js
@@ -214,7 +214,7 @@ describe('features/copy-paste', function() {
       });
 
       // then
-      expect(rootElement.children).to.have.length(9);
+      expect(rootElement.children).to.have.length(13);
 
       var subProcesses = elements.filter(function(element) {
         return is(element, 'bpmn:SubProcess');

--- a/test/spec/features/modeling/append/TextAnnotationSpec.js
+++ b/test/spec/features/modeling/append/TextAnnotationSpec.js
@@ -24,11 +24,11 @@ describe('features/modeling - append text-annotation', function() {
 
     it('in lane');
 
-    it('in participant', inject(function(elementRegistry, modeling) {
+    it('in participant', inject(function(elementRegistry, modeling, canvas) {
 
       // given
       var eventShape = elementRegistry.get('IntermediateCatchEvent_1'),
-          process = elementRegistry.get('Participant_1').businessObject.processRef;
+          collaboration = elementRegistry.get('_Collaboration_2').businessObject;
 
       // when
       var annotationShape = modeling.appendShape(eventShape, { type: 'bpmn:TextAnnotation' }),
@@ -49,11 +49,11 @@ describe('features/modeling - append text-annotation', function() {
       expect(connecting.targetRef).to.eql(annotation);
 
       // correctly assign artifact parent
-      expect(annotation.$parent).to.eql(process);
-      expect(connecting.$parent).to.eql(process);
+      expect(annotation.$parent).to.eql(collaboration);
+      expect(connecting.$parent).to.eql(collaboration);
 
-      expect(process.artifacts).to.include(annotation);
-      expect(process.artifacts).to.include(connecting);
+      expect(collaboration.artifacts).to.include(annotation);
+      expect(collaboration.artifacts).to.include(connecting);
     }));
 
 
@@ -81,8 +81,8 @@ describe('features/modeling - append text-annotation', function() {
       expect(connecting.targetRef).to.eql(annotation);
 
       // correctly assign artifact parent
-      expect(annotation.$parent.id).to.equal('Transaction_2');
-      expect(connecting.$parent.id).to.equal('Transaction_2');
+      expect(annotation.$parent.id).to.equal('_Collaboration_2');
+      expect(connecting.$parent.id).to.equal('_Collaboration_2');
     }));
 
     it('with right size', inject(function(elementRegistry, elementFactory, modeling) {
@@ -107,7 +107,7 @@ describe('features/modeling - append text-annotation', function() {
 
       // given
       var eventShape = elementRegistry.get('IntermediateCatchEvent_1'),
-          process = elementRegistry.get('Participant_1').businessObject.processRef;
+          collaboration = elementRegistry.get('_Collaboration_2').businessObject;
 
       var annotationShape = modeling.appendShape(eventShape, { type: 'bpmn:TextAnnotation' }),
           annotation = annotationShape.businessObject;
@@ -125,10 +125,10 @@ describe('features/modeling - append text-annotation', function() {
       expect(connecting.sourceRef).to.be.null;
       expect(connecting.targetRef).to.be.null;
       expect(connecting.$parent).to.be.null;
-      expect(process.artifacts).not.to.include(connecting);
+      expect(collaboration.artifacts).not.to.include(connecting);
 
       expect(annotation.$parent).to.be.null;
-      expect(process.artifacts).not.to.include(annotation);
+      expect(collaboration.artifacts).not.to.include(annotation);
     }));
 
   });

--- a/test/spec/features/modeling/behavior/FixHoverBehavior.annotation.bpmn
+++ b/test/spec/features/modeling/behavior/FixHoverBehavior.annotation.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0">
+  <process id="Process" isExecutable="false">
+    <task id="Task" />
+    <textAnnotation id="TextAnnotation_1" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNShape id="TextAnnotation_0fmduw3_di" bpmnElement="TextAnnotation_1">
+        <omgdc:Bounds x="154" y="80" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_di" bpmnElement="Task">
+        <omgdc:Bounds x="154" y="131" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/modeling/behavior/FixHoverBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/FixHoverBehaviorSpec.js
@@ -269,6 +269,74 @@ describe('features/modeling/behavior - fix hover', function() {
   });
 
 
+  describe('Annotation', function() {
+
+    var diagramXML = require('./FixHoverBehavior.annotation.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules
+    }));
+
+    beforeEach(inject(function(dragging) {
+      dragging.setOptions({ manual: true });
+    }));
+
+
+    describe('create', function() {
+
+      it('should <create.hover> root', inject(
+        function(dragging, elementFactory, elementRegistry, create, canvas) {
+
+          // given
+          var task = elementRegistry.get('Task');
+
+          var annotation = elementFactory.createShape({ type: 'bpmn:TextAnnotation' });
+
+          create.start(canvasEvent({ x: 0, y: 0 }), annotation, true);
+
+          // when
+          dragging.hover({ element: task, gfx: elementRegistry.getGraphics(task) });
+
+          dragging.move(canvasEvent({ x: 240, y: 220 }));
+
+          dragging.end();
+
+          // then
+          expect(annotation.parent).to.equal(canvas.getRootElement());
+        }
+      ));
+
+    });
+
+
+    describe('move', function() {
+
+      it('should <shape.move.hover> root', inject(
+        function(dragging, elementRegistry, move, canvas) {
+
+          // given
+          var task = elementRegistry.get('Task');
+          var annotation = elementRegistry.get('TextAnnotation_1');
+
+          move.start(canvasEvent({ x: 175, y: 150 }), annotation, true);
+
+          // when
+          dragging.hover({ element: task, gfx: elementRegistry.getGraphics(task) });
+
+          dragging.move(canvasEvent({ x: 240, y: 220 }));
+
+          dragging.end();
+
+          // then
+          expect(annotation.parent).to.equal(canvas.getRootElement());
+        }
+      ));
+
+    });
+
+  });
+
+
   describe('connect lane', function() {
 
     var diagramXML = require('./FixHoverBehavior.lane-connect.bpmn');

--- a/test/spec/features/modeling/behavior/ReplaceConnectionBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/ReplaceConnectionBehaviorSpec.js
@@ -360,42 +360,6 @@ describe('features/modeling - replace connection', function() {
     }));
 
 
-    describe('moving text-annotation to participant', function() {
-
-      it('execute', inject(function(modeling, elementRegistry) {
-
-        // given
-        var textAnnotationShape = element('TextAnnotation_1'),
-            targetShape = element('Participant_1');
-
-        // when
-        modeling.moveElements([ textAnnotationShape ], { x: -200, y: 40 }, targetShape);
-
-        // then
-        expect(textAnnotationShape.parent).to.eql(targetShape);
-
-        expectNotConnected(textAnnotationShape, targetShape, 'bpmn:TextAnnotation');
-      }));
-
-
-      it('undo', inject(function(modeling, elementRegistry, commandStack) {
-
-        // given
-        var textAnnotationShape = element('TextAnnotation_1'),
-            targetShape = element('Participant_1');
-
-        modeling.moveElements([ textAnnotationShape ], { x: -200, y: 40 }, targetShape);
-
-        // when
-        commandStack.undo();
-
-        // then
-        expectConnected(textAnnotationShape, targetShape, element('Association_1'));
-      }));
-
-    });
-
-
     describe('reconnecting data output association to text annotation', function() {
 
       it('execute', inject(function(modeling) {

--- a/test/spec/features/modeling/behavior/TextAnnotationBehaviorSpec.bpmn
+++ b/test/spec/features/modeling/behavior/TextAnnotationBehaviorSpec.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0sumicc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="Process_00kwner" isExecutable="true">
+    <bpmn:subProcess id="Subprocess_1">
+      <bpmn:task id="Task_1" />
+      <bpmn:textAnnotation id="TextAnnotation_1" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_00kwner">
+      <bpmndi:BPMNShape id="Activity_0oq21yg_di" bpmnElement="Subprocess_1" isExpanded="true">
+        <dc:Bounds x="160" y="70" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1beb5hp_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="380" y="80" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0stlo9y_di" bpmnElement="Task_1">
+        <dc:Bounds x="290" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/TextAnnotationBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/TextAnnotationBehaviorSpec.js
@@ -1,0 +1,62 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'lib/features/modeling';
+import coreModule from 'lib/core';
+import autoResizeModule from 'lib/features/auto-resize';
+
+
+describe('features/modeling - TextAnnotationBehavior', function() {
+
+  var testModules = [ coreModule, modelingModule, autoResizeModule ];
+
+  var processDiagramXML = require('./TextAnnotationBehaviorSpec.bpmn');
+
+  beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+  var annotation,
+      task,
+      subprocess;
+
+  beforeEach(inject(function(elementRegistry) {
+    annotation = elementRegistry.get('TextAnnotation_1');
+    task = elementRegistry.get('Task_1');
+    subprocess = elementRegistry.get('Subprocess_1');
+  }));
+
+
+  it('should NOT resize Container on appending Text Annotation', inject(function(modeling) {
+
+    // when
+    modeling.appendShape(task, { type: 'bpmn:TextAnnotation' });
+
+    // then
+    expect(subprocess.width).to.equal(350);
+    expect(subprocess.height).to.equal(200);
+  }));
+
+
+  it('should NOT resize Container on Text Annotation resize', inject(function(modeling) {
+
+    // when
+    modeling.resizeShape(annotation, { x: 0, y: 0, width: 1000, height: 1000 });
+
+    // then
+    expect(subprocess.width).to.equal(350);
+    expect(subprocess.height).to.equal(200);
+  }));
+
+
+  it('should NOT resize Container on Text Annotation resize', inject(function(modeling) {
+
+    // when
+    modeling.moveShape(annotation, { x: 250, y: 250 });
+
+    // then
+    expect(subprocess.width).to.equal(350);
+    expect(subprocess.height).to.equal(200);
+  }));
+
+});


### PR DESCRIPTION
![Recording 2024-01-11 at 13 57 23](https://github.com/bpmn-io/bpmn-js/assets/21984219/8f05dbac-1cf5-430c-be38-14b136e22782)

- render Annotations always on top
- Disable auto-resize for text annotations

closes https://github.com/bpmn-io/bpmn-js/issues/2049
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
