### PR TITLE
Do not translate technical errors

### DIFF
--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -34,7 +34,6 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('./BpmnFactory').default} BpmnFactory
  * @typedef {import('diagram-js/lib/layout/CroppingConnectionDocking').default} CroppingConnectionDocking
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  *
  * @typedef {import('../../model/Types').Connection} Connection
  * @typedef {import('../../model/Types').Element} Element
@@ -50,22 +49,18 @@ import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
  * @param {EventBus} eventBus
  * @param {BpmnFactory} bpmnFactory
  * @param {CroppingConnectionDocking} connectionDocking
- * @param {Translate} translate
  */
 export default function BpmnUpdater(
     eventBus,
     bpmnFactory,
-    connectionDocking,
-    translate
+    connectionDocking
 ) {
 
   CommandInterceptor.call(this, eventBus);
 
   this._bpmnFactory = bpmnFactory;
-  this._translate = translate;
 
   var self = this;
-
 
 
   // connection cropping //////////////////////
@@ -322,8 +317,7 @@ inherits(BpmnUpdater, CommandInterceptor);
 BpmnUpdater.$inject = [
   'eventBus',
   'bpmnFactory',
-  'connectionDocking',
-  'translate'
+  'connectionDocking'
 ];
 
 
@@ -562,8 +556,7 @@ BpmnUpdater.prototype.getLaneSet = function(container) {
  */
 BpmnUpdater.prototype.updateSemanticParent = function(businessObject, newParent, visualParent) {
 
-  var containment,
-      translate = this._translate;
+  var containment;
 
   if (businessObject.$parent === newParent) {
     return;
@@ -668,13 +661,7 @@ BpmnUpdater.prototype.updateSemanticParent = function(businessObject, newParent,
   }
 
   if (!containment) {
-    throw new Error(translate(
-      'no parent for {element} in {parent}',
-      {
-        element: businessObject.id,
-        parent: newParent.id
-      }
-    ));
+    throw new Error(`no parent for <${ businessObject.id }> in <${ newParent.id }>`);
   }
 
   var children;

--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -34,8 +34,6 @@ import {
 } from '../../util/CompatibilityUtil';
 
 /**
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
- *
  * @typedef {import('diagram-js/lib/util/Types').Dimensions} Dimensions
  *
  * @typedef {import('./BpmnFactory').default} BpmnFactory
@@ -62,22 +60,19 @@ import {
  *
  * @param {BpmnFactory} bpmnFactory
  * @param {Moddle} moddle
- * @param {Translate} translate
  */
-export default function ElementFactory(bpmnFactory, moddle, translate) {
+export default function ElementFactory(bpmnFactory, moddle) {
   BaseElementFactory.call(this);
 
   this._bpmnFactory = bpmnFactory;
   this._moddle = moddle;
-  this._translate = translate;
 }
 
 inherits(ElementFactory, BaseElementFactory);
 
 ElementFactory.$inject = [
   'bpmnFactory',
-  'moddle',
-  'translate'
+  'moddle'
 ];
 
 ElementFactory.prototype._baseCreate = BaseElementFactory.prototype.create;
@@ -155,17 +150,17 @@ ElementFactory.prototype.create = function(elementType, attrs) {
  * @return {T}
  */
 ElementFactory.prototype.createElement = function(elementType, attrs) {
-  var size,
-      translate = this._translate;
 
   attrs = assign({}, attrs || {});
+
+  var size;
 
   var businessObject = attrs.businessObject,
       di = attrs.di;
 
   if (!businessObject) {
     if (!attrs.type) {
-      throw new Error(translate('no shape type specified'));
+      throw new Error('no shape type specified');
     }
 
     businessObject = this._bpmnFactory.create(attrs.type);

--- a/lib/features/modeling/behavior/UpdateFlowNodeRefsBehavior.js
+++ b/lib/features/modeling/behavior/UpdateFlowNodeRefsBehavior.js
@@ -9,7 +9,6 @@ import {
 /**
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('../Modeling').default} Modeling
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  */
 
 var LOW_PRIORITY = 500,
@@ -21,9 +20,8 @@ var LOW_PRIORITY = 500,
  *
  * @param {EventBus} eventBus
  * @param {Modeling} modeling
- * @param {Translate} translate
  */
-export default function UpdateFlowNodeRefsBehavior(eventBus, modeling, translate) {
+export default function UpdateFlowNodeRefsBehavior(eventBus, modeling) {
 
   CommandInterceptor.call(this, eventBus);
 
@@ -46,7 +44,7 @@ export default function UpdateFlowNodeRefsBehavior(eventBus, modeling, translate
 
   function getContext() {
     if (!context) {
-      throw new Error(translate('out of bounds release'));
+      throw new Error('out of bounds release');
     }
 
     return context;
@@ -55,7 +53,7 @@ export default function UpdateFlowNodeRefsBehavior(eventBus, modeling, translate
   function releaseContext() {
 
     if (!context) {
-      throw new Error(translate('out of bounds release'));
+      throw new Error('out of bounds release');
     }
 
     var triggerUpdate = context.leave();
@@ -127,8 +125,7 @@ export default function UpdateFlowNodeRefsBehavior(eventBus, modeling, translate
 
 UpdateFlowNodeRefsBehavior.$inject = [
   'eventBus',
-  'modeling' ,
-  'translate'
+  'modeling'
 ];
 
 inherits(UpdateFlowNodeRefsBehavior, CommandInterceptor);

--- a/lib/features/modeling/cmd/SplitLaneHandler.js
+++ b/lib/features/modeling/cmd/SplitLaneHandler.js
@@ -11,7 +11,6 @@ import {
  * @typedef {import('diagram-js/lib/command/CommandHandler').default} CommandHandler
  *
  * @typedef {import('../Modeling').default} Modeling
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  */
 
 /**
@@ -21,23 +20,19 @@ import {
  * @implements {CommandHandler}
  *
  * @param {Modeling} modeling
- * @param {Translate} translate
  */
-export default function SplitLaneHandler(modeling, translate) {
+export default function SplitLaneHandler(modeling) {
   this._modeling = modeling;
-  this._translate = translate;
 }
 
 SplitLaneHandler.$inject = [
-  'modeling',
-  'translate'
+  'modeling'
 ];
 
 
 SplitLaneHandler.prototype.preExecute = function(context) {
 
-  var modeling = this._modeling,
-      translate = this._translate;
+  var modeling = this._modeling;
 
   var shape = context.shape,
       newLanesCount = context.count;
@@ -46,7 +41,7 @@ SplitLaneHandler.prototype.preExecute = function(context) {
       existingLanesCount = childLanes.length;
 
   if (existingLanesCount > newLanesCount) {
-    throw new Error(translate('more than {count} child lanes', { count: newLanesCount }));
+    throw new Error(`more than <${newLanesCount}> child lanes`);
   }
 
   var isHorizontalLane = isHorizontal(shape);

--- a/lib/features/modeling/cmd/UpdatePropertiesHandler.js
+++ b/lib/features/modeling/cmd/UpdatePropertiesHandler.js
@@ -16,7 +16,6 @@ import {
  *
  * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
  * @typedef {import('../../../model/Types').Moddle} Moddle
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  * @typedef {import('../Modeling').default} Modeling
  * @typedef {import('../../../draw/TextRenderer').default} TextRenderer
  *
@@ -45,17 +44,15 @@ var NULL_DIMENSIONS = {
  *
  * @param {ElementRegistry} elementRegistry
  * @param {Moddle} moddle
- * @param {Translate} translate
  * @param {Modeling} modeling
  * @param {TextRenderer} textRenderer
  */
 export default function UpdatePropertiesHandler(
-    elementRegistry, moddle, translate,
+    elementRegistry, moddle,
     modeling, textRenderer) {
 
   this._elementRegistry = elementRegistry;
   this._moddle = moddle;
-  this._translate = translate;
   this._modeling = modeling;
   this._textRenderer = textRenderer;
 }
@@ -63,7 +60,6 @@ export default function UpdatePropertiesHandler(
 UpdatePropertiesHandler.$inject = [
   'elementRegistry',
   'moddle',
-  'translate',
   'modeling',
   'textRenderer'
 ];
@@ -84,11 +80,10 @@ UpdatePropertiesHandler.$inject = [
 UpdatePropertiesHandler.prototype.execute = function(context) {
 
   var element = context.element,
-      changed = [ element ],
-      translate = this._translate;
+      changed = [ element ];
 
   if (!element) {
-    throw new Error(translate('element required'));
+    throw new Error('element required');
   }
 
   var elementRegistry = this._elementRegistry,

--- a/lib/features/ordering/BpmnOrderingProvider.js
+++ b/lib/features/ordering/BpmnOrderingProvider.js
@@ -15,7 +15,6 @@ import {
 /**
  * @typedef {import('diagram-js/lib/core/Canvas').default} Canvas
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
- * @typedef {import('diagram-js/i18n/translate/translate').default} Translate
  */
 
 /**
@@ -23,9 +22,8 @@ import {
  *
  * @param {EventBus} eventBus
  * @param {Canvas} canvas
- * @param {Translate} translate
  */
-export default function BpmnOrderingProvider(eventBus, canvas, translate) {
+export default function BpmnOrderingProvider(eventBus, canvas) {
 
   OrderingProvider.call(this, eventBus);
 
@@ -189,6 +187,6 @@ export default function BpmnOrderingProvider(eventBus, canvas, translate) {
   };
 }
 
-BpmnOrderingProvider.$inject = [ 'eventBus', 'canvas', 'translate' ];
+BpmnOrderingProvider.$inject = [ 'eventBus', 'canvas' ];
 
 inherits(BpmnOrderingProvider, OrderingProvider);

--- a/lib/features/ordering/index.js
+++ b/lib/features/ordering/index.js
@@ -1,11 +1,6 @@
-import translate from 'diagram-js/lib/i18n/translate';
-
 import BpmnOrderingProvider from './BpmnOrderingProvider';
 
 export default {
-  __depends__: [
-    translate
-  ],
   __init__: [ 'bpmnOrderingProvider' ],
   bpmnOrderingProvider: [ 'type', BpmnOrderingProvider ]
 };

--- a/lib/import/BpmnImporter.js
+++ b/lib/import/BpmnImporter.js
@@ -26,7 +26,6 @@ import {
  * @typedef {import('diagram-js/lib/core/Canvas').default} Canvas
  * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  *
  * @typedef {import('../features/modeling/ElementFactory').default} ElementFactory
  * @typedef {import('../draw/TextRenderer').default} TextRenderer
@@ -68,12 +67,10 @@ function getWaypoints(di, source, target) {
   });
 }
 
-function notYetDrawn(translate, semantic, refSemantic, property) {
-  return new Error(translate('element {element} referenced by {referenced}#{property} not yet drawn', {
-    element: elementToString(refSemantic),
-    referenced: elementToString(semantic),
-    property: property
-  }));
+function notYetDrawn(semantic, refSemantic, property) {
+  return new Error(
+    `element ${ elementToString(refSemantic) } referenced by ${ elementToString(semantic) }#${ property } not yet drawn`
+  );
 }
 
 
@@ -84,18 +81,16 @@ function notYetDrawn(translate, semantic, refSemantic, property) {
  * @param {Canvas} canvas
  * @param {ElementFactory} elementFactory
  * @param {ElementRegistry} elementRegistry
- * @param {Function} translate
  * @param {TextRenderer} textRenderer
  */
 export default function BpmnImporter(
     eventBus, canvas, elementFactory,
-    elementRegistry, translate, textRenderer) {
+    elementRegistry, textRenderer) {
 
   this._eventBus = eventBus;
   this._canvas = canvas;
   this._elementFactory = elementFactory;
   this._elementRegistry = elementRegistry;
-  this._translate = translate;
   this._textRenderer = textRenderer;
 }
 
@@ -104,7 +99,6 @@ BpmnImporter.$inject = [
   'canvas',
   'elementFactory',
   'elementRegistry',
-  'translate',
   'textRenderer'
 ];
 
@@ -121,7 +115,6 @@ BpmnImporter.$inject = [
  */
 BpmnImporter.prototype.add = function(semantic, di, parentElement) {
   var element,
-      translate = this._translate,
       hidden;
 
   var parentIndex;
@@ -207,17 +200,15 @@ BpmnImporter.prototype.add = function(semantic, di, parentElement) {
 
     this._canvas.addConnection(element, parentElement, parentIndex);
   } else {
-    throw new Error(translate('unknown di {di} for element {semantic}', {
-      di: elementToString(di),
-      semantic: elementToString(semantic)
-    }));
+    throw new Error(
+      `unknown di ${ elementToString(di) } for element ${ elementToString(semantic) }`
+    );
   }
 
   // (optional) LABEL
   if (isLabelExternal(semantic) && getLabel(element)) {
     this.addLabel(semantic, di, element);
   }
-
 
   this._eventBus.fire('bpmnElement.added', { element: element });
 
@@ -232,20 +223,19 @@ BpmnImporter.prototype.add = function(semantic, di, parentElement) {
  * @param {Shape} boundaryElement
  */
 BpmnImporter.prototype._attachBoundary = function(boundarySemantic, boundaryElement) {
-  var translate = this._translate;
   var hostSemantic = boundarySemantic.attachedToRef;
 
   if (!hostSemantic) {
-    throw new Error(translate('missing {semantic}#attachedToRef', {
-      semantic: elementToString(boundarySemantic)
-    }));
+    throw new Error(
+      `missing ${ elementToString(boundarySemantic) }#attachedToRef`
+    );
   }
 
   var host = this._elementRegistry.get(hostSemantic.id),
       attachers = host && host.attachers;
 
   if (!host) {
-    throw notYetDrawn(translate, boundarySemantic, hostSemantic, 'attachedToRef');
+    throw notYetDrawn(boundarySemantic, hostSemantic, 'attachedToRef');
   }
 
   // wire element.host <> host.attachers
@@ -311,8 +301,7 @@ BpmnImporter.prototype._getConnectedElement = function(semantic, side) {
 
   var element,
       refSemantic,
-      type = semantic.$type,
-      translate = this._translate;
+      type = semantic.$type;
 
   refSemantic = semantic[side + 'Ref'];
 
@@ -335,12 +324,11 @@ BpmnImporter.prototype._getConnectedElement = function(semantic, side) {
   }
 
   if (refSemantic) {
-    throw notYetDrawn(translate, semantic, refSemantic, side + 'Ref');
+    throw notYetDrawn(semantic, refSemantic, side + 'Ref');
   } else {
-    throw new Error(translate('{semantic}#{side} Ref not specified', {
-      semantic: elementToString(semantic),
-      side: side
-    }));
+    throw new Error(
+      `${ elementToString(semantic) }#${ side } Ref not specified`
+    );
   }
 };
 

--- a/lib/import/BpmnTreeWalker.js
+++ b/lib/import/BpmnTreeWalker.js
@@ -13,8 +13,6 @@ import {
 } from '../util/CompatibilityUtil';
 
 /**
- * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
- *
  * @typedef {import('../model/Types').ModdleElement} ModdleElement
  */
 
@@ -47,9 +45,8 @@ function findDisplayCandidate(definitions) {
 
 /**
  * @param {Record<'element' | 'root' | 'error', Function>} handler
- * @param {Translate} translate
  */
-export default function BpmnTreeWalker(handler, translate) {
+export default function BpmnTreeWalker(handler) {
 
   // list of containers already walked
   var handledElements = {};
@@ -83,7 +80,7 @@ export default function BpmnTreeWalker(handler, translate) {
     // avoid multiple rendering of elements
     if (gfx) {
       throw new Error(
-        translate('already rendered {element}', { element: elementToString(element) })
+        'already rendered ${ elementToString(element) }'
       );
     }
 
@@ -103,11 +100,10 @@ export default function BpmnTreeWalker(handler, translate) {
       handled(element);
 
       return gfx;
-    } catch (e) {
-      logError(e.message, { element: element, error: e });
+    } catch (error) {
+      logError(error.message, { element, error });
 
-      console.error(translate('failed to import {element}', { element: elementToString(element) }));
-      console.error(e);
+      console.error(`failed to import ${ elementToString(element) }`, error);
     }
   }
 
@@ -123,9 +119,7 @@ export default function BpmnTreeWalker(handler, translate) {
     if (bpmnElement) {
       if (diMap[bpmnElement.id]) {
         logError(
-          translate('multiple DI elements defined for {element}', {
-            element: elementToString(bpmnElement)
-          }),
+          `multiple DI elements defined for ${ elementToString(bpmnElement) }`,
           { element: bpmnElement }
         );
       } else {
@@ -135,9 +129,7 @@ export default function BpmnTreeWalker(handler, translate) {
       }
     } else {
       logError(
-        translate('no bpmnElement referenced in {element}', {
-          element: elementToString(di)
-        }),
+        `no bpmnElement referenced in ${ elementToString(di) }`,
         { element: di }
       );
     }
@@ -175,7 +167,7 @@ export default function BpmnTreeWalker(handler, translate) {
     var diagrams = definitions.diagrams;
 
     if (diagram && diagrams.indexOf(diagram) === -1) {
-      throw new Error(translate('diagram not part of bpmn:Definitions'));
+      throw new Error('diagram not part of <bpmn:Definitions />');
     }
 
     if (!diagram && diagrams && diagrams.length) {
@@ -184,7 +176,7 @@ export default function BpmnTreeWalker(handler, translate) {
 
     // no diagram -> nothing to import
     if (!diagram) {
-      throw new Error(translate('no diagram to display'));
+      throw new Error('no diagram to display');
     }
 
     // load DI from selected diagram only
@@ -195,10 +187,9 @@ export default function BpmnTreeWalker(handler, translate) {
     var plane = diagram.plane;
 
     if (!plane) {
-      throw new Error(translate(
-        'no plane for {element}',
-        { element: elementToString(diagram) }
-      ));
+      throw new Error(
+        `no plane for ${ elementToString(diagram) }`
+      );
     }
 
     var rootElement = plane.bpmnElement;
@@ -209,14 +200,11 @@ export default function BpmnTreeWalker(handler, translate) {
       rootElement = findDisplayCandidate(definitions);
 
       if (!rootElement) {
-        throw new Error(translate('no process or collaboration to display'));
+        throw new Error('no process or collaboration to display');
       } else {
 
         logError(
-          translate('correcting missing bpmnElement on {plane} to {rootElement}', {
-            plane: elementToString(plane),
-            rootElement: elementToString(rootElement)
-          })
+          `correcting missing bpmnElement on ${ elementToString(plane) } to ${ elementToString(rootElement) }`
         );
 
         // correct DI on the fly
@@ -237,10 +225,7 @@ export default function BpmnTreeWalker(handler, translate) {
       handleUnhandledProcesses(definitions.rootElements, ctx);
     } else {
       throw new Error(
-        translate('unsupported bpmnElement for {plane}: {rootElement}', {
-          plane: elementToString(plane),
-          rootElement: elementToString(rootElement)
-        })
+        `unsupported bpmnElement for ${ elementToString(plane) }: ${ elementToString(rootElement) }`
       );
     }
 
@@ -402,31 +387,31 @@ export default function BpmnTreeWalker(handler, translate) {
   }
 
   function handleFlowElements(flowElements, context) {
-    forEach(flowElements, function(e) {
-      if (is(e, 'bpmn:SequenceFlow')) {
+    forEach(flowElements, function(flowElement) {
+      if (is(flowElement, 'bpmn:SequenceFlow')) {
         deferred.push(function() {
-          handleSequenceFlow(e, context);
+          handleSequenceFlow(flowElement, context);
         });
-      } else if (is(e, 'bpmn:BoundaryEvent')) {
+      } else if (is(flowElement, 'bpmn:BoundaryEvent')) {
         deferred.unshift(function() {
-          handleFlowNode(e, context);
+          handleFlowNode(flowElement, context);
         });
-      } else if (is(e, 'bpmn:FlowNode')) {
-        handleFlowNode(e, context);
-      } else if (is(e, 'bpmn:DataObject')) {
+      } else if (is(flowElement, 'bpmn:FlowNode')) {
+        handleFlowNode(flowElement, context);
+      } else if (is(flowElement, 'bpmn:DataObject')) {
 
         // SKIP (assume correct referencing via DataObjectReference)
-      } else if (is(e, 'bpmn:DataStoreReference')) {
-        handleDataElement(e, context);
-      } else if (is(e, 'bpmn:DataObjectReference')) {
-        handleDataElement(e, context);
+      } else if (is(flowElement, 'bpmn:DataStoreReference')) {
+        handleDataElement(flowElement, context);
+      } else if (is(flowElement, 'bpmn:DataObjectReference')) {
+        handleDataElement(flowElement, context);
       } else {
         logError(
-          translate('unrecognized flowElement {element} in context {context}', {
-            element: elementToString(e),
-            context: (context ? elementToString(context.businessObject) : 'null')
-          }),
-          { element: e, context: context }
+          `unrecognized flowElement ${ elementToString(flowElement) } in context ${ elementToString(context && context.businessObject) }`,
+          {
+            element: flowElement,
+            context
+          }
         );
       }
     });

--- a/lib/import/Importer.js
+++ b/lib/import/Importer.js
@@ -35,7 +35,6 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
 
   var importer,
       eventBus,
-      translate,
       canvas;
 
   var error,
@@ -65,7 +64,7 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
       }
     };
 
-    var walker = new BpmnTreeWalker(visitor, translate);
+    var walker = new BpmnTreeWalker(visitor);
 
 
     bpmnDiagram = bpmnDiagram || (definitions.diagrams && definitions.diagrams[0]);
@@ -73,7 +72,7 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
     var diagramsToImport = getDiagramsToImport(definitions, bpmnDiagram);
 
     if (!diagramsToImport) {
-      throw new Error(translate('no diagram to display'));
+      throw new Error('no diagram to display');
     }
 
     // traverse BPMN 2.0 document model,
@@ -96,7 +95,6 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
     try {
       importer = diagram.get('bpmnImporter');
       eventBus = diagram.get('eventBus');
-      translate = diagram.get('translate');
       canvas = diagram.get('canvas');
 
       eventBus.fire('import.render.start', { definitions: definitions });


### PR DESCRIPTION
This PR proposes a change in how we handle technical errors: These are no longer translated, both during modeling _and_ during import.

Due to the nature of _technical_ errors it makes little sense to localize them. If I need help on how to fix a particular technical issue, then I want to search for these errors _as is_.

Closes https://github.com/bpmn-io/internal-docs/issues/937

Related to https://github.com/bpmn-io/bpmn-js/pull/2137