### PR TITLE
feat(label-editing): remove background for embedded labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: do not hide Task markers while editing labels
+
 ## 17.3.0
 
 * `FEAT`: auto-place elements vertically ([#2110](https://github.com/bpmn-io/bpmn-js/issues/2110))

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -202,6 +202,13 @@ LabelEditingProvider.prototype.activate = function(element) {
   assign(context, bounds);
 
   var options = {};
+  var style = context.style || {};
+
+  // Remove background and border
+  assign(style, {
+    backgroundColor: null,
+    border: null
+  });
 
   // tasks
   if (
@@ -223,6 +230,12 @@ LabelEditingProvider.prototype.activate = function(element) {
     assign(options, {
       autoResize: true
     });
+
+    // keep background and border for external labels
+    assign(style, {
+      backgroundColor: '#ffffff',
+      border: '1px solid #ccc'
+    });
   }
 
   // text annotations
@@ -231,10 +244,17 @@ LabelEditingProvider.prototype.activate = function(element) {
       resizable: true,
       autoResize: true
     });
+
+    // keep background and border for text annotations
+    assign(style, {
+      backgroundColor: '#ffffff',
+      border: '1px solid #ccc'
+    });
   }
 
   assign(context, {
-    options: options
+    options: options,
+    style: style
   });
 
   return context;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^8.1.0",
         "diagram-js": "^14.3.1",
-        "diagram-js-direct-editing": "^2.1.2",
+        "diagram-js-direct-editing": "^3.0.1",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.1.1",
@@ -3343,9 +3343,9 @@
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.1.2.tgz",
-      "integrity": "sha512-VpccLAnLqLF1cp3fk363QUbRVTd/qTcj2oOb+IqgcmOiWszJp7J9Ta6y5GjUvw48hDZpzCatlmWwA4CJ3MaYGQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.0.1.tgz",
+      "integrity": "sha512-V44JO55nwFbsRv6tTmrfdz6fIsE3A4YIIqInaeJZyD2EongZzEo4acH9TqsE4hi9R/kAqsyttMKxTAgHplFn8w==",
       "dependencies": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2"
@@ -17763,9 +17763,9 @@
       }
     },
     "diagram-js-direct-editing": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.1.2.tgz",
-      "integrity": "sha512-VpccLAnLqLF1cp3fk363QUbRVTd/qTcj2oOb+IqgcmOiWszJp7J9Ta6y5GjUvw48hDZpzCatlmWwA4CJ3MaYGQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.0.1.tgz",
+      "integrity": "sha512-V44JO55nwFbsRv6tTmrfdz6fIsE3A4YIIqInaeJZyD2EongZzEo4acH9TqsE4hi9R/kAqsyttMKxTAgHplFn8w==",
       "requires": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "bpmn-moddle": "^8.1.0",
     "diagram-js": "^14.3.1",
-    "diagram-js-direct-editing": "^2.1.2",
+    "diagram-js-direct-editing": "^3.0.1",
     "ids": "^1.0.5",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.1.1",


### PR DESCRIPTION
With this PR, we explicitly set when direct editing should have a background and disable it for all other cases.

related to https://github.com/camunda/web-modeler/issues/8477
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
