### PR TITLE
 Vertically Auto-Place Elements

### DIFF
--- a/lib/features/auto-place/BpmnAutoPlaceUtil.js
+++ b/lib/features/auto-place/BpmnAutoPlaceUtil.js
@@ -1,5 +1,9 @@
 import { is } from '../../util/ModelUtil';
-import { isAny } from '../modeling/util/ModelingUtil';
+
+import {
+  isAny,
+  isDirectionHorizontal
+} from '../modeling/util/ModelingUtil';
 
 import {
   getMid,
@@ -47,7 +51,7 @@ export function getNewShapePosition(source, element) {
 }
 
 /**
- * Get the position for given new flow node. Try placing the flow node right of
+ * Get the position for given new flow node. Try placing the flow node right/bottom of
  * the source.
  *
  * @param {Shape} source
@@ -60,34 +64,60 @@ export function getFlowNodePosition(source, element) {
   var sourceTrbl = asTRBL(source);
   var sourceMid = getMid(source);
 
-  var horizontalDistance = getConnectedDistance(source, {
+  var placeHorizontally = isDirectionHorizontal(source);
+
+  var placement = placeHorizontally ? {
+    directionHint: 'e',
+    minDistance: 80,
+    baseOrientation: 'left',
+    boundaryOrientation: 'top',
+    start: 'top',
+    end: 'bottom'
+  } : {
+    directionHint: 's',
+    minDistance: 90,
+    baseOrientation: 'top',
+    boundaryOrientation: 'left',
+    start: 'left',
+    end: 'right'
+  };
+
+  var connectedDistance = getConnectedDistance(source, {
     filter: function(connection) {
       return is(connection, 'bpmn:SequenceFlow');
-    }
+    },
+    direction: placement.directionHint
   });
 
   var margin = 30,
-      minDistance = 80,
-      orientation = 'left';
+      minDistance = placement.minDistance,
+      orientation = placement.baseOrientation;
 
   if (is(source, 'bpmn:BoundaryEvent')) {
     orientation = getOrientation(source, source.host, -25);
 
-    if (orientation.indexOf('top') !== -1) {
+    if (orientation.indexOf(placement.boundaryOrientation) !== -1) {
       margin *= -1;
     }
   }
 
-  var position = {
-    x: sourceTrbl.right + horizontalDistance + element.width / 2,
-    y: sourceMid.y + getVerticalDistance(orientation, minDistance)
+  var position = placeHorizontally ? {
+    x: sourceTrbl.right + connectedDistance + element.width / 2,
+    y: sourceMid.y + getDistance(orientation, minDistance, placement)
+  } : {
+    x: sourceMid.x + getDistance(orientation, minDistance, placement),
+    y: sourceTrbl.bottom + connectedDistance + element.height / 2
   };
 
-  var nextPositionDirection = {
-    y: {
-      margin: margin,
-      minDistance: minDistance
-    }
+  var nextPosition = {
+    margin: margin,
+    minDistance: minDistance
+  };
+
+  var nextPositionDirection = placeHorizontally ? {
+    y: nextPosition
+  } : {
+    x: nextPosition
   };
 
   return findFreePosition(source, element, position, generateGetNextPosition(nextPositionDirection));
@@ -96,13 +126,14 @@ export function getFlowNodePosition(source, element) {
 /**
  * @param {DirectionTRBL} orientation
  * @param {number} minDistance
+ * @param {any} placement
  *
  * @return {number}
  */
-function getVerticalDistance(orientation, minDistance) {
-  if (orientation.includes('top')) {
+function getDistance(orientation, minDistance, placement) {
+  if (orientation.includes(placement.start)) {
     return -1 * minDistance;
-  } else if (orientation.includes('bottom')) {
+  } else if (orientation.includes(placement.end)) {
     return minDistance;
   } else {
     return 0;
@@ -112,7 +143,7 @@ function getVerticalDistance(orientation, minDistance) {
 
 /**
  * Get the position for given text annotation. Try placing the text annotation
- * top-right of the source.
+ * top-right of the source (bottom-right in vertical layouts).
  *
  * @param {Shape} source
  * @param {Shape} element
@@ -123,22 +154,35 @@ export function getTextAnnotationPosition(source, element) {
 
   var sourceTrbl = asTRBL(source);
 
-  var position = {
+  var placeHorizontally = isDirectionHorizontal(source);
+
+  var position = placeHorizontally ? {
     x: sourceTrbl.right + element.width / 2,
     y: sourceTrbl.top - 50 - element.height / 2
+  } : {
+    x: sourceTrbl.right + 50 + element.width / 2,
+    y: sourceTrbl.bottom + element.height / 2
   };
 
   if (isConnection(source)) {
     position = getMid(source);
-    position.x += 100;
-    position.y -= 50;
+    if (placeHorizontally) {
+      position.x += 100;
+      position.y -= 50;
+    } else {
+      position.x += 100;
+      position.y += 50;
+    }
   }
 
-  var nextPositionDirection = {
-    y: {
-      margin: -30,
-      minDistance: 20
-    }
+  var nextPosition = {
+    margin: placeHorizontally ? -30 : 30,
+    minDistance: 20
+  };
+  var nextPositionDirection = placeHorizontally ? {
+    y: nextPosition
+  } : {
+    x: nextPosition
   };
 
   return findFreePosition(source, element, position, generateGetNextPosition(nextPositionDirection));
@@ -147,7 +191,7 @@ export function getTextAnnotationPosition(source, element) {
 
 /**
  * Get the position for given new data element. Try placing the data element
- * bottom-right of the source.
+ * bottom-right of the source (bottom-left in vertical layouts).
  *
  * @param {Shape} source
  * @param {Shape} element
@@ -158,16 +202,24 @@ export function getDataElementPosition(source, element) {
 
   var sourceTrbl = asTRBL(source);
 
-  var position = {
+  var placeHorizontally = isDirectionHorizontal(source);
+
+  var position = placeHorizontally ? {
     x: sourceTrbl.right - 10 + element.width / 2,
     y: sourceTrbl.bottom + 40 + element.width / 2
+  } : {
+    x: sourceTrbl.left - 40 - element.width / 2,
+    y: sourceTrbl.bottom - 10 + element.height / 2
   };
 
-  var nextPositionDirection = {
-    x: {
-      margin: 30,
-      minDistance: 30
-    }
+  var nextPosition = {
+    margin: 30,
+    minDistance: 30
+  };
+  var nextPositionDirection = placeHorizontally ? {
+    x: nextPosition
+  } : {
+    y: nextPosition
   };
 
   return findFreePosition(source, element, position, generateGetNextPosition(nextPositionDirection));

--- a/lib/features/auto-place/BpmnAutoPlaceUtil.js
+++ b/lib/features/auto-place/BpmnAutoPlaceUtil.js
@@ -126,7 +126,7 @@ export function getFlowNodePosition(source, element) {
 /**
  * @param {DirectionTRBL} orientation
  * @param {number} minDistance
- * @param {any} placement
+ * @param {{ start: DirectionTRBL, end: DirectionTRBL }} placement
  *
  * @return {number}
  */

--- a/lib/features/modeling/BpmnLayouter.js
+++ b/lib/features/modeling/BpmnLayouter.js
@@ -22,6 +22,8 @@ import {
 
 import { is } from '../../util/ModelUtil';
 
+import { isDirectionHorizontal } from './util/ModelingUtil';
+
 /**
  * @typedef {import('diagram-js/lib/util/Types').Point} Point
  *
@@ -41,6 +43,51 @@ import { is } from '../../util/ModelUtil';
 
 var ATTACH_ORIENTATION_PADDING = -10,
     BOUNDARY_TO_HOST_THRESHOLD = 40;
+
+// layout all connection between flow elements h:h, except for
+// (1) outgoing of boundary events -> layout based on attach orientation and target orientation
+// (2) incoming/outgoing of gateways -> v:h for outgoing, h:v for incoming
+// (3) loops connect sides clockwise
+var PREFERRED_LAYOUTS_HORIZONTAL = {
+  default: [ 'h:h' ],
+  fromGateway: [ 'v:h' ],
+  toGateway: [ 'h:v' ],
+  loop: {
+    fromTop: [ 't:r' ],
+    fromRight: [ 'r:b' ],
+    fromLeft: [ 'l:t' ],
+    fromBottom: [ 'b:l' ]
+  },
+  boundaryLoop: {
+    alternateHorizontalSide: 'b',
+    alternateVerticalSide: 'l',
+    default: 'v'
+  },
+  messageFlow: [ 'straight', 'v:v' ],
+  subProcess: [ 'straight', 'h:h' ],
+  isHorizontal: true
+};
+
+// for vertical layouts, switch h and v and loop counter-clockwise
+var PREFERRED_LAYOUTS_VERTICAL = {
+  default: [ 'v:v' ],
+  fromGateway: [ 'h:v' ],
+  toGateway: [ 'v:h' ],
+  loop: {
+    fromTop: [ 't:l' ],
+    fromRight: [ 'r:t' ],
+    fromLeft: [ 'l:b' ],
+    fromBottom: [ 'b:r' ]
+  },
+  boundaryLoop: {
+    alternateHorizontalSide: 't',
+    alternateVerticalSide: 'r',
+    default: 'h'
+  },
+  messageFlow: [ 'straight', 'h:h' ],
+  subProcess: [ 'straight', 'v:v' ],
+  isHorizontal: false
+};
 
 var oppositeOrientationMapping = {
   'top': 'bottom',
@@ -94,9 +141,6 @@ BpmnLayouter.prototype.layoutConnection = function(connection, hints) {
     connectionEnd = getConnectionDocking(waypoints && waypoints[ waypoints.length - 1 ], target);
   }
 
-  // TODO(nikku): support vertical modeling
-  // and invert preferredLayouts accordingly
-
   if (is(connection, 'bpmn:Association') ||
       is(connection, 'bpmn:DataAssociation')) {
 
@@ -105,35 +149,36 @@ BpmnLayouter.prototype.layoutConnection = function(connection, hints) {
     }
   }
 
+  var layout = isDirectionHorizontal(source) ? PREFERRED_LAYOUTS_HORIZONTAL : PREFERRED_LAYOUTS_VERTICAL;
+
   if (is(connection, 'bpmn:MessageFlow')) {
-    manhattanOptions = getMessageFlowManhattanOptions(source, target);
+    manhattanOptions = getMessageFlowManhattanOptions(source, target, layout);
   } else if (is(connection, 'bpmn:SequenceFlow') || isCompensationAssociation(source, target)) {
 
-    // layout all connection between flow elements h:h, except for
-    // (1) outgoing of boundary events -> layout based on attach orientation and target orientation
-    // (2) incoming/outgoing of gateways -> v:h for outgoing, h:v for incoming
-    // (3) loops
     if (source === target) {
       manhattanOptions = {
-        preferredLayouts: getLoopPreferredLayout(source, connection)
+        preferredLayouts: getLoopPreferredLayout(source, connection, layout)
       };
     } else if (is(source, 'bpmn:BoundaryEvent')) {
       manhattanOptions = {
-        preferredLayouts: getBoundaryEventPreferredLayouts(source, target, connectionEnd)
+        preferredLayouts: getBoundaryEventPreferredLayouts(source, target, connectionEnd, layout)
       };
     } else if (isExpandedSubProcess(source) || isExpandedSubProcess(target)) {
-      manhattanOptions = getSubProcessManhattanOptions(source);
+      manhattanOptions = {
+        preferredLayouts: layout.subProcess,
+        preserveDocking: getSubProcessPreserveDocking(source)
+      };
     } else if (is(source, 'bpmn:Gateway')) {
       manhattanOptions = {
-        preferredLayouts: [ 'v:h' ]
+        preferredLayouts: layout.fromGateway
       };
     } else if (is(target, 'bpmn:Gateway')) {
       manhattanOptions = {
-        preferredLayouts: [ 'h:v' ]
+        preferredLayouts: layout.toGateway
       };
     } else {
       manhattanOptions = {
-        preferredLayouts: [ 'h:h' ]
+        preferredLayouts: layout.default
       };
     }
   }
@@ -163,9 +208,9 @@ function getAttachOrientation(attachedElement) {
   return getOrientation(getMid(attachedElement), hostElement, ATTACH_ORIENTATION_PADDING);
 }
 
-function getMessageFlowManhattanOptions(source, target) {
+function getMessageFlowManhattanOptions(source, target, layout) {
   return {
-    preferredLayouts: [ 'straight', 'v:v' ],
+    preferredLayouts: layout.messageFlow,
     preserveDocking: getMessageFlowPreserveDocking(source, target)
   };
 }
@@ -200,13 +245,6 @@ function getMessageFlowPreserveDocking(source, target) {
   }
 
   return null;
-}
-
-function getSubProcessManhattanOptions(source) {
-  return {
-    preferredLayouts: [ 'straight', 'h:h' ],
-    preserveDocking: getSubProcessPreserveDocking(source)
-  };
 }
 
 function getSubProcessPreserveDocking(source) {
@@ -271,23 +309,23 @@ function isHorizontalOrientation(orientation) {
   return orientation === 'right' || orientation === 'left';
 }
 
-function getLoopPreferredLayout(source, connection) {
+function getLoopPreferredLayout(source, connection, layout) {
   var waypoints = connection.waypoints;
 
   var orientation = waypoints && waypoints.length && getOrientation(waypoints[0], source);
 
   if (orientation === 'top') {
-    return [ 't:r' ];
+    return layout.loop.fromTop;
   } else if (orientation === 'right') {
-    return [ 'r:b' ];
+    return layout.loop.fromRight;
   } else if (orientation === 'left') {
-    return [ 'l:t' ];
+    return layout.loop.fromLeft;
   }
 
-  return [ 'b:l' ];
+  return layout.loop.fromBottom;
 }
 
-function getBoundaryEventPreferredLayouts(source, target, end) {
+function getBoundaryEventPreferredLayouts(source, target, end, layout) {
   var sourceMid = getMid(source),
       targetMid = getMid(target),
       attachOrientation = getAttachOrientation(source),
@@ -304,31 +342,31 @@ function getBoundaryEventPreferredLayouts(source, target, end) {
   });
 
   if (isLoop) {
-    return getBoundaryEventLoopLayout(attachOrientation, attachedToSide, source, target, end);
+    return getBoundaryEventLoopLayout(attachOrientation, attachedToSide, source, target, end, layout);
   }
 
   // source layout
-  sourceLayout = getBoundaryEventSourceLayout(attachOrientation, targetOrientation, attachedToSide);
+  sourceLayout = getBoundaryEventSourceLayout(attachOrientation, targetOrientation, attachedToSide, layout.isHorizontal);
 
   // target layout
-  targetLayout = getBoundaryEventTargetLayout(attachOrientation, targetOrientation, attachedToSide);
+  targetLayout = getBoundaryEventTargetLayout(attachOrientation, targetOrientation, attachedToSide, layout.isHorizontal);
 
   return [ sourceLayout + ':' + targetLayout ];
 }
 
-function getBoundaryEventLoopLayout(attachOrientation, attachedToSide, source, target, end) {
-  var orientation = attachedToSide ? attachOrientation : getVerticalOrientation(attachOrientation),
+function getBoundaryEventLoopLayout(attachOrientation, attachedToSide, source, target, end, layout) {
+  var orientation = attachedToSide ? attachOrientation : layout.isHorizontal ? getVerticalOrientation(attachOrientation) : getHorizontalOrientation(attachOrientation),
       sourceLayout = orientationDirectionMapping[ orientation ],
       targetLayout;
 
   if (attachedToSide) {
     if (isHorizontalOrientation(attachOrientation)) {
-      targetLayout = shouldConnectToSameSide('y', source, target, end) ? 'h' : 'b';
+      targetLayout = shouldConnectToSameSide('y', source, target, end) ? 'h' : layout.boundaryLoop.alternateHorizontalSide;
     } else {
-      targetLayout = shouldConnectToSameSide('x', source, target, end) ? 'v' : 'l';
+      targetLayout = shouldConnectToSameSide('x', source, target, end) ? 'v' : layout.boundaryLoop.alternateVerticalSide;
     }
   } else {
-    targetLayout = 'v';
+    targetLayout = layout.boundaryLoop.default;
   }
 
   return [ sourceLayout + ':' + targetLayout ];
@@ -351,7 +389,7 @@ function areCloseOnAxis(axis, a, b, threshold) {
   return Math.abs(a[ axis ] - b[ axis ]) < threshold;
 }
 
-function getBoundaryEventSourceLayout(attachOrientation, targetOrientation, attachedToSide) {
+function getBoundaryEventSourceLayout(attachOrientation, targetOrientation, attachedToSide, isHorizontal) {
 
   // attached to either top, right, bottom or left side
   if (attachedToSide) {
@@ -360,20 +398,36 @@ function getBoundaryEventSourceLayout(attachOrientation, targetOrientation, atta
 
   // attached to either top-right, top-left, bottom-right or bottom-left corner
 
-  // same vertical or opposite horizontal orientation
-  if (isSame(
-    getVerticalOrientation(attachOrientation), getVerticalOrientation(targetOrientation)
-  ) || isOppositeOrientation(
-    getHorizontalOrientation(attachOrientation), getHorizontalOrientation(targetOrientation)
-  )) {
-    return orientationDirectionMapping[ getVerticalOrientation(attachOrientation) ];
+  var verticalAttachOrientation = getVerticalOrientation(attachOrientation),
+      horizontalAttachOrientation = getHorizontalOrientation(attachOrientation),
+      verticalTargetOrientation = getVerticalOrientation(targetOrientation),
+      horizontalTargetOrientation = getHorizontalOrientation(targetOrientation);
+
+  if (isHorizontal) {
+
+    // same vertical or opposite horizontal orientation
+    if (
+      isSame(verticalAttachOrientation, verticalTargetOrientation) ||
+      isOppositeOrientation(horizontalAttachOrientation, horizontalTargetOrientation)
+    ) {
+      return orientationDirectionMapping[ verticalAttachOrientation ];
+    }
+  } else {
+
+    // same horizontal or opposite vertical orientation
+    if (
+      isSame(horizontalAttachOrientation, horizontalTargetOrientation) ||
+      isOppositeOrientation(verticalAttachOrientation, verticalTargetOrientation)
+    ) {
+      return orientationDirectionMapping[ horizontalAttachOrientation ];
+    }
   }
 
   // fallback
-  return orientationDirectionMapping[ getHorizontalOrientation(attachOrientation) ];
+  return orientationDirectionMapping[ isHorizontal ? horizontalAttachOrientation : verticalAttachOrientation ];
 }
 
-function getBoundaryEventTargetLayout(attachOrientation, targetOrientation, attachedToSide) {
+function getBoundaryEventTargetLayout(attachOrientation, targetOrientation, attachedToSide, isHorizontal) {
 
   // attached to either top, right, bottom or left side
   if (attachedToSide) {
@@ -409,14 +463,19 @@ function getBoundaryEventTargetLayout(attachOrientation, targetOrientation, atta
   }
 
   // attached to either top-right, top-left, bottom-right or bottom-left corner
+  // and orientation is same on the counter-axis
 
-  // orientation is right, left
-  // or same vertical orientation but also right or left
-  if (isHorizontalOrientation(targetOrientation) ||
-    (isSame(getVerticalOrientation(attachOrientation), getVerticalOrientation(targetOrientation)) &&
-      getHorizontalOrientation(targetOrientation))) {
-    return 'h';
+  if (isHorizontal) {
+    if (isSame(getVerticalOrientation(attachOrientation), getVerticalOrientation(targetOrientation))) {
+      return 'h';
+    } else {
+      return 'v';
+    }
   } else {
-    return 'v';
+    if (isSame(getHorizontalOrientation(attachOrientation), getHorizontalOrientation(targetOrientation))) {
+      return 'v';
+    } else {
+      return 'h';
+    }
   }
 }

--- a/lib/features/modeling/util/ModelingUtil.js
+++ b/lib/features/modeling/util/ModelingUtil.js
@@ -47,10 +47,9 @@ export function isDirectionHorizontal(element) {
   var parent = getParent(element, types);
   if (parent) {
     return isHorizontal(parent);
-  } else
-  if (isAny(element, types)) {
+  } else if (isAny(element, types)) {
     return isHorizontal(element);
   }
-  return true;
 
+  return true;
 }

--- a/lib/features/modeling/util/ModelingUtil.js
+++ b/lib/features/modeling/util/ModelingUtil.js
@@ -4,6 +4,8 @@ export { is, isAny } from '../../../util/ModelUtil';
 
 import { isAny } from '../../../util/ModelUtil';
 
+import { isHorizontal } from '../../../util/DiUtil';
+
 /**
  * @typedef {import('../../../model/Types').Element} Element
  */
@@ -29,4 +31,26 @@ export function getParent(element, anyType) {
   }
 
   return null;
+}
+
+/**
+ * Determines if the local modeling direction is vertical or horizontal.
+ *
+ * @param {Element} element
+ *
+ * @return {boolean} false for vertical pools, lanes and their children. true otherwise
+ */
+export function isDirectionHorizontal(element) {
+
+  var types = [ 'bpmn:Participant', 'bpmn:Lane' ];
+
+  var parent = getParent(element, types);
+  if (parent) {
+    return isHorizontal(parent);
+  } else
+  if (isAny(element, types)) {
+    return isHorizontal(element);
+  }
+  return true;
+
 }

--- a/test/spec/features/auto-place/BpmnAutoPlace.vertical.boundary-events.bpmn
+++ b/test/spec/features/auto-place/BpmnAutoPlace.vertical.boundary-events.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <collaboration id="Collaboration_00uhzgy">
+    <participant id="Participant_0z8w6pv" name="Vertical Container" processRef="Process_0d17hu8" />
+  </collaboration>
+  <process id="Process_0d17hu8" isExecutable="false">
+    <task id="V_TASK_1" name="TASK_1">
+      <outgoing>Flow_1y0zvux</outgoing>
+    </task>
+    <task id="V_TASK_2" name="TASK_2">
+      <incoming>Flow_1y0zvux</incoming>
+    </task>
+    <task id="V_TASK_3" name="TASK_3" />
+    <subProcess id="V_SUBPROCESS" name="SUBPROCESS" />
+    <boundaryEvent id="V_BOUNDARY_LEFT" name="BOUNDARY_LEFT" attachedToRef="V_TASK_1" />
+    <boundaryEvent id="V_BOUNDARY_RIGHT" name="BOUNDARY_RIGHT" attachedToRef="V_TASK_1" />
+    <boundaryEvent id="V_BOUNDARY_BOTTOM_LEFT" name="BOUNDARY_BOTTOM_LEFT" attachedToRef="V_TASK_2" />
+    <boundaryEvent id="V_BOUNDARY_SUBPROCESS_LEFT" name="BOUNDARY_SUBPROCESS_LEFT" attachedToRef="V_SUBPROCESS" />
+    <boundaryEvent id="V_BOUNDARY_SUBPROCESS_RIGHT" name="BOUNDARY_SUBPROCESS_RIGHT" attachedToRef="V_SUBPROCESS" />
+    <sequenceFlow id="Flow_1y0zvux" sourceRef="V_TASK_1" targetRef="V_TASK_2" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Collaboration_00uhzgy">
+      <bpmndi:BPMNShape id="Participant_0z8w6pv_di" bpmnElement="Participant_0z8w6pv" isHorizontal="false">
+        <omgdc:Bounds x="150" y="70" width="720" height="460" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_128m38c_di" bpmnElement="V_TASK_1">
+        <omgdc:Bounds x="280" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yg8kwt_di" bpmnElement="V_TASK_2">
+        <omgdc:Bounds x="280" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x017g4_di" bpmnElement="V_TASK_3">
+        <omgdc:Bounds x="410" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m7ggp4_di" bpmnElement="V_SUBPROCESS" isExpanded="true">
+        <omgdc:Bounds x="560" y="160" width="140" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eqqcds_di" bpmnElement="V_BOUNDARY_SUBPROCESS_RIGHT">
+        <omgdc:Bounds x="682" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="718" y="160" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0o5rw4a_di" bpmnElement="V_BOUNDARY_SUBPROCESS_LEFT">
+        <omgdc:Bounds x="542" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="468" y="150" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0g6qahc_di" bpmnElement="V_BOUNDARY_BOTTOM_LEFT">
+        <omgdc:Bounds x="262" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="238" y="395" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ppxmxi_di" bpmnElement="V_BOUNDARY_RIGHT">
+        <omgdc:Bounds x="362" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="381" y="156" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0e90iez_di" bpmnElement="V_BOUNDARY_LEFT">
+        <omgdc:Bounds x="262" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="199" y="156" width="82" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1y0zvux_di" bpmnElement="Flow_1y0zvux">
+        <omgdi:waypoint x="330" y="240" />
+        <omgdi:waypoint x="330" y="290" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/auto-place/BpmnAutoPlace.vertical.bpmn
+++ b/test/spec/features/auto-place/BpmnAutoPlace.vertical.bpmn
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ignc9k" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:collaboration id="Collaboration_0p66v1k">
+    <bpmn:participant id="Participant_19mkn6l" name="Vertical Container" processRef="Process_0f5io8u" />
+    <bpmn:textAnnotation id="TextAnnotation_0mgb6fp" />
+    <bpmn:association id="Association_0r7uwu2" associationDirection="None" sourceRef="V_Task_3" targetRef="TextAnnotation_0mgb6fp" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0f5io8u" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_0dssf78" />
+    <bpmn:startEvent id="Start_Event_0">
+      <bpmn:outgoing>Flow_1mfxkzi</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="V_Task_0" name="V_Task_0">
+      <bpmn:incoming>Flow_1mfxkzi</bpmn:incoming>
+      <bpmn:incoming>Flow_0hd2tlx</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:intermediateThrowEvent id="Event_11wc1st">
+      <bpmn:outgoing>Flow_0hd2tlx</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:startEvent id="Start_Event_1">
+      <bpmn:outgoing>Flow_05pkcjk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="V_Task_1" name="V_Task_1">
+      <bpmn:incoming>Flow_05pkcjk</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="V_Task_3" name="V_Task_3">
+      <bpmn:outgoing>Flow_1atamhe</bpmn:outgoing>
+      <bpmn:dataOutputAssociation id="DataOutputAssociation_0ztmifm">
+        <bpmn:targetRef>DataStoreReference_0urqui4</bpmn:targetRef>
+      </bpmn:dataOutputAssociation>
+    </bpmn:task>
+    <bpmn:task id="V_Task_4" name="V_Task_4">
+      <bpmn:incoming>Flow_1atamhe</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:task id="V_Task_5" name="V_Task_5">
+      <bpmn:incoming>Flow_07bte1m</bpmn:incoming>
+      <bpmn:incoming>Flow_1u4h0mv</bpmn:incoming>
+      <bpmn:incoming>Flow_1fj63ew</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:startEvent id="Start_Event_5c">
+      <bpmn:outgoing>Flow_1fj63ew</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="V_Task_2" name="V_Task_2">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:subProcess id="V_Sub_Process_1" name="V_Sub_Process_1" />
+    <bpmn:sequenceFlow id="Flow_1mfxkzi" sourceRef="Start_Event_0" targetRef="V_Task_0" />
+    <bpmn:sequenceFlow id="Flow_0hd2tlx" sourceRef="Event_11wc1st" targetRef="V_Task_0" />
+    <bpmn:sequenceFlow id="Flow_05pkcjk" sourceRef="Start_Event_1" targetRef="V_Task_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="V_Task_1" targetRef="V_Task_2" />
+    <bpmn:sequenceFlow id="Flow_1atamhe" sourceRef="V_Task_3" targetRef="V_Task_4" />
+    <bpmn:sequenceFlow id="Flow_07bte1m" sourceRef="Start_Event_5b" targetRef="V_Task_5" />
+    <bpmn:sequenceFlow id="Flow_1u4h0mv" sourceRef="Start_Event_5a" targetRef="V_Task_5" />
+    <bpmn:sequenceFlow id="Flow_1fj63ew" sourceRef="Start_Event_5c" targetRef="V_Task_5" />
+    <bpmn:startEvent id="Start_Event" name="Start_Event" />
+    <bpmn:startEvent id="Start_Event_5a">
+      <bpmn:outgoing>Flow_1u4h0mv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Start_Event_5b">
+      <bpmn:outgoing>Flow_07bte1m</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:dataStoreReference id="DataStoreReference_0urqui4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0p66v1k">
+      <bpmndi:BPMNShape id="Participant_19mkn6l_di" bpmnElement="Participant_19mkn6l" isHorizontal="false">
+        <dc:Bounds x="160" y="80" width="780" height="1150" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tma4cw_di" bpmnElement="Start_Event_0">
+        <dc:Bounds x="292" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07pv6zp_di" bpmnElement="V_Task_0">
+        <dc:Bounds x="260" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11wc1st_di" bpmnElement="Event_11wc1st">
+        <dc:Bounds x="202" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0j193v2_di" bpmnElement="Start_Event_1">
+        <dc:Bounds x="432" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgae2h_di" bpmnElement="V_Task_1">
+        <dc:Bounds x="400" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01nha6s_di" bpmnElement="V_Task_3">
+        <dc:Bounds x="320" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1rsjcrk_di" bpmnElement="V_Task_4">
+        <dc:Bounds x="320" y="1090" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fm33gl_di" bpmnElement="V_Task_5">
+        <dc:Bounds x="590" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_082abml_di" bpmnElement="Start_Event_5c">
+        <dc:Bounds x="692" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fh6yd7_di" bpmnElement="V_Task_2">
+        <dc:Bounds x="400" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_0urqui4_di" bpmnElement="DataStoreReference_0urqui4">
+        <dc:Bounds x="225" y="835" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03j5prr_di" bpmnElement="V_Sub_Process_1" isExpanded="true">
+        <dc:Bounds x="658" y="570" width="182" height="310" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zdlsl0_di" bpmnElement="Start_Event">
+        <dc:Bounds x="602" y="1002" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="650" y="1013" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0iix2qp_di" bpmnElement="Start_Event_5a">
+        <dc:Bounds x="622" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0axdds6_di" bpmnElement="Start_Event_5b">
+        <dc:Bounds x="582" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1mfxkzi_di" bpmnElement="Flow_1mfxkzi">
+        <di:waypoint x="310" y="238" />
+        <di:waypoint x="310" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hd2tlx_di" bpmnElement="Flow_0hd2tlx">
+        <di:waypoint x="220" y="372" />
+        <di:waypoint x="220" y="330" />
+        <di:waypoint x="260" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05pkcjk_di" bpmnElement="Flow_05pkcjk">
+        <di:waypoint x="450" y="238" />
+        <di:waypoint x="450" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06dk35w_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="450" y="370" />
+        <di:waypoint x="450" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1atamhe_di" bpmnElement="Flow_1atamhe">
+        <di:waypoint x="370" y="840" />
+        <di:waypoint x="370" y="1090" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07bte1m_di" bpmnElement="Flow_07bte1m">
+        <di:waypoint x="600" y="208" />
+        <di:waypoint x="600" y="249" />
+        <di:waypoint x="620" y="249" />
+        <di:waypoint x="620" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u4h0mv_di" bpmnElement="Flow_1u4h0mv">
+        <di:waypoint x="640" y="248" />
+        <di:waypoint x="640" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fj63ew_di" bpmnElement="Flow_1fj63ew">
+        <di:waypoint x="710" y="208" />
+        <di:waypoint x="710" y="244" />
+        <di:waypoint x="660" y="244" />
+        <di:waypoint x="660" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0mgb6fp_di" bpmnElement="TextAnnotation_0mgb6fp">
+        <dc:Bounds x="470" y="840" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0r7uwu2_di" bpmnElement="Association_0r7uwu2">
+        <di:waypoint x="420" y="818" />
+        <di:waypoint x="479" y="840" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="DataOutputAssociation_0ztmifm_di" bpmnElement="DataOutputAssociation_0ztmifm">
+        <di:waypoint x="320" y="825" />
+        <di:waypoint x="275" y="848" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/auto-place/BpmnAutoPlace.vertical.multi-connection.bpmn
+++ b/test/spec/features/auto-place/BpmnAutoPlace.vertical.multi-connection.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_1l65oiw">
+    <bpmn:participant id="Participant_0p0tobq" name="Vertical Container" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:sequenceFlow id="SequenceFlow_1q8yl3p" sourceRef="V_TASK_1" targetRef="V_TASK_4" />
+    <bpmn:sequenceFlow id="SequenceFlow_0uj471x" sourceRef="V_TASK_1" targetRef="V_TASK_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sys8ww" sourceRef="V_TASK_1" targetRef="V_TASK_3" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dh9p3h" sourceRef="V_TASK_1" targetRef="V_TASK_2" />
+    <bpmn:task id="V_TASK_1" name="TASK_1">
+      <bpmn:outgoing>SequenceFlow_0uj471x</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0sys8ww</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1q8yl3p</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dh9p3h</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="V_TASK_3" name="TASK_3">
+      <bpmn:incoming>SequenceFlow_0sys8ww</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:task id="V_TASK_4" name="TASK_4">
+      <bpmn:incoming>SequenceFlow_1q8yl3p</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:task id="V_TASK_2" name="TASK_2">
+      <bpmn:incoming>SequenceFlow_0uj471x</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1dh9p3h</bpmn:incoming>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1l65oiw">
+      <bpmndi:BPMNShape id="Participant_0p0tobq_di" bpmnElement="Participant_0p0tobq" isHorizontal="false">
+        <dc:Bounds x="170" y="100" width="500" height="500" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_1_di" bpmnElement="V_TASK_1">
+        <dc:Bounds x="280" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_3_di" bpmnElement="V_TASK_3">
+        <dc:Bounds x="408" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_4_di" bpmnElement="V_TASK_4">
+        <dc:Bounds x="529" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TASK_2_di" bpmnElement="V_TASK_2">
+        <dc:Bounds x="280" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q8yl3p_di" bpmnElement="SequenceFlow_1q8yl3p">
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="579" y="230" />
+        <di:waypoint x="579" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="291.5" y="132" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uj471x_di" bpmnElement="SequenceFlow_0uj471x">
+        <di:waypoint x="330" y="260" />
+        <di:waypoint x="330" y="470" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="135" y="264.5" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sys8ww_di" bpmnElement="SequenceFlow_0sys8ww">
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="458" y="230" />
+        <di:waypoint x="458" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="236" y="132" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dh9p3h_di" bpmnElement="SequenceFlow_1dh9p3h">
+        <di:waypoint x="280" y="230" />
+        <di:waypoint x="220" y="230" />
+        <di:waypoint x="220" y="520" />
+        <di:waypoint x="280" y="520" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="29" y="264.5" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/RemoveElementBehavior.vertical.diagonal.bpmn
+++ b/test/spec/features/modeling/behavior/RemoveElementBehavior.vertical.diagonal.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_18lcs93">
+    <bpmn:participant id="Participant_0vm2g58" name="Vertical Container" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent1">
+      <bpmn:outgoing>SequenceFlow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task1">
+      <bpmn:incoming>SequenceFlow1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent1">
+      <bpmn:incoming>SequenceFlow2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow1" sourceRef="StartEvent1" targetRef="Task1" />
+    <bpmn:sequenceFlow id="SequenceFlow2" sourceRef="Task1" targetRef="EndEvent1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_18lcs93">
+      <bpmndi:BPMNShape id="Participant_0vm2g58_di" bpmnElement="Participant_0vm2g58" isHorizontal="false">
+        <dc:Bounds x="80" y="130" width="250" height="600" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent1_di" bpmnElement="StartEvent1">
+        <dc:Bounds x="106" y="204" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="72" y="177" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task1_di" bpmnElement="Task1">
+        <dc:Bounds x="143" y="407" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent1_di" bpmnElement="EndEvent1">
+        <dc:Bounds x="269" y="650" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="72" y="622" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow1_di" bpmnElement="SequenceFlow1">
+        <di:waypoint x="124" y="240" />
+        <di:waypoint x="124" y="324" />
+        <di:waypoint x="183" y="324" />
+        <di:waypoint x="183" y="407" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="44" y="278.5" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow2_di" bpmnElement="SequenceFlow2">
+        <di:waypoint x="183" y="487" />
+        <di:waypoint x="183" y="579" />
+        <di:waypoint x="287" y="579" />
+        <di:waypoint x="287" y="650" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="44" y="533" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/behavior/RemoveElementBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/RemoveElementBehaviorSpec.js
@@ -246,6 +246,44 @@ describe('features/modeling - remove element behavior', function() {
 
     });
 
+
+    describe('vertical connection layouting', function() {
+
+      var processDiagramXML = require('./RemoveElementBehavior.vertical.diagonal.bpmn');
+
+      beforeEach(bootstrapModeler(processDiagramXML, { modules: testModules }));
+
+
+      it('should execute', inject(function(modeling, elementRegistry) {
+
+        // given
+        var task = elementRegistry.get('Task1');
+        var sequenceFlow1 = elementRegistry.get('SequenceFlow1');
+
+        // when
+        modeling.removeShape(task);
+
+        // then
+        var waypoints = sequenceFlow1.waypoints;
+
+        // SequenceFlow2 should be deleted
+        expect(elementRegistry.get('SequenceFlow2')).to.be.undefined;
+        expect(elementRegistry.get(task.id)).to.be.undefined;
+
+        // source and target have one connection each
+        expect(elementRegistry.get('StartEvent1').outgoing.length).to.be.equal(1);
+        expect(elementRegistry.get('EndEvent1').incoming.length).to.be.equal(1);
+
+        // connection has Manhattan layout
+        expect(waypoints).to.have.length(4);
+        expect(waypoints[0].x).to.eql(waypoints[1].x);
+        expect(waypoints[1].y).to.eql(waypoints[2].y);
+        expect(waypoints[2].x).to.eql(waypoints[3].x);
+
+      }));
+
+    });
+
   });
 
 

--- a/test/spec/features/modeling/layout/LayoutMessageFlowSpec.js
+++ b/test/spec/features/modeling/layout/LayoutMessageFlowSpec.js
@@ -310,3 +310,309 @@ describe('features/modeling - layout message flows', function() {
   });
 
 });
+
+
+describe('features/modeling - vertical layout message flows', function() {
+
+  var diagramXML = require('./LayoutMessageFlowSpec.vertical.bpmn');
+
+  var testModules = [ coreModule, modelingModule ];
+
+  beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+  it('should layout manhattan after Task move', inject(function(elementRegistry, modeling) {
+
+    // given
+    var taskShape = elementRegistry.get('Task_A'),
+        messageFlowConnection = elementRegistry.get('MessageFlow_4');
+
+    // when
+    modeling.moveElements([ taskShape ], { x: 20, y: 30 });
+
+    // then
+    // expect cropped, repaired manhattan connection
+    expect(messageFlowConnection).to.have.waypoints([
+      { x: 244, y: 420 },
+      { x: 387, y: 420 },
+      { x: 387, y: 318 },
+      { x: 448, y: 318 }
+    ]);
+  }));
+
+
+  it('should layout Task -> Participant straight after Task move',
+    inject(function(elementRegistry, modeling) {
+
+      // given
+      var taskShape = elementRegistry.get('Task_B'),
+          messageFlowConnection = elementRegistry.get('MessageFlow_1');
+
+      // when
+      modeling.moveElements([ taskShape ], { x: -20, y: 20 });
+
+      // then
+
+      // expect cropped, repaired manhattan connection
+      expect(messageFlowConnection).to.have.waypoints([
+        { x: 204, y: 600 },
+        { x: 415, y: 600 }
+      ]);
+    })
+  );
+
+
+  it('should layout straight after Participant move', inject(function(elementRegistry, modeling) {
+
+    // given
+    var participantShape = elementRegistry.get('Participant_B'),
+        messageFlowConnection = elementRegistry.get('MessageFlow_5');
+
+    // when
+    modeling.moveElements([ participantShape ], { x: 50, y: 100 });
+
+    // then
+
+    // expect cropped, repaired manhattan connection
+    expect(messageFlowConnection).to.have.waypoints([
+      { x: 214, y: 671 },
+      { x: 465, y: 671 }
+    ]);
+  }));
+
+
+  it('should layout EndEvent -> Participant manhattan',
+    inject(function(elementRegistry, modeling) {
+
+      // given
+      var participantShape = elementRegistry.get('Participant_B'),
+          messageFlowConnection = elementRegistry.get('MessageFlow_5');
+
+      // when
+      modeling.moveElements([ participantShape ], { x: 0, y: -200 });
+
+      // then
+      // expect cropped, repaired manhattan connection
+      expect(messageFlowConnection).to.have.waypoints([
+        { x: 214, y: 671 },
+        { x: 315, y: 671 },
+        { x: 315, y: 471 },
+        { x: 415, y: 471 }
+      ]);
+    })
+  );
+
+
+  it('should layout SubProcess -> SubProcess (straight) on SubProcess move',
+    inject(function(elementRegistry, modeling) {
+
+      // given
+      var subProcessShape = elementRegistry.get('SubProcess_G'),
+          messageFlowConnection = elementRegistry.get('MessageFlow_3');
+
+      // when
+      modeling.moveElements([ subProcessShape ], { x: 0, y: 300 });
+
+      // then
+      expect(messageFlowConnection).to.have.waypoints([
+        { x: 266, y: 902 },
+        { x: 458, y: 902 }
+      ]);
+    })
+  );
+
+
+  describe('should keep task docking', function() {
+
+    describe('on SubProcess resize', function() {
+
+      it('SubProcess -> Task (straight)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var subProcessShape = elementRegistry.get('SubProcess_G'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_7');
+
+          // when
+          modeling.resizeShape(subProcessShape, {
+            x: 458,
+            y: 586,
+            width: 122,
+            height: 212
+          });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 458, y: 752 },
+            { x: 224, y: 752 }
+          ]);
+        })
+      );
+    });
+
+
+    describe('on SubProcess move', function() {
+
+      it('SubProcess -> Task (straight)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var subProcessShape = elementRegistry.get('SubProcess_G'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_7');
+
+          // when
+          modeling.moveElements([ subProcessShape ], { x: 0, y: 50 });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 458, y: 752 },
+            { x: 224, y: 752 }
+          ]);
+        })
+      );
+    });
+
+
+    describe('on Participant move', function() {
+
+      it('Task -> Participant (straight)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var participantShape = elementRegistry.get('Participant_B'),
+              messageFlowConnection_1 = elementRegistry.get('MessageFlow_1'),
+              messageFlowConnection_6 = elementRegistry.get('MessageFlow_6');
+
+          // when
+          modeling.moveElements([ participantShape ], { x: 50, y: 300 });
+
+          // then
+
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection_1).to.have.waypoints([
+            { x: 224, y: 580 },
+            { x: 465, y: 580 }
+          ]);
+
+          expect(messageFlowConnection_6).to.have.waypoints([
+            { x: 465, y: 773 },
+            { x: 224, y: 773 }
+          ]);
+        })
+      );
+
+    });
+
+
+    describe('on Participant resize', function() {
+
+      it('Task -> Participant (straight)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var participantShape = elementRegistry.get('Participant_B'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_1');
+
+          // when
+          modeling.resizeShape(participantShape, {
+            x: 415,
+            y: 222,
+            width: 185,
+            height: 580
+          });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 224, y: 580 },
+            { x: 415, y: 580 }
+          ]);
+        })
+      );
+
+
+      it('Participant -> Task (straight)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var participantShape = elementRegistry.get('Participant_B'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_6');
+
+          // when
+          modeling.resizeShape(participantShape, {
+            x: 415,
+            y: 222,
+            width: 185,
+            height: 580
+          });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 415, y: 773 },
+            { x: 224, y: 773 }
+          ]);
+        })
+      );
+
+
+      it('Task -> Participant (manhattan)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var participantShape = elementRegistry.get('Participant_B'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_1');
+
+          // when
+          modeling.resizeShape(participantShape, {
+            x: 415,
+            y: 622,
+            width: 185,
+            height: 600
+          });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 224, y: 580 },
+            { x: 320, y: 580 },
+            { x: 320, y: 980 },
+            { x: 415, y: 980 }
+          ]);
+        })
+      );
+
+
+      it('Participant -> Task (manhattan)',
+        inject(function(elementRegistry, modeling) {
+
+          // given
+          var participantShape = elementRegistry.get('Participant_B'),
+              messageFlowConnection = elementRegistry.get('MessageFlow_6');
+
+          // when
+          modeling.resizeShape(participantShape, {
+            x: 415,
+            y: 222,
+            width: 185,
+            height: 500
+          });
+
+          // then
+          // expect cropped, repaired manhattan connection
+          expect(messageFlowConnection).to.have.waypoints([
+            { x: 415, y: 681 },
+            { x: 320, y: 681 },
+            { x: 320, y: 773 },
+            { x: 224, y: 773 }
+          ]);
+        })
+      );
+
+    });
+
+  });
+
+});

