### PR TITLE
docs(modeling): improve connect optional param jsdoc definition

### DIFF
--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -114,7 +114,7 @@ Modeling.prototype.updateLabel = function(element, newLabel, newBounds, hints) {
 /**
  * @param {Element} source
  * @param {Element} target
- * @param {Partial<Connection>} attrs
+ * @param {Partial<Connection>} [attrs]
  * @param {ModelingHints} [hints]
  *
  * @return {T}


### PR DESCRIPTION
### Proposed Changes

This only fixes the jsdoc param for `attrs` in modeling connect being typed as required while it's optional.
If this was intended to be required, I can also delete this PR.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
