### PR TITLE
Update to `bpmn-moddle@9`

### DIFF
--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "import"
-  ],
-  "rules": {
-    "import/no-unresolved": "error"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "17.11.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^8.1.0",
+        "bpmn-moddle": "^9.0.1",
         "diagram-js": "^14.11.2",
         "diagram-js-direct-editing": "^3.0.1",
         "ids": "^1.0.5",
@@ -2443,13 +2443,16 @@
       "dev": true
     },
     "node_modules/bpmn-moddle": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.1.0.tgz",
-      "integrity": "sha512-yI5OAFfYVJwViKTsTsonVfCBPtB3MlefADUORwNIxxBOMp21vnoxuxsdgUWlPH/dvAEZh/+mr8UtqOBNu8NC5Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
+      "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
       "dependencies": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.2.3",
-        "moddle-xml": "^10.1.0"
+        "min-dash": "^4.2.1",
+        "moddle": "^7.0.0",
+        "moddle-xml": "^11.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/brace-expansion": {
@@ -8566,21 +8569,26 @@
       }
     },
     "node_modules/moddle": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.3.tgz",
-      "integrity": "sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
+      "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
       "dependencies": {
-        "min-dash": "^4.0.0"
+        "min-dash": "^4.2.1"
       }
     },
     "node_modules/moddle-xml": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
-      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
+      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
       "dependencies": {
         "min-dash": "^4.0.0",
-        "moddle": "^6.0.0",
-        "saxen": "^8.1.2"
+        "saxen": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "moddle": ">= 6.2.0"
       }
     },
     "node_modules/moment": {
@@ -12824,9 +12832,12 @@
       "dev": true
     },
     "node_modules/saxen": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
-      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
+      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.0.0",
@@ -17539,13 +17550,13 @@
       "dev": true
     },
     "bpmn-moddle": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.1.0.tgz",
-      "integrity": "sha512-yI5OAFfYVJwViKTsTsonVfCBPtB3MlefADUORwNIxxBOMp21vnoxuxsdgUWlPH/dvAEZh/+mr8UtqOBNu8NC5Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
+      "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
       "requires": {
-        "min-dash": "^4.0.0",
-        "moddle": "^6.2.3",
-        "moddle-xml": "^10.1.0"
+        "min-dash": "^4.2.1",
+        "moddle": "^7.0.0",
+        "moddle-xml": "^11.0.0"
       }
     },
     "brace-expansion": {
@@ -21899,21 +21910,20 @@
       "dev": true
     },
     "moddle": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.3.tgz",
-      "integrity": "sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
+      "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
       "requires": {
-        "min-dash": "^4.0.0"
+        "min-dash": "^4.2.1"
       }
     },
     "moddle-xml": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
-      "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
+      "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
       "requires": {
         "min-dash": "^4.0.0",
-        "moddle": "^6.0.0",
-        "saxen": "^8.1.2"
+        "saxen": "^10.0.0"
       }
     },
     "moment": {
@@ -24955,9 +24965,9 @@
       "dev": true
     },
     "saxen": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
-      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
+      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g=="
     },
     "schema-utils": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "webpack": "^5.74.0"
   },
   "dependencies": {
-    "bpmn-moddle": "^8.1.0",
+    "bpmn-moddle": "^9.0.1",
     "diagram-js": "^14.11.2",
     "diagram-js-direct-editing": "^3.0.1",
     "ids": "^1.0.5",


### PR DESCRIPTION
This uses `bpmn-moddle@9`, a release that cleans up some [existing legacy](https://github.com/bpmn-io/bpmn-moddle/blob/main/CHANGELOG.md#900).

The library, as well as upstream now expose true ES modules, and still expose CJS modules for use. The library also requires Node@18 (Node@16 is [out of maintainance](https://nodejs.org/en/about/previous-releases) since 2023).

For safety reasons I'd regard this as a breaking change that we want to batch with other breaking changes (if any).