--- a/test/spec/features/modeling/layout/LayoutMessageFlowSpec.vertical.bpmn
+++ b/test/spec/features/modeling/layout/LayoutMessageFlowSpec.vertical.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_pHDz0KojEeOJhIBv1RySdg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:collaboration id="_Collaboration_2">
+    <bpmn2:participant id="Participant_A" name="A" processRef="Process_A" />
+    <bpmn2:participant id="Participant_B" name="B" processRef="Process_B" />
+    <bpmn2:messageFlow id="MessageFlow_1" name="1" sourceRef="Task_B" targetRef="Participant_B" />
+    <bpmn2:messageFlow id="MessageFlow_2" name="2" sourceRef="Participant_B" targetRef="Participant_A" />
+    <bpmn2:messageFlow id="MessageFlow_3" name="3" sourceRef="SubProcess_E" targetRef="SubProcess_G" />
+    <bpmn2:messageFlow id="MessageFlow_4" name="4" sourceRef="Task_A" targetRef="StartEvent_F" />
+    <bpmn2:messageFlow id="MessageFlow_5" name="5" sourceRef="EndEvent_C" targetRef="Participant_B" />
+    <bpmn2:messageFlow id="MessageFlow_6" name="6" sourceRef="Participant_B" targetRef="Task_D" />
+    <bpmn2:messageFlow id="MessageFlow_7" name="7" sourceRef="SubProcess_G" targetRef="Task_D" />
+  </bpmn2:collaboration>
+  <bpmn2:process id="Process_A" isExecutable="false">
+    <bpmn2:task id="Task_A" name="A" />
+    <bpmn2:endEvent id="EndEvent_C" name="C">
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_2" />
+    </bpmn2:endEvent>
+    <bpmn2:task id="Task_B" name="B" />
+    <bpmn2:task id="Task_D" name="D" />
+    <bpmn2:subProcess id="SubProcess_E" name="E" />
+  </bpmn2:process>
+  <bpmn2:process id="Process_B" isExecutable="false">
+    <bpmn2:subProcess id="SubProcess_G" name="G" />
+    <bpmn2:startEvent id="StartEvent_F" name="F">
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1" />
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="_Collaboration_2">
+      <bpmndi:BPMNShape id="Participant_A_di" bpmnElement="Participant_A" isHorizontal="false">
+        <dc:Bounds x="64" y="278" width="237" height="823" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_B_di" bpmnElement="Participant_B" isHorizontal="false">
+        <dc:Bounds x="415" y="222" width="185" height="600" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_F_di" bpmnElement="StartEvent_F">
+        <dc:Bounds x="448" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="459" y="313" width="90" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_Task_D" bpmnElement="Task_A">
+        <dc:Bounds x="124" y="360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_MessageFlow_1" bpmnElement="MessageFlow_1" sourceElement="_BPMNShape_Task_4" targetElement="Participant_B_di">
+        <di:waypoint xsi:type="dc:Point" x="224" y="580" />
+        <di:waypoint xsi:type="dc:Point" x="415" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="565" width="90" height="6" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_MessageFlow_2" bpmnElement="MessageFlow_2" sourceElement="Participant_B_di" targetElement="Participant_A_di">
+        <di:waypoint xsi:type="dc:Point" x="415" y="506" />
+        <di:waypoint xsi:type="dc:Point" x="301" y="506" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="356" y="487" width="90" height="6" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_MessageFlow_4" bpmnElement="MessageFlow_4" sourceElement="_BPMNShape_Task_D" targetElement="StartEvent_F_di">
+        <di:waypoint xsi:type="dc:Point" x="224" y="390" />
+        <di:waypoint xsi:type="dc:Point" x="387" y="390" />
+        <di:waypoint xsi:type="dc:Point" x="387" y="318" />
+        <di:waypoint xsi:type="dc:Point" x="448" y="318" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="321" y="361" width="90" height="6" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_C_di" bpmnElement="EndEvent_C">
+        <dc:Bounds x="178" y="653" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="114" y="666" width="90" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_MessageFlow_5" bpmnElement="MessageFlow_5" sourceElement="EndEvent_C_di" targetElement="Participant_B_di">
+        <di:waypoint xsi:type="dc:Point" x="214" y="671" />
+        <di:waypoint xsi:type="dc:Point" x="415" y="671" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="314" y="646" width="90" height="6" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_Task_4" bpmnElement="Task_B">
+        <dc:Bounds x="124" y="516" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_D_di" bpmnElement="Task_D">
+        <dc:Bounds x="124" y="723" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_6_di" bpmnElement="MessageFlow_6">
+        <di:waypoint xsi:type="dc:Point" x="415" y="773" />
+        <di:waypoint xsi:type="dc:Point" x="224" y="773" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="289" y="783" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SubProcess_E_di" bpmnElement="SubProcess_E" isExpanded="true">
+        <dc:Bounds x="135" y="855" width="131" height="184" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_G_di" bpmnElement="SubProcess_G" isExpanded="true">
+        <dc:Bounds x="458" y="566" width="122" height="212" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_7_di" bpmnElement="MessageFlow_7">
+        <di:waypoint xsi:type="dc:Point" x="458" y="752" />
+        <di:waypoint xsi:type="dc:Point" x="224" y="752" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="288" y="728" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="MessageFlow_3_di" bpmnElement="MessageFlow_3">
+        <di:waypoint xsi:type="dc:Point" x="266" y="902" />
+        <di:waypoint xsi:type="dc:Point" x="362" y="902" />
+        <di:waypoint xsi:type="dc:Point" x="362" y="708" />
+        <di:waypoint xsi:type="dc:Point" x="458" y="708" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="330" y="824" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.js
+++ b/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.js
@@ -286,6 +286,274 @@ describe('features/modeling - layout', function() {
   });
 
 
