### PR TITLE
fix: show delete action for labels

### DIFF
--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -172,9 +172,7 @@ ContextPadProvider.prototype._isDeleteAllowed = function(elements) {
   });
 
   if (isArray(baseAllowed)) {
-    return every(baseAllowed, function(element) {
-      return includes(baseAllowed, element);
-    });
+    return every(elements, el => baseAllowed.includes(el));
   }
 
   return baseAllowed;
@@ -192,7 +190,6 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       connect = this._connect,
       create = this._create,
       popupMenu = this._popupMenu,
-      rules = this._rules,
       autoPlace = this._autoPlace,
       translate = this._translate,
       appendPreview = this._appendPreview;
@@ -200,6 +197,19 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
   var actions = {};
 
   if (element.type === 'label') {
+    if (this._isDeleteAllowed([ element ])) {
+      assign(actions, {
+        'delete': {
+          group: 'edit',
+          className: 'bpmn-icon-trash',
+          title: translate('Delete'),
+          action: {
+            click: removeElement
+          }
+        }
+      });
+    }
+
     return actions;
   }
 
@@ -537,16 +547,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
-  // delete element entry, only show if allowed by rules
-  var deleteAllowed = rules.allowed('elements.delete', { elements: [ element ] });
-
-  if (isArray(deleteAllowed)) {
-
-    // was the element returned as a deletion candidate?
-    deleteAllowed = deleteAllowed[0] === element;
-  }
-
-  if (deleteAllowed) {
+  if (this._isDeleteAllowed([ element ])) {
     assign(actions, {
       'delete': {
         group: 'edit',
@@ -585,8 +586,4 @@ function isEventType(businessObject, type, eventDefinitionType) {
   });
 
   return isType && isDefinition;
-}
-
-function includes(array, item) {
-  return array.indexOf(item) !== -1;
 }

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -198,16 +198,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   if (element.type === 'label') {
     if (this._isDeleteAllowed([ element ])) {
-      assign(actions, {
-        'delete': {
-          group: 'edit',
-          className: 'bpmn-icon-trash',
-          title: translate('Delete'),
-          action: {
-            click: removeElement
-          }
-        }
-      });
+      addDeleteAction();
     }
 
     return actions;
@@ -221,6 +212,19 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   function removeElement(e, element) {
     modeling.removeElements([ element ]);
+  }
+
+  function addDeleteAction() {
+    assign(actions, {
+      'delete': {
+        group: 'edit',
+        className: 'bpmn-icon-trash',
+        title: translate('Delete'),
+        action: {
+          click: removeElement
+        }
+      }
+    });
   }
 
   function getReplaceMenuPosition(element) {
@@ -548,16 +552,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
   }
 
   if (this._isDeleteAllowed([ element ])) {
-    assign(actions, {
-      'delete': {
-        group: 'edit',
-        className: 'bpmn-icon-trash',
-        title: translate('Delete'),
-        action: {
-          click: removeElement
-        }
-      }
-    });
+    addDeleteAction();
   }
 
   return actions;

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -198,7 +198,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   if (element.type === 'label') {
     if (this._isDeleteAllowed([ element ])) {
-      addDeleteAction();
+      assign(actions, deleteAction());
     }
 
     return actions;
@@ -214,8 +214,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     modeling.removeElements([ element ]);
   }
 
-  function addDeleteAction() {
-    assign(actions, {
+  function deleteAction() {
+    return {
       'delete': {
         group: 'edit',
         className: 'bpmn-icon-trash',
@@ -224,7 +224,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
           click: removeElement
         }
       }
-    });
+    };
   }
 
   function getReplaceMenuPosition(element) {
@@ -552,7 +552,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
   }
 
   if (this._isDeleteAllowed([ element ])) {
-    addDeleteAction();
+    assign(actions, deleteAction());
   }
 
   return actions;

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -72,6 +72,20 @@ describe('features - context-pad', function() {
     }));
 
 
+    it('should add delete action to elements label by default', inject(function(elementRegistry, contextPad) {
+
+      // given
+      var element = elementRegistry.get('StartEvent_1');
+      var label = element.label;
+
+      // when
+      contextPad.open(label);
+
+      // then
+      expect(deleteAction(label)).to.exist;
+    }));
+
+
     it('should include delete action when rule returns true',
       inject(function(elementRegistry, contextPad, customRules) {
 


### PR DESCRIPTION
Closes #2163

### Proposed Changes

Show delete action for element's label.

![image](https://github.com/bpmn-io/bpmn-js/assets/24656920/2b72eb53-d155-4235-aa6d-ce4627146232)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
