### PR TITLE
Keep Direction When Collapsing/Expanding Pools

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -295,10 +295,17 @@ ElementFactory.prototype.getDefaultSize = function(element, di) {
   }
 
   if (is(bo, 'bpmn:Participant')) {
+    var isHorizontalPool = di.isHorizontal === undefined || di.isHorizontal === true;
     if (isExpanded(bo, di)) {
-      return { width: 600, height: 250 };
+      if (isHorizontalPool) {
+        return { width: 600, height: 250 };
+      }
+      return { width: 250, height: 600 };
     } else {
-      return { width: 400, height: 60 };
+      if (isHorizontalPool) {
+        return { width: 400, height: 60 };
+      }
+      return { width: 60, height: 400 };
     }
   }
 

--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -10,6 +10,7 @@ import {
 
 import {
   is,
+  getDi,
   getBusinessObject
 } from '../../util/ModelUtil';
 
@@ -19,7 +20,8 @@ import {
 
 import {
   isExpanded,
-  isEventSubProcess
+  isEventSubProcess,
+  isHorizontal
 } from '../../util/DiUtil';
 
 import { getPropertyNames } from '../copy-paste/ModdleCopy';
@@ -284,9 +286,16 @@ export default function BpmnReplace(
         hints.moveChildren = false;
       }
 
-      // apply same width and default height
-      newElement.width = element.width;
-      newElement.height = elementFactory.getDefaultSize(newElement).height;
+      // apply same directionality
+      var isHorizontalPool = isHorizontal(element);
+      if (!getDi(element).isHorizontal) {
+        getDi(newElement).isHorizontal = isHorizontalPool;
+      }
+
+      // keep the existing size of the pool's direction to
+      // prevent dangling message flows
+      newElement.width = isHorizontalPool ? element.width : elementFactory.getDefaultSize(newElement).width;
+      newElement.height = isHorizontalPool ? elementFactory.getDefaultSize(newElement).height : element.height;
     }
 
     if (!rules.allowed('shape.resize', { shape: newBusinessObject })) {

--- a/test/spec/features/replace/BpmnReplace.collaboration.vertical.bpmn
+++ b/test/spec/features/replace/BpmnReplace.collaboration.vertical.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_1wsnry3">
+    <bpmn:participant id="V_Participant_1" name="Vertical_A" processRef="Process_1" />
+    <bpmn:participant id="V_Participant_2" name="Vertical_B" />
+    <bpmn:messageFlow id="V_MessageFlow_B_to_A" sourceRef="V_Participant_2" targetRef="V_Participant_1" />
+    <bpmn:messageFlow id="MessageFlow_1" sourceRef="Task_1" targetRef="V_Participant_2" />
+    <bpmn:messageFlow id="MessageFlow_3" sourceRef="EndEvent_1" targetRef="V_Participant_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1">
+        <bpmn:flowNodeRef>Task_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_2" />
+    </bpmn:laneSet>
+    <bpmn:task id="Task_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:messageEventDefinition />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="Process_18059hr" isExecutable="false" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1wsnry3">
+      <bpmndi:BPMNShape id="Participant_0dhyklk_di" bpmnElement="V_Participant_1" isHorizontal="false">
+        <dc:Bounds x="82" y="181" width="271" height="458" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1lr6kkb_di" bpmnElement="Lane_1">
+        <dc:Bounds x="82" y="211" width="138" height="428" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0c9o07a_di" bpmnElement="Lane_2">
+        <dc:Bounds x="220" y="211" width="133" height="428" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_06fwm9a_di" bpmnElement="V_Participant_2" isHorizontal="false">
+        <dc:Bounds x="436" y="237" width="115" height="378" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_1xdh89f_di" bpmnElement="V_MessageFlow_B_to_A">
+        <di:waypoint xsi:type="dc:Point" x="436" y="368" />
+        <di:waypoint xsi:type="dc:Point" x="353" y="368" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="384.5" y="381" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_0atv48s_di" bpmnElement="Task_1">
+        <dc:Bounds x="102" y="286" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_19wrxbj_di" bpmnElement="MessageFlow_1">
+        <di:waypoint xsi:type="dc:Point" x="202" y="326" />
+        <di:waypoint xsi:type="dc:Point" x="436" y="326" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="304" y="281" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1ooqi8q_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="134" y="535" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="170" y="508" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_B_to_A_di" bpmnElement="MessageFlow_3">
+        <di:waypoint xsi:type="dc:Point" x="170" y="553" />
+        <di:waypoint xsi:type="dc:Point" x="434" y="553" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="293" y="508" width="20" height="90" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/replace/BpmnReplace.poolMessageFlows.vertical.bpmn
+++ b/test/spec/features/replace/BpmnReplace.poolMessageFlows.vertical.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.5.0">
+  <bpmn:collaboration id="Collaboration_16ydlxc">
+    <bpmn:participant id="V_Participant_1" name="V_Participant_1" processRef="Process_1" />
+    <bpmn:participant id="V_Participant_2" name="V_Participant_2" processRef="Process_2" />
+    <bpmn:messageFlow id="V_MessageFlow_1" sourceRef="Task_A" targetRef="Task_B" />
+    <bpmn:messageFlow id="V_MessageFlow_2" sourceRef="Task_B" targetRef="Task_A" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:laneSet />
+    <bpmn:task id="Task_B" name="Task_B" />
+  </bpmn:process>
+  <bpmn:process id="Process_2" isExecutable="false">
+    <bpmn:task id="Task_A" name="Task_A" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_16ydlxc">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="V_Participant_1" isHorizontal="false">
+        <dc:Bounds x="483" y="94" width="149" height="372" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_B_di" bpmnElement="Task_B">
+        <dc:Bounds x="522" y="342" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_2_di" bpmnElement="V_Participant_2" isHorizontal="false">
+        <dc:Bounds x="40" y="96" width="125" height="383" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_A_di" bpmnElement="Task_A">
+        <dc:Bounds x="51" y="342" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="V_MessageFlow_1_di" bpmnElement="V_MessageFlow_1">
+        <di:waypoint x="151" y="400" />
+        <di:waypoint x="522" y="402" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="301.5" y="815" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="MessageFlow_2_di" bpmnElement="V_MessageFlow_2">
+        <di:waypoint x="522" y="366" />
+        <di:waypoint x="151" y="366" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="316.5" y="795" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/replace/BpmnReplaceSpec.js
+++ b/test/spec/features/replace/BpmnReplaceSpec.js
@@ -440,6 +440,7 @@ describe('features/replace - bpmn replace', function() {
       // then
       expect(isExpanded(newShape)).to.be.false; // collapsed
       expect(newShape.children).to.be.empty;
+      expect(newShape.di.isHorizontal).to.be.true;
 
       expect(newShape).to.have.bounds(collapsedBounds);
 
@@ -466,6 +467,72 @@ describe('features/replace - bpmn replace', function() {
       // then
       expect(isExpanded(newShape)).to.be.true; // expanded
       expect(newShape.children).to.be.empty;
+      expect(newShape.di.isHorizontal).to.be.true;
+
+      expect(newShape).to.have.bounds(expandedBounds);
+    }));
+
+  });
+
+
+  describe('should replace in vertical collaboration', function() {
+
+    var diagramXML = require('./BpmnReplace.collaboration.vertical.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules,
+      moddleExtensions: {
+        camunda: camundaPackage
+      }
+    }));
+
+
+    it('expanded with collapsed pool', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var shape = elementRegistry.get('V_Participant_1');
+
+      var messageFlow = elementRegistry.get('V_MessageFlow_B_to_A');
+
+      var collapsedBounds = assign({}, getBounds(shape), { width: 60 });
+
+      // when
+      var newShape = bpmnReplace.replaceElement(shape, {
+        type: 'bpmn:Participant',
+        isExpanded: false
+      });
+
+      // then
+      expect(isExpanded(newShape)).to.be.false; // collapsed
+      expect(newShape.children).to.be.empty;
+      expect(newShape.di.isHorizontal).to.be.false;
+
+      expect(newShape).to.have.bounds(collapsedBounds);
+
+      expect(messageFlow).to.have.waypoints([
+        { x: 436, y: 368 },
+        { x: newShape.x + collapsedBounds.width, y: 368 }
+      ]);
+    }));
+
+
+    it('collapsed with expanded pool', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var shape = elementRegistry.get('V_Participant_2');
+
+      var expandedBounds = assign({}, getBounds(shape), { width: 250 });
+
+      // when
+      var newShape = bpmnReplace.replaceElement(shape, {
+        type: 'bpmn:Participant',
+        isExpanded: true
+      });
+
+      // then
+      expect(isExpanded(newShape)).to.be.true; // expanded
+      expect(newShape.children).to.be.empty;
+      expect(newShape.di.isHorizontal).to.be.false;
 
       expect(newShape).to.have.bounds(expandedBounds);
     }));
