### PR TITLE
Rendering of Gateway Without Marker

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -216,11 +216,9 @@ ElementFactory.prototype.createElement = function(elementType, attrs) {
   }
 
   if (is(businessObject, 'bpmn:ExclusiveGateway')) {
-    if (has(attrs, 'isMarkerVisible')) {
-      if (attrs.isMarkerVisible === undefined) {
+    if (has(di, 'isMarkerVisible')) {
+      if (di.isMarkerVisible === undefined) {
         di.isMarkerVisible = false;
-      } else {
-        attrs = applyAttribute(di, attrs, 'isMarkerVisible');
       }
     } else {
       di.isMarkerVisible = true;

--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -172,8 +172,7 @@ PaletteProvider.prototype.getPaletteEntries = function() {
     ),
     'create.exclusive-gateway': createAction(
       'bpmn:ExclusiveGateway', 'gateway', 'bpmn-icon-gateway-none',
-      translate('Create gateway'),
-      { isMarkerVisible: true }
+      translate('Create gateway')
     ),
     'create.task': createAction(
       'bpmn:Task', 'activity', 'bpmn-icon-task',

--- a/test/spec/features/modeling/ElementFactorySpec.js
+++ b/test/spec/features/modeling/ElementFactorySpec.js
@@ -212,7 +212,7 @@ describe('features - element factory', function() {
       // when
       var shape = elementFactory.createShape({
         type: 'bpmn:ExclusiveGateway',
-        isMarkerVisible: true
+        di: { isMarkerVisible: true }
       });
 
       // then
@@ -225,7 +225,7 @@ describe('features - element factory', function() {
       // when
       var shape = elementFactory.createShape({
         type: 'bpmn:ExclusiveGateway',
-        isMarkerVisible: false
+        di: { isMarkerVisible: false }
       });
 
       // then


### PR DESCRIPTION
Closes #2063 

I think it was a mistake to rely on `attrs`. Without it, this is the most simple solution I found. Please have a look.