+  describe('vertical boundary events', function() {
+
+    describe('loops', function() {
+
+      var diagramXML = require('./LayoutSequenceFlowSpec.vertical.boundaryEventsLoops.bpmn');
+
+      var testModules = [ coreModule, modelingModule ];
+
+      beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+      describe('in the corner', function() {
+
+        it('attached top right', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_TopRight', 'SubProcess');
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 628, y: 170 },
+            { x: 648, y: 170 },
+            { x: 648, y: 270 },
+            { x: 610, y: 270 }
+          ]);
+        });
+
+
+        it('attached bottom right', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_BottomRight', 'SubProcess');
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 628, y: 338 },
+            { x: 648, y: 338 },
+            { x: 648, y: 270 },
+            { x: 610, y: 270 }
+          ]);
+        });
+
+
+        it('attached bottom left', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_BottomLeft', 'SubProcess');
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 242, y: 370 },
+            { x: 222, y: 370 },
+            { x: 222, y: 270 },
+            { x: 260, y: 270 }
+          ]);
+        });
+
+
+        it('attached top left', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_TopLeft', 'SubProcess');
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 242, y: 208 },
+            { x: 222, y: 208 },
+            { x: 222, y: 270 },
+            { x: 260, y: 270 }
+          ]);
+        });
+      });
+
+
+      describe('on the side center', function() {
+
+        var host = 'SubProcess_2';
+
+
+        it('attached top center', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_TopCenter', host);
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 435, y: 412 },
+            { x: 435, y: 392 },
+            { x: 630, y: 392 },
+            { x: 630, y: 530 },
+            { x: 610, y: 530 }
+          ]);
+        });
+
+
+        it('attached center right', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_CenterRight', host);
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 628, y: 530 },
+            { x: 648, y: 530 },
+            { x: 648, y: 410 },
+            { x: 435, y: 410 },
+            { x: 435, y: 430 }
+          ]);
+        });
+
+
+        it('attached bottom center', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_BottomCenter', host);
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 435, y: 648 },
+            { x: 435, y: 668 },
+            { x: 630, y: 668 },
+            { x: 630, y: 530 },
+            { x: 610, y: 530 }
+          ]);
+        });
+
+
+        it('attached center left', function() {
+
+          // when
+          var connection = connect('BoundaryEvent_CenterLeft', host);
+
+          // then
+          expect(connection).to.have.waypoints([
+            { x: 242, y: 530 },
+            { x: 222, y: 530 },
+            { x: 222, y: 410 },
+            { x: 435, y: 410 },
+            { x: 435, y: 430 }
+          ]);
+        });
+      });
+    });
+
+
+    describe('non-loops', function() {
+
+      var diagramXML = require('./LayoutSequenceFlowSpec.vertical.boundaryEvents.bpmn');
+
+      var testModules = [ coreModule, modelingModule ];
+
+      beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+      it('attached bottom left, orientation left', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomLeft', 'Task_Left');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 502, y: 740 },
+          { x: 260, y: 740 },
+          { x: 260, y: 580 }
+        ]);
+      });
+
+
+      it('attached bottom left, orientation bottom', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomLeft', 'Task_Bottom');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 520, y: 758 },
+          { x: 520, y: 990 },
+          { x: 560, y: 990 }
+        ]);
+      });
+
+
+      it('attached bottom left, orientation right', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomLeft', 'Task_Right');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 502, y: 740 },
+          { x: 482, y: 740 },
+          { x: 482, y: 540 },
+          { x: 860, y: 540 }
+        ]);
+      });
+
+
+      it('attached bottom left, orientation top', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomLeft', 'Task_Top');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 502, y: 740 },
+          { x: 482, y: 740 },
+          { x: 482, y: 140 },
+          { x: 560, y: 140 }
+        ]);
+      });
+
+
+      it('attached right center, orientation right', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_RightCenter', 'Task_Right');
+
+        expect(connection).to.have.waypoints([
+          { x: 738, y: 540 },
+          { x: 860, y: 540 }
+        ]);
+      });
+
+
+      it('attached left center, orientation left', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_LeftCenter', 'Task_Left');
+
+        expect(connection).to.have.waypoints([
+          { x: 502, y: 540 },
+          { x: 310, y: 540 }
+        ]);
+      });
+
+
+      it('attached bottom center, orientation bottom', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomCenter', 'Task_Bottom');
+
+        expect(connection).to.have.waypoints([
+          { x: 610, y: 758 },
+          { x: 610, y: 950 }
+        ]);
+      });
+
+
+      it('attached bottom center, orientation top', function() {
+
+        // when
+        var connection = connect('BoundaryEvent_BottomCenter', 'Task_Top');
+
+        expect(connection).to.have.waypoints([
+          { x: 610, y: 758 },
+          { x: 610, y: 778 },
+          { x: 630, y: 778 },
+          { x: 630, y: 624 },
+          { x: 610, y: 624 },
+          { x: 610, y: 180 }
+        ]);
+      });
+
+    });
+
+  });
+
+
   describe('flow elements', function() {
 
     var diagramXML = require('./LayoutSequenceFlowSpec.flowElements.bpmn');
@@ -553,6 +821,273 @@ describe('features/modeling - layout', function() {
   });
 
 
+  describe('vertical flow elements', function() {
+
+    var diagramXML = require('./LayoutSequenceFlowSpec.vertical.flowElements.bpmn');
+
+    var testModules = [ coreModule, modelingModule ];
+
+    beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+    describe('loops', function() {
+
+      it('should layout loop', function() {
+
+        // when
+        var connection = connect('Task_1', 'Task_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 510, y: 382 },
+          { x: 510, y: 402 },
+          { x: 580, y: 402 },
+          { x: 580, y: 342 },
+          { x: 560, y: 342 }
+        ]);
+      });
+
+
+      it('should NOT relayout loop', inject(function(elementRegistry) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_1'),
+            task = elementRegistry.get('Task_1');
+
+        // when
+        reconnectEnd(sequenceFlow, task, getMid(task));
+
+        // then
+        expect(sequenceFlow).to.have.waypoints([
+          { x: 531, y: 382 },
+          { x: 531, y: 569 },
+          { x: 510, y: 569 },
+          { x: 510, y: 382 }
+        ]);
+      }));
+
+
+      it('should relayout loop (r:t)', inject(function(elementRegistry) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_2'),
+            task = elementRegistry.get('Task_1');
+
+        // when
+        reconnectEnd(sequenceFlow, task, getMid(task));
+
+        // then
+        expect(sequenceFlow).to.have.waypoints([
+          { x: 560, y: 342 },
+          { x: 580, y: 342 },
+          { x: 580, y: 282 },
+          { x: 510, y: 282 },
+          { x: 510, y: 302 }
+        ]);
+      }));
+
+
+      it('should relayout loop (t:l)', inject(function(elementRegistry) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_3'),
+            task = elementRegistry.get('Task_1');
+
+        // when
+        reconnectEnd(sequenceFlow, task, getMid(task));
+
+        // then
+        expect(sequenceFlow).to.have.waypoints([
+          { x: 510, y: 302 },
+          { x: 510, y: 282 },
+          { x: 440, y: 282 },
+          { x: 440, y: 342 },
+          { x: 460, y: 342 }
+        ]);
+      }));
+
+
+      it('should relayout loop (l:b)', inject(function(elementRegistry) {
+
+        // given
+        var sequenceFlow = elementRegistry.get('SequenceFlow_4'),
+            task = elementRegistry.get('Task_1');
+
+        // when
+        reconnectEnd(sequenceFlow, task, getMid(task));
+
+        // then
+        expect(sequenceFlow).to.have.waypoints([
+          { x: 460, y: 342 },
+          { x: 440, y: 342 },
+          { x: 440, y: 402 },
+          { x: 510, y: 402 },
+          { x: 510, y: 382 }
+        ]);
+      }));
+
+    });
+
+
+    describe('gateway layout', function() {
+
+      it('should layout h:v after Gateway', inject(function() {
+
+        // when
+        var connection = connect('ExclusiveGateway_1', 'BusinessRuleTask_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 577, y: 688 },
+          { x: 530, y: 688 },
+          { x: 530, y: 810 }
+        ]);
+      }));
+
+
+      it('should layout v:h before Gateway', inject(function() {
+
+        // when
+        var connection = connect('BusinessRuleTask_1', 'ParallelGateway_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 530, y: 890 },
+          { x: 530, y: 1015 },
+          { x: 577, y: 1015 }
+        ]);
+      }));
+
+    });
+
+
+    describe('other elements layout', function() {
+
+      it('should layout v:v after StartEvent', inject(function() {
+
+        // when
+        var connection = connect('StartEvent_1', 'Task_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 602, y: 198 },
+          { x: 602, y: 250 },
+          { x: 510, y: 250 },
+          { x: 510, y: 302 }
+        ]);
+      }));
+
+
+      it('should layout v:v after Task', inject(function() {
+
+        // when
+        var connection = connect('ServiceTask_1', 'BusinessRuleTask_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 407, y: 728 },
+          { x: 407, y: 769 },
+          { x: 530, y: 769 },
+          { x: 530, y: 810 }
+        ]);
+      }));
+
+
+      it('should layout v:v after IntermediateEvent', inject(function() {
+
+        // when
+        var connection = connect('IntermediateThrowEvent_1', 'ServiceTask_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 602, y: 524 },
+          { x: 602, y: 586 },
+          { x: 407, y: 586 },
+          { x: 407, y: 648 }
+        ]);
+      }));
+
+
+      it('should layout v:v after IntermediateEvent (bottom to top)', inject(function() {
+
+        // when
+        var connection = connect('IntermediateThrowEvent_1', 'Task_1');
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 602, y: 488 },
+          { x: 602, y: 435 },
+          { x: 510, y: 435 },
+          { x: 510, y: 382 }
+        ]);
+      }));
+
+    });
+
+
+    describe('relayout', function() {
+
+      it('should repair after reconnect end', inject(function() {
+
+        // given
+        var newDocking = { x: 660, y: 300 };
+        var connection = element('SequenceFlow_1');
+
+        // when
+        reconnectEnd(connection, 'ExclusiveGateway_1', newDocking);
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 531, y: 382 },
+          { x: 531, y: 569 },
+          { x: 660, y: 569 },
+          { x: 660, y: 300 }
+        ]);
+      }));
+
+
+      it('should repair after target move', inject(function() {
+
+        // given
+        var delta = { x: 20, y: -30 };
+        var connection = element('SequenceFlow_1');
+
+        // when
+        move('ServiceTask_1', delta);
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 531, y: 382 },
+          { x: 531, y: 569 },
+          { x: 448, y: 569 },
+          { x: 448, y: 618 }
+        ]);
+      }));
+
+
+      it('should repair after source move', inject(function() {
+
+        // given
+        var delta = { x: 20, y: -30 };
+        var connection = element('SequenceFlow_1');
+
+        // when
+        move('Task_1', delta);
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: 551, y: 352 },
+          { x: 551, y: 569 },
+          { x: 428, y: 569 },
+          { x: 428, y: 648 }
+        ]);
+      }));
+
+    });
+
+  });
+
+
   describe('subProcess', function() {
 
     var diagramXML = require('./LayoutSequenceFlowSpec.subProcess.bpmn');
@@ -664,6 +1199,122 @@ describe('features/modeling - layout', function() {
       expect(connection).to.have.waypoints([
         { x: expectedX, y: source.y + source.height },
         { x: expectedX, y: target.y }
+      ]);
+    });
+  });
+
+
+  describe('vertical subProcess', function() {
+
+    var diagramXML = require('./LayoutSequenceFlowSpec.vertical.subProcess.bpmn');
+
+    var testModules = [ coreModule, modelingModule ];
+
+    beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+    it('should layout straight between subProcesses (left -> right)', function() {
+
+      // when
+      var connection = connect('SubProcess_Center', 'SubProcess_Right'),
+          source = connection.source,
+          target = connection.target;
+
+      var expectedY = getMid(target).y;
+
+      // then
+      expect(connection).to.have.waypoints([
+        { x: source.x + source.width, y: expectedY },
+        { x: target.x, y: expectedY }
+      ]);
+    });
+
+
+    it('should layout straight between subProcesses (right -> left)', function() {
+
+      // when
+      var connection = connect('SubProcess_Right', 'SubProcess_Center'),
+          source = connection.source,
+          target = connection.target;
+
+      var expectedY = getMid(target).y;
+
+      // then
+      expect(connection).to.have.waypoints([
+        { x: source.x, y: expectedY },
+        { x: target.x + target.width, y: expectedY }
+      ]);
+    });
+
+
+    it('should layout straight between subProcess and task below (subProcess -> task)',
+      function() {
+
+        // when
+        var connection = connect('SubProcess_Center', 'Task_Bottom'),
+            source = connection.source,
+            target = connection.target;
+
+        var expectedX = getMid(target).x;
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: expectedX, y: source.y + source.height },
+          { x: expectedX, y: target.y }
+        ]);
+      }
+    );
+
+
+    it('should layout straight between subProcess and task below (task -> subProcess)',
+      function() {
+
+        // when
+        var connection = connect('Task_Bottom', 'SubProcess_Center'),
+            source = connection.source,
+            target = connection.target;
+
+        var expectedX = getMid(source).x;
+
+        // then
+        expect(connection).to.have.waypoints([
+          { x: expectedX, y: source.y },
+          { x: expectedX, y: target.y + target.height }
+        ]);
+      }
+    );
+
+
+    it('should layout straight between subProcess and task next to it (subProcess -> task)', function() {
+
+      // when
+      var connection = connect('SubProcess_Center', 'Task_Left'),
+          source = connection.source,
+          target = connection.target;
+
+      var expectedY = getMid(target).y;
+
+      // then
+      expect(connection).to.have.waypoints([
+        { x: source.x, y: expectedY },
+        { x: target.x + target.width, y: expectedY }
+      ]);
+    });
+
+
+    it('should layout straight between subProcess and task next to it (task -> subProcess)', function() {
+
+      // when
+      var connection = connect('Task_Left', 'SubProcess_Center'),
+          source = connection.source,
+          target = connection.target;
+
+      var expectedY = getMid(source).y;
+
+      // then
+      expect(connection).to.have.waypoints([
+        { x: source.x + source.width, y: expectedY },
+        { x: target.x, y: expectedY }
       ]);
     });
   });

