### PR TITLE
Add accessible label to drill down button

### DIFF
--- a/lib/features/drilldown/DrilldownOverlayBehavior.js
+++ b/lib/features/drilldown/DrilldownOverlayBehavior.js
@@ -10,6 +10,7 @@ import { getPlaneIdFromShape } from '../../util/DrilldownUtil';
  * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('diagram-js/lib/features/overlays/Overlays').default} Overlays
+ * @typedef {import('diagram-js/lib/i18n/translate/translate').default} Translate
  *
  * @typedef {import('../../model/Types').Element} Element
  * @typedef {import('../../model/Types').Parent} Parent
@@ -26,9 +27,10 @@ var EMPTY_MARKER = 'bjs-drilldown-empty';
  * @param {EventBus} eventBus
  * @param {ElementRegistry} elementRegistry
  * @param {Overlays} overlays
+ * @param {Translate} translate
  */
 export default function DrilldownOverlayBehavior(
-    canvas, eventBus, elementRegistry, overlays
+    canvas, eventBus, elementRegistry, overlays, translate
 ) {
   CommandInterceptor.call(this, eventBus);
 
@@ -36,6 +38,7 @@ export default function DrilldownOverlayBehavior(
   this._eventBus = eventBus;
   this._elementRegistry = elementRegistry;
   this._overlays = overlays;
+  this._translate = translate;
 
   var self = this;
 
@@ -169,7 +172,8 @@ DrilldownOverlayBehavior.prototype._updateOverlayVisibility = function(element) 
  */
 DrilldownOverlayBehavior.prototype._addOverlay = function(element) {
   var canvas = this._canvas,
-      overlays = this._overlays;
+      overlays = this._overlays,
+      bo = getBusinessObject(element);
 
   var existingOverlays = overlays.get({ element: element, type: 'drilldown' });
 
@@ -177,7 +181,10 @@ DrilldownOverlayBehavior.prototype._addOverlay = function(element) {
     this._removeOverlay(element);
   }
 
-  var button = domify('<button class="bjs-drilldown">' + ARROW_DOWN_SVG + '</button>');
+  var button = domify('<button type="button" class="bjs-drilldown">' + ARROW_DOWN_SVG + '</button>'),
+      elementName = bo.get('name') || bo.get('id'),
+      title = this._translate('Open {element}', { element: elementName });
+  button.setAttribute('title', title);
 
   button.addEventListener('click', function() {
     canvas.setRootElement(canvas.findRoot(getPlaneIdFromShape(element)));
@@ -207,5 +214,6 @@ DrilldownOverlayBehavior.$inject = [
   'canvas',
   'eventBus',
   'elementRegistry',
-  'overlays'
+  'overlays',
+  'translate'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,12 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.2",
+        "@bpmn-io/a11y": "^0.1.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
         "@rollup/plugin-terser": "^0.4.4",
-        "axe-core": "^4.9.0",
         "babel-loader": "^9.1.0",
         "babel-plugin-istanbul": "^6.1.1",
         "bio-dts": "^0.11.0",
@@ -482,6 +482,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bpmn-io/a11y": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/a11y/-/a11y-0.1.0.tgz",
+      "integrity": "sha512-pEQGGZQchACYRblv+ubA3QXUOSMR+CMSRkabErI06T5MGHcnUQ3WULUaOM/ieF3imMIR6Hz7MPOuwCfrAaNqJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "^4.9.1"
+      },
+      "peerDependencies": {
+        "chai": "*"
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {
@@ -2242,10 +2255,11 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
-      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
       "dev": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
@@ -15923,6 +15937,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bpmn-io/a11y": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/a11y/-/a11y-0.1.0.tgz",
+      "integrity": "sha512-pEQGGZQchACYRblv+ubA3QXUOSMR+CMSRkabErI06T5MGHcnUQ3WULUaOM/ieF3imMIR6Hz7MPOuwCfrAaNqJw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.9.1"
+      }
+    },
     "@bpmn-io/diagram-js-ui": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
@@ -17252,9 +17275,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
-      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
       "dev": true
     },
     "b4a": {

--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.20.2",
+    "@bpmn-io/a11y": "^0.1.0",
     "@rollup/plugin-commonjs": "^26.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
     "@rollup/plugin-terser": "^0.4.4",
-    "axe-core": "^4.9.0",
     "babel-loader": "^9.1.0",
     "babel-plugin-istanbul": "^6.1.1",
     "bio-dts": "^0.11.0",

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -1,4 +1,4 @@
-import axe from 'axe-core';
+import { expectToBeAccessible } from '@bpmn-io/a11y';
 
 import Modeler from 'lib/Modeler';
 import Viewer from 'lib/Viewer';
@@ -931,12 +931,8 @@ describe('Modeler', function() {
       const xml = require('../fixtures/bpmn/simple.bpmn');
       await createModeler(xml);
 
-      // when
-      const results = await axe.run(container);
-
       // then
-      expect(results.passes).to.be.not.empty;
-      expect(results.violations).to.be.empty;
+      await expectToBeAccessible(container);
     });
 
   });

--- a/test/spec/NavigatedViewerSpec.js
+++ b/test/spec/NavigatedViewerSpec.js
@@ -1,4 +1,4 @@
-import axe from 'axe-core';
+import { expectToBeAccessible } from '@bpmn-io/a11y';
 
 import NavigatedViewer from 'lib/NavigatedViewer';
 
@@ -111,12 +111,8 @@ describe('NavigatedViewer', function() {
       const xml = require('../fixtures/bpmn/simple.bpmn');
       await createViewer(container, NavigatedViewer, xml);
 
-      // when
-      const results = await axe.run(container);
-
       // then
-      expect(results.passes).to.be.not.empty;
-      expect(results.violations).to.be.empty;
+      await expectToBeAccessible(container);
     });
 
   });

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -1,4 +1,4 @@
-import axe from 'axe-core';
+import { expectToBeAccessible } from '@bpmn-io/a11y';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -1806,12 +1806,8 @@ describe('Viewer', function() {
       const xml = require('../fixtures/bpmn/simple.bpmn');
       await createViewer(container, Viewer, xml);
 
-      // when
-      const results = await axe.run(container);
-
       // then
-      expect(results.passes).to.be.not.empty;
-      expect(results.violations).to.be.empty;
+      await expectToBeAccessible(container);
     });
 
   });

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -1,3 +1,5 @@
+import { expectToBeAccessible } from '@bpmn-io/a11y';
+
 import {
   inject
 } from 'test/TestHelper';
@@ -530,6 +532,18 @@ describe('features - drilldown', function() {
 
   });
 
+
+  describe('a11y', function() {
+
+    it('should report no violations', inject(async function(canvas) {
+
+      // given
+      const container = canvas.getContainer();
+
+      // then
+      await expectToBeAccessible(container);
+    }));
+  });
 });
 
 


### PR DESCRIPTION
### Proposed Changes

This PR:
* replaces `axe-core` with `@bpmn-io/a11y` to ensure common a11y goal
* adds accessible label to drill down button via `title`

<img width="520" alt="image" src="https://github.com/bpmn-io/bpmn-js/assets/28307541/bf839a73-a1b4-4145-aaa3-bb7a73bfbf94">

Related to https://github.com/camunda/camunda-modeler/issues/4394

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
