### PR TITLE
fix(import): handle missing BPMNDiagram#plane

### DIFF
--- a/lib/import/Importer.js
+++ b/lib/import/Importer.js
@@ -125,7 +125,7 @@ export function importBpmnDiagram(diagram, definitions, bpmnDiagram) {
  * @return {ModdleElement[]}
  */
 function getDiagramsToImport(definitions, bpmnDiagram) {
-  if (!bpmnDiagram) {
+  if (!bpmnDiagram || !bpmnDiagram.plane) {
     return;
   }
 
@@ -173,6 +173,11 @@ function getDiagramsToImport(definitions, bpmnDiagram) {
   var handledElements = [ bpmnElement ];
 
   forEach(definitions.diagrams, function(diagram) {
+
+    if (!diagram.plane) {
+      return;
+    }
+
     var businessObject = diagram.plane.bpmnElement;
 
     if (

--- a/test/spec/import/ImporterSpec.js
+++ b/test/spec/import/ImporterSpec.js
@@ -602,6 +602,48 @@ describe('import - Importer', function() {
     });
 
 
+    it('should import with missing BPMNDiagram#plane DI', function() {
+
+      // given
+      var xml = require('./missing-di-plane.bpmn');
+
+      // when
+      return runImport(diagram, xml).then(function(result) {
+
+        var {
+          error,
+          warnings
+        } = result;
+
+        // then
+        expect(warnings).to.be.empty;
+        expect(error).not.to.exist;
+      });
+    });
+
+
+    it('should error import with missing BPMNDiagram#plane DI', function() {
+
+      // given
+      var xml = require('./missing-di-plane-root-element.bpmn');
+
+      // when
+      return runImport(diagram, xml).then(function(result) {
+
+        var {
+          error,
+          warnings
+        } = result;
+
+        // then
+        // warning: no bpmnElement referenced in <bpmndi:BPMNPlane />
+        // warning: correcting missing bpmnElement on <bpmndi:BPMNPlane />
+        expect(warnings).to.have.length(2);
+        expect(error).not.to.exist;
+      });
+    });
+
+
     it('should import sequence flow without waypoints', function() {
 
       // given

--- a/test/spec/import/missing-di-plane-root-element.bpmn
+++ b/test/spec/import/missing-di-plane-root-element.bpmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_01360mp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="PROCESS" isExecutable="true">
+    <bpmn:subProcess id="SUB_PROCESS">
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1">
+      <bpmndi:BPMNShape id="SUB_PROCESS_di" bpmnElement="SUB_PROCESS" isExpanded="false">
+        <dc:Bounds x="355" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/import/missing-di-plane.bpmn
+++ b/test/spec/import/missing-di-plane.bpmn
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_01360mp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="PROCESS" isExecutable="true">
+    <bpmn:subProcess id="SUB_PROCESS">
+      <bpmn:subProcess id="SUB_PROCESS_MISSING_DI" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PROCESS">
+      <bpmndi:BPMNShape id="SUB_PROCESS_di" bpmnElement="SUB_PROCESS" isExpanded="false">
+        <dc:Bounds x="355" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <!-- missing plane element -->
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Without this change any auxiliary `<bpmndi:BPMNDiagram />` without a plane would crash the importer.

Now the (broken) BPMN diagram is simply ignored during import.

----

Related to https://github.com/bpmn-io/bpmnlint/pull/135