### PR TITLE
feat: Update gateway's outline path

### DIFF
--- a/lib/features/outline/OutlineProvider.js
+++ b/lib/features/outline/OutlineProvider.js
@@ -59,15 +59,10 @@ OutlineProvider.prototype.getOutline = function(element) {
   }
 
   if (is(element, 'bpmn:Gateway')) {
-    outline = svgCreate('rect');
-
-    assign(outline.style, {
-      'transform-box': 'fill-box',
-      'transform': 'rotate(45deg)',
-      'transform-origin': 'center'
-    });
+    outline = svgCreate('polygon');
 
     svgAttr(outline, assign({
+      points: getDiamondPath(element),
       x: 2,
       y: 2,
       rx: 4,
@@ -165,6 +160,20 @@ OutlineProvider.prototype.updateOutline = function(element, outline) {
 
 
 // helpers //////////
+
+function getDiamondPath(element) {
+  const x_2 = element.width / 2;
+  const y_2 = element.height / 2;
+
+  const points = [
+    { x: x_2, y: -DEFAULT_OFFSET },
+    { x: element.width + DEFAULT_OFFSET, y: y_2 },
+    { x: x_2, y: element.height + DEFAULT_OFFSET },
+    { x: -DEFAULT_OFFSET, y: y_2 }
+  ];
+
+  return points.map(({ x, y }) => `${x},${y}`).join(' ');
+}
 
 function isStandardSize(element, type) {
   var standardSize;

--- a/test/spec/features/outline/OutlineProviderSpec.js
+++ b/test/spec/features/outline/OutlineProviderSpec.js
@@ -68,8 +68,7 @@ describe('features/outline - outline provider', function() {
 
       // then
       expect(outlineShape).to.exist;
-      expect(outlineShape.tagName).to.eql('rect');
-      expect(outlineShape.style.transform).to.eql('rotate(45deg)');
+      expect(outlineShape.tagName).to.eql('polygon');
     }));
 
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

When I reset the resise rule, if I adjust the size of the gateway node, the original implementation will cause an abnormal display of the outline.

Like this.

![image](https://github.com/bpmn-io/bpmn-js/assets/50617660/d5ca6714-806e-458a-addd-232a00009d9f)


Now, will become like this

![image](https://github.com/bpmn-io/bpmn-js/assets/50617660/7f2e0deb-b93f-47e9-80c2-5df11a8c11ae)
