### PR TITLE
feat(modeling): keep global elements when deleting last participant

### DIFF
--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -246,6 +246,8 @@ Modeling.prototype.makeProcess = function() {
   };
 
   this._commandStack.execute('canvas.updateRoot', context);
+
+  return processElement;
 };
 
 /**

--- a/lib/features/modeling/behavior/RemoveParticipantBehavior.js
+++ b/lib/features/modeling/behavior/RemoveParticipantBehavior.js
@@ -44,7 +44,12 @@ export default function RemoveParticipantBehavior(eventBus, modeling) {
     if (collaborationRoot && !collaborationRoot.businessObject.participants.length) {
 
       // replace empty collaboration with process diagram
-      modeling.makeProcess();
+      var process = modeling.makeProcess();
+
+      // move all root elements from collaboration to process
+      var children = collaborationRoot.children.slice();
+
+      modeling.moveElements(children, { x: 0, y: 0 }, process);
     }
   }, true);
 

--- a/test/fixtures/bpmn/collaboration/collaboration-data-store.bpmn
+++ b/test/fixtures/bpmn/collaboration/collaboration-data-store.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="_P58jANhOEeSW1LwlVzMs4g" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:collaboration id="_Collaboration_2">
+    <bpmn2:participant id="_Participant_2" name="Participant" processRef="Process_1" />
+  </bpmn2:collaboration>
+  <bpmn2:process id="Process_1" isExecutable="false">
+    <bpmn2:dataStoreReference id="DataStoreReference_1by5u7v" />
+    <bpmn2:startEvent id="Event_13f8lfq" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="_Collaboration_2">
+      <bpmndi:BPMNShape id="_BPMNShape_Participant_2" bpmnElement="_Participant_2" isHorizontal="true">
+        <dc:Bounds x="154" y="82" width="546" height="236" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13f8lfq_di" bpmnElement="Event_13f8lfq">
+        <dc:Bounds x="222" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataStoreReference_1by5u7v_di" bpmnElement="DataStoreReference_1by5u7v">
+        <dc:Bounds x="154" y="375" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
closes #1676

![Recording 2024-05-28 at 13 40 39](https://github.com/bpmn-io/bpmn-js/assets/21984219/eab7881a-9ecc-496a-8512-70b990223b6b)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
