### PR TITLE
Gracefully handle missing `BPMNDiagram#plane` in legacy sub-process behavior

### DIFF
--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -57,20 +57,9 @@ SubprocessCompatibility.prototype._handleImport = function(definitions) {
     self._processToDiagramMap[diagram.plane.bpmnElement.id] = diagram;
   });
 
-  var newDiagrams = definitions.diagrams.reduce(
-    function(newDiagrams, diagram) {
-
-      const plane = diagram.plane;
-
-      if (!plane) {
-        return newDiagrams;
-      }
-
-      const createdDiagrams = self._createNewDiagrams(plane);
-      return newDiagrams.concat(createdDiagrams);
-    },
-    []
-  );
+  var newDiagrams = definitions.diagrams
+    .filter(diagram => diagram.plane)
+    .flatMap(diagram => self._createNewDiagrams(diagram.plane));
 
   newDiagrams.forEach(function(diagram) {
     self._movePlaneElementsToOrigin(diagram.plane);

--- a/lib/features/drilldown/SubprocessCompatibility.js
+++ b/lib/features/drilldown/SubprocessCompatibility.js
@@ -57,11 +57,20 @@ SubprocessCompatibility.prototype._handleImport = function(definitions) {
     self._processToDiagramMap[diagram.plane.bpmnElement.id] = diagram;
   });
 
-  var newDiagrams = [];
-  definitions.diagrams.forEach(function(diagram) {
-    var createdDiagrams = self._createNewDiagrams(diagram.plane);
-    Array.prototype.push.apply(newDiagrams, createdDiagrams);
-  });
+  var newDiagrams = definitions.diagrams.reduce(
+    function(newDiagrams, diagram) {
+
+      const plane = diagram.plane;
+
+      if (!plane) {
+        return newDiagrams;
+      }
+
+      const createdDiagrams = self._createNewDiagrams(plane);
+      return newDiagrams.concat(createdDiagrams);
+    },
+    []
+  );
 
   newDiagrams.forEach(function(diagram) {
     self._movePlaneElementsToOrigin(diagram.plane);

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -400,7 +400,7 @@ describe('features - drilldown', function() {
   });
 
 
-  describe('Legacy Processes', function() {
+  describe('features - drilldown - Legacy Processes', function() {
 
     beforeEach(bootstrapViewer(legacyXML, { modules: testModules }));
 
@@ -448,6 +448,42 @@ describe('features - drilldown', function() {
       // then
       expect(emptyRoot).to.exist;
     }));
+
+  });
+
+});
+
+
+describe('features/drilldown - integration', function() {
+
+  var testModules = [
+    coreModule,
+    DrilldownModule
+  ];
+
+  var missingDiXML = require('./missing-di-bpmndiagram-plane.bpmn');
+
+  var multiLayerXML = require('./nested-subprocesses.bpmn');
+
+  beforeEach(bootstrapViewer(multiLayerXML, { modules: testModules }));
+
+
+  describe('error handling', function() {
+
+    it('should import diagram with missing BPMNDiagram#plane', inject(
+      async function(bpmnjs) {
+
+        let error;
+
+        try {
+          await bpmnjs.importXML(missingDiXML);
+        } catch (_error) {
+          error = _error;
+        }
+
+        expect(error).not.to.exist;
+      }
+    ));
 
   });
 

--- a/test/spec/features/drilldown/missing-di-bpmndiagram-plane.bpmn
+++ b/test/spec/features/drilldown/missing-di-bpmndiagram-plane.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="DEFINITIONS" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="PROCESS" isExecutable="true">
+    <bpmn:subProcess id="SUB_PROCESS">
+      <bpmn:subProcess id="SUB_PROCESS_NESTED_NO_DI" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PROCESS">
+      <bpmndi:BPMNShape id="SUB_PROCESS_di" bpmnElement="SUB_PROCESS" isExpanded="false">
+        <dc:Bounds x="355" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Previously we'd scroll through all diagrams, assuming `plane` would always be set.