### PR TITLE
fix: lane resize constraint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: lane resize constraints for se and nw direction ([#2209](https://github.com/bpmn-io/bpmn-js/issues/2209))
+
 ## 17.9.2
 
 * `FIX`: keep direction when collapsing pools ([#2208](https://github.com/bpmn-io/bpmn-js/issues/2208))

--- a/lib/features/modeling/behavior/ResizeBehavior.js
+++ b/lib/features/modeling/behavior/ResizeBehavior.js
@@ -160,10 +160,25 @@ export function getParticipantResizeConstraints(laneShape, resizeDirection, bala
 
     var otherTrbl = asTRBL(other);
 
-    if (/n/.test(resizeDirection)) {
-      if (isHorizontalLane && otherTrbl.top < (laneTrbl.top - 10)) {
+    // lane flags
+    if (isHorizontalLane) {
+      if (otherTrbl.top < (laneTrbl.top - 10)) {
         isFirst = false;
       }
+      if (otherTrbl.bottom > (laneTrbl.bottom + 10)) {
+        isLast = false;
+      }
+    }
+    else {
+      if (otherTrbl.left < (laneTrbl.left - 10)) {
+        isFirst = false;
+      }
+      if (otherTrbl.right > (laneTrbl.right + 10)) {
+        isLast = false;
+      }
+    }
+
+    if (/n/.test(resizeDirection)) {
 
       // max top size (based on next element)
       if (balanced && abs(laneTrbl.top - otherTrbl.bottom) < 10) {
@@ -178,10 +193,6 @@ export function getParticipantResizeConstraints(laneShape, resizeDirection, bala
 
     if (/e/.test(resizeDirection)) {
 
-      if (!isHorizontalLane && otherTrbl.right > (laneTrbl.right + 10)) {
-        isLast = false;
-      }
-
       // max right size (based on previous element)
       if (balanced && abs(laneTrbl.right - otherTrbl.left) < 10) {
         addMin(maxTrbl, 'right', otherTrbl.right - minDimensions.width);
@@ -195,10 +206,6 @@ export function getParticipantResizeConstraints(laneShape, resizeDirection, bala
 
     if (/s/.test(resizeDirection)) {
 
-      if (isHorizontalLane && otherTrbl.bottom > (laneTrbl.bottom + 10)) {
-        isLast = false;
-      }
-
       // max bottom size (based on previous element)
       if (balanced && abs(laneTrbl.bottom - otherTrbl.top) < 10) {
         addMin(maxTrbl, 'bottom', otherTrbl.bottom - minDimensions.height);
@@ -211,10 +218,6 @@ export function getParticipantResizeConstraints(laneShape, resizeDirection, bala
     }
 
     if (/w/.test(resizeDirection)) {
-
-      if (!isHorizontalLane && otherTrbl.left < (laneTrbl.left - 10)) {
-        isFirst = false;
-      }
 
       // max left size (based on next element)
       if (balanced && abs(laneTrbl.left - otherTrbl.right) < 10) {
@@ -239,23 +242,26 @@ export function getParticipantResizeConstraints(laneShape, resizeDirection, bala
 
     var flowElementTrbl = asTRBL(flowElement);
 
-    if (isFirst && /n/.test(resizeDirection)) {
+    // vertical lane will resize from top with respect to flow element irrespective of first or last lane
+    if (/n/.test(resizeDirection) && (!isHorizontalLane || isFirst)) {
       addMin(minTrbl, 'top', flowElementTrbl.top - padding.top);
     }
 
-    if (isLast && /e/.test(resizeDirection)) {
+    // horizonal lane will resize from right with respect to flow element irrespective of first or last lane
+    if (/e/.test(resizeDirection) && (isHorizontalLane || isLast)) {
       addMax(minTrbl, 'right', flowElementTrbl.right + padding.right);
     }
 
-    if (isLast && /s/.test(resizeDirection)) {
+    // vertical lane will resize from bottom with respect to flow element irrespective of first or last lane
+    if (/s/.test(resizeDirection) && (!isHorizontalLane || isLast)) {
       addMax(minTrbl, 'bottom', flowElementTrbl.bottom + padding.bottom);
     }
 
-    if (isFirst && /w/.test(resizeDirection)) {
+    // horizonal lane will resize from left with respect to flow element irrespective of first or last lane
+    if (/w/.test(resizeDirection) && (isHorizontalLane || isFirst)) {
       addMin(minTrbl, 'left', flowElementTrbl.left - padding.left);
     }
   });
-
   return {
     min: minTrbl,
     max: maxTrbl

--- a/test/spec/features/modeling/behavior/ResizeBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/ResizeBehaviorSpec.js
@@ -326,6 +326,66 @@ describe('features/modeling - resize behavior', function() {
         })
       );
 
+
+      it('should snap to nested child lanes from <ne>', inject(
+        function(dragging, elementRegistry, resize) {
+
+          // given
+          var lane = elementRegistry.get('Lane_A');
+
+          // when
+          resize.activate(canvasEvent({ x: 0, y: 0 }), lane, 'ne');
+
+          dragging.move(canvasEvent({ x: -500, y: 500 }));
+
+          dragging.end();
+
+          // then
+          expect(lane.width).to.equal(330);
+          expect(lane.height).to.equal(105);
+        })
+      );
+
+
+      it('should snap to nested child lanes from <sw>', inject(
+        function(dragging, elementRegistry, resize) {
+
+          // given
+          var lane = elementRegistry.get('Lane_A');
+
+          // when
+          resize.activate(canvasEvent({ x: 0, y: 0 }), lane, 'sw');
+
+          dragging.move(canvasEvent({ x: 500, y: -500 }));
+
+          dragging.end();
+
+          // then
+          expect(lane.width).to.equal(563);
+          expect(lane.height).to.equal(60);
+        })
+      );
+
+
+      it('should snap to other sibling lanes child participants from <nw>', inject(
+        function(dragging, elementRegistry, resize) {
+
+          // given
+          var lane = elementRegistry.get('Lane_B_0');
+
+          // when
+          resize.activate(canvasEvent({ x: 0, y: 0 }), lane, 'nw');
+
+          dragging.move(canvasEvent({ x: 500, y: 500 }));
+
+          dragging.end();
+
+          // then
+          expect(lane.width).to.equal(563);
+          expect(lane.height).to.equal(60);
+        })
+      );
+
     });
 
 
@@ -887,6 +947,43 @@ describe('modeling/behavior - resize behavior - utilities', function() {
         expect(sizeConstraints).to.eql({
           min: {
             right: taskShape.x + taskShape.width + LANE_RIGHT_PADDING
+          },
+          max: {}
+        });
+
+      }));
+
+      it('left lane (E)', inject(function(elementRegistry) {
+
+        // given
+        var resizeShape = elementRegistry.get('Vertical_Lane_A'),
+            nestedLaneShape = elementRegistry.get('Nested_Vertical_Lane_B');
+
+        // when
+        var sizeConstraints = getParticipantResizeConstraints(resizeShape, 'e');
+
+        // then
+        expect(sizeConstraints).to.eql({
+          min: {
+            right: nestedLaneShape.x + VERTICAL_LANE_MIN_WIDTH
+          },
+          max: {}
+        });
+
+      }));
+
+      it('nested left lane (E)', inject(function(elementRegistry) {
+
+        // given
+        var resizeShape = elementRegistry.get('Nested_Vertical_Lane_A');
+
+        // when
+        var sizeConstraints = getParticipantResizeConstraints(resizeShape, 'e');
+
+        // then
+        expect(sizeConstraints).to.eql({
+          min: {
+            right: resizeShape.x + VERTICAL_LANE_MIN_WIDTH
           },
           max: {}
         });


### PR DESCRIPTION
**Issue:** The lane resize constraints do not work when using any lane except for the lowest one of the participant and using the bottom right corner of the lane.

<img width="692" alt="image" src="https://github.com/user-attachments/assets/eac02e73-3c38-4f22-b525-f9bf2fedd59d">

<img width="692" alt="image" src="https://github.com/user-attachments/assets/17d6abf3-1de4-4385-98ec-6b90837a973c">

**Resolution:** Fixed lane resizing when multiple lanes exist with participants from NW and SE direction. 

<img width="692" alt="image" src="https://github.com/user-attachments/assets/4fdc64db-1fcd-4e12-8910-f63ea9b44622">


**Identified Issue:** isFirst and isLast flag was not setting with corresponding lanes during resizing. 

Closes #2209 