--- a/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.boundaryEvents.bpmn
+++ b/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.boundaryEvents.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_1c6j3sk">
+    <bpmn:participant id="Participant_0gpnzzr" name="Vertical Container" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Task_Bottom" name="Bottom" />
+    <bpmn:task id="Task_Top" name="Top" />
+    <bpmn:subProcess id="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomCenter" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomLeft" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_TopRight" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_RightCenter" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomRight1" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_LeftCenter" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_TopLeft1" attachedToRef="SubProcess" />
+    <bpmn:task id="Task_Right" name="Right" />
+    <bpmn:task id="Task_Left" name="Left" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1c6j3sk">
+      <bpmndi:BPMNShape id="Participant_0gpnzzr_di" bpmnElement="Participant_0gpnzzr" isHorizontal="false">
+        <dc:Bounds x="190" y="50" width="790" height="1000" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0ygk7bh_di" bpmnElement="Task_Right">
+        <dc:Bounds x="860" y="500" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_174r9fd_di" bpmnElement="Task_Bottom">
+        <dc:Bounds x="560" y="950" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0b6k3xo_di" bpmnElement="Task_Top">
+        <dc:Bounds x="560" y="100" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1bc634w_di" bpmnElement="Task_Left">
+        <dc:Bounds x="210" y="500" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_12qmapm_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="520" y="390" width="200" height="350" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0s0nl1k_di" bpmnElement="BoundaryEvent_TopLeft1">
+        <dc:Bounds x="540" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_TopCenter_di" bpmnElement="BoundaryEvent_LeftCenter">
+        <dc:Bounds x="502" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0nomac7_di" bpmnElement="BoundaryEvent_BottomRight1">
+        <dc:Bounds x="670" y="722" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_BottomCenter_di" bpmnElement="BoundaryEvent_RightCenter">
+        <dc:Bounds x="702" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1spolhy_di" bpmnElement="BoundaryEvent_TopRight">
+        <dc:Bounds x="702" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_13iwzlu_di" bpmnElement="BoundaryEvent_BottomLeft">
+        <dc:Bounds x="502" y="722" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_RightCenter_di" bpmnElement="BoundaryEvent_BottomCenter">
+        <dc:Bounds x="592" y="722" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.boundaryEventsLoops.bpmn
+++ b/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.boundaryEventsLoops.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_0ffsons">
+    <bpmn:participant id="Participant_1n4j215" name="Vertical Container" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:subProcess id="SubProcess" name="SubProcess" />
+    <bpmn:subProcess id="SubProcess_2" name="SubProcess_2" />
+    <bpmn:boundaryEvent id="BoundaryEvent_TopLeft" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomRight" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomLeft" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_TopRight" attachedToRef="SubProcess" />
+    <bpmn:boundaryEvent id="BoundaryEvent_CenterRight" attachedToRef="SubProcess_2" />
+    <bpmn:boundaryEvent id="BoundaryEvent_BottomCenter" attachedToRef="SubProcess_2" />
+    <bpmn:boundaryEvent id="BoundaryEvent_TopCenter" attachedToRef="SubProcess_2" />
+    <bpmn:boundaryEvent id="BoundaryEvent_CenterLeft" attachedToRef="SubProcess_2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ffsons">
+      <bpmndi:BPMNShape id="Participant_1n4j215_di" bpmnElement="Participant_1n4j215" isHorizontal="false">
+        <dc:Bounds x="160" y="80" width="540" height="630" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_12qmapm_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="260" y="170" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_2_di" bpmnElement="SubProcess_2" isExpanded="true">
+        <dc:Bounds x="260" y="430" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0s0nl1k_di" bpmnElement="BoundaryEvent_TopLeft">
+        <dc:Bounds x="242" y="190" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0nomac7_di" bpmnElement="BoundaryEvent_BottomRight">
+        <dc:Bounds x="592" y="320" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1spolhy_di" bpmnElement="BoundaryEvent_BottomLeft">
+        <dc:Bounds x="242" y="352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_13iwzlu_di" bpmnElement="BoundaryEvent_TopRight">
+        <dc:Bounds x="592" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_CenterRight_di" bpmnElement="BoundaryEvent_CenterRight">
+        <dc:Bounds x="592" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_BottomCenter_di" bpmnElement="BoundaryEvent_BottomCenter">
+        <dc:Bounds x="417" y="612" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_TopCenter_di" bpmnElement="BoundaryEvent_TopCenter">
+        <dc:Bounds x="417" y="412" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_CenterLeft_di" bpmnElement="BoundaryEvent_CenterLeft">
+        <dc:Bounds x="242" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.flowElements.bpmn
+++ b/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.flowElements.bpmn
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_0sm9luj">
+    <bpmn:participant id="Participant_0ntgbyn" name="Vertical Container" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1" />
+    <bpmn:task id="Task_1" name="Task_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_3</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_4</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1" />
+    <bpmn:serviceTask id="ServiceTask_1" name="ServiceTask_1">
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="ParallelGateway_1" />
+    <bpmn:endEvent id="EndEvent_1" />
+    <bpmn:businessRuleTask id="BusinessRuleTask_1" name="BusinessRuleTask_1" />
+    <bpmn:task id="Task_2" name="Task_2">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:task id="Task_3" name="Task_3">
+      <bpmn:incoming>SequenceFlow_3</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:task id="Task_4" name="Task_4">
+      <bpmn:incoming>SequenceFlow_4</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="Task_1" targetRef="ServiceTask_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_3" sourceRef="Task_1" targetRef="Task_3" />
+    <bpmn:sequenceFlow id="SequenceFlow_4" sourceRef="Task_1" targetRef="Task_4" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0sm9luj">
+      <bpmndi:BPMNShape id="Participant_0ntgbyn_di" bpmnElement="Participant_0ntgbyn" isHorizontal="false">
+        <dc:Bounds x="190" y="90" width="640" height="970" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="584" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="125" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="577" y="663" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="327" y="633" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="460" y="302" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_1_di" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="584" y="488" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="451" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="357" y="648" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ParallelGateway_1_di" bpmnElement="ParallelGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="577" y="990" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="327" y="960" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="389" y="488" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="135" y="451" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BusinessRuleTask_1_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="480" y="810" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="710" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_3_di" bpmnElement="Task_3">
+        <dc:Bounds x="357" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_4_di" bpmnElement="Task_4">
+        <dc:Bounds x="210" y="466" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="531" y="382" />
+        <di:waypoint x="531" y="569" />
+        <di:waypoint x="428" y="569" />
+        <di:waypoint x="428" y="648" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158.5" y="460" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="560" y="342" />
+        <di:waypoint x="760" y="342" />
+        <di:waypoint x="760" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="510" y="302" />
+        <di:waypoint x="510" y="260" />
+        <di:waypoint x="407" y="260" />
+        <di:waypoint x="407" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="460" y="342" />
+        <di:waypoint x="260" y="342" />
+        <di:waypoint x="260" y="466" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.subProcess.bpmn
+++ b/test/spec/features/modeling/layout/LayoutSequenceFlowSpec.vertical.subProcess.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_00dfyhw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+  <bpmn:collaboration id="Collaboration_0qdgort">
+    <bpmn:participant id="Participant_0ufcvvc" name="Vertical Container" processRef="Process_00i7uqd" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_00i7uqd" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_Right" name="Sub Process Right" />
+    <bpmn:subProcess id="SubProcess_Center" name="Sub Process Top" />
+    <bpmn:task id="Task_Left" name="Left" />
+    <bpmn:task id="Task_Bottom" name="Bottom" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0qdgort">
+      <bpmndi:BPMNShape id="Participant_0ufcvvc_di" bpmnElement="Participant_0ufcvvc" isHorizontal="false">
+        <dc:Bounds x="190" y="80" width="1090" height="830" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16fbgsj_di" bpmnElement="Task_Left">
+        <dc:Bounds x="240" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0fm36cc_di" bpmnElement="Task_Bottom">
+        <dc:Bounds x="410" y="490" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tbriov_di" bpmnElement="SubProcess_Right" isExpanded="true">
+        <dc:Bounds x="900" y="220" width="350" height="210" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0r2w32m_di" bpmnElement="SubProcess_Center" isExpanded="true">
+        <dc:Bounds x="410" y="130" width="350" height="210" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Closes #2110

This implements auto place and flow layouting for vertical pools and lanes and works only within those containers.

It's an almost exact mapping of the horizontal layout.
The exception: Per #2110, data objects are placed to the left of tasks and text annotations are placed to their right (only for vertical layouts).

Since data objects are not avilable by default, you can use this Context Pad code for testing (insert near `append.append-task`):

```
        'append.data-store': appendAction(
          'bpmn:DataStoreReference',
          'bpmn-icon-data-store',
          'Data Store TEST'
        ),
        'append.data-object': appendAction(
          'bpmn:DataObjectReference',
          'bpmn-icon-data-object',
          'Data Object TEST'
        ),
```

The initial dimensions and content of sub processes are still laid out horizontally.
I think that's a feature for the future. At the moment I'm not sure how much I can do about that.