@@ -502,6 +569,40 @@ describe('features/replace - bpmn replace', function() {
 
       expect(elementRegistry.get('MessageFlow_1')).to.exist;
       expect(elementRegistry.get('MessageFlow_2')).to.exist;
+    }));
+
+  });
+
+
+  describe('should collapse vertical pool, reconnecting message flows', function() {
+
+    var diagramXML = require('./BpmnReplace.poolMessageFlows.vertical.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules,
+      moddleExtensions: {
+        camunda: camundaPackage
+      }
+    }));
+
+
+    it('expanded with collapsed pool', inject(function(elementRegistry, bpmnReplace) {
+
+      // given
+      var shape = elementRegistry.get('V_Participant_1');
+
+      // when
+      var newShape = bpmnReplace.replaceElement(shape, {
+        type: 'bpmn:Participant',
+        isExpanded: false
+      });
+
+      // then
+      expect(isExpanded(newShape)).to.be.false; // collapsed
+      expect(newShape.children).to.be.empty;
+
+      expect(elementRegistry.get('V_MessageFlow_1')).to.exist;
+      expect(elementRegistry.get('V_MessageFlow_2')).to.exist;
     }));
 
   });


### PR DESCRIPTION
### Proposed Changes

Closes #2208

When collapsing or expanding a pool, the direction (horizontal/vertical) remains intact. This works with the existing UI.
The safeguard for message flows (keeping the pool's length) works with any pool.

<details>
<summary>Visual demo</summary>

![visual-demo](https://github.com/user-attachments/assets/faf4fff7-e4bd-4465-b96c-9b5838c46594)

</details>
