### PR TITLE
Handle elements without label when using search

### DIFF
--- a/lib/features/search/BpmnSearchProvider.js
+++ b/lib/features/search/BpmnSearchProvider.js
@@ -146,12 +146,12 @@ function compareTokens(tokensA, tokensB) {
 /**
  * Compares two strings.
  *
- * @param {string} a
- * @param {string} b
+ * @param {string} [a]
+ * @param {string} [b]
  *
  * @returns {number}
  */
-function compareStrings(a, b) {
+function compareStrings(a = '', b = '') {
   return a.localeCompare(b);
 }
 

--- a/test/spec/features/search/BpmnSearchProviderSpec.js
+++ b/test/spec/features/search/BpmnSearchProviderSpec.js
@@ -206,6 +206,21 @@ describe('features - BPMN search provider', function() {
       expect(elements[5].element.id).to.eql('foo_1');
     }));
 
+
+    it('should handle elements without label', inject(function(bpmnSearch) {
+
+      // given
+      var pattern = 'ass';
+
+      // when
+      var elements = bpmnSearch.find(pattern);
+
+      // then
+      expect(elements).length(2);
+      expect(elements[0].element.id).to.eql('Association_1');
+      expect(elements[1].element.id).to.eql('Association_2');
+    }));
+
   });
 
 });

--- a/test/spec/features/search/bpmn-search-sorting.bpmn
+++ b/test/spec/features/search/bpmn-search-sorting.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0ikirpg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0ikirpg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:task id="foo_3" name="foo bar" />
     <bpmn:task id="baz" name="bar foo" />
@@ -7,32 +7,50 @@
     <bpmn:task id="foo_2" name="foo bar" />
     <bpmn:task id="foo_1" name="baz" />
     <bpmn:task id="foo_0" name="bar" />
+    <bpmn:textAnnotation id="TextAnnotation_1" />
+    <bpmn:association id="Association_1" associationDirection="None" sourceRef="foo_3" targetRef="TextAnnotation_1" />
+    <bpmn:textAnnotation id="TextAnnotation_2" />
+    <bpmn:association id="Association_2" associationDirection="None" sourceRef="baz" targetRef="TextAnnotation_2" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_1sd3etr_di" bpmnElement="foo_3">
-        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <dc:Bounds x="160" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0tpx833_di" bpmnElement="baz">
-        <dc:Bounds x="290" y="80" width="100" height="80" />
+        <dc:Bounds x="290" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_03mqj66_di" bpmnElement="bar">
-        <dc:Bounds x="420" y="80" width="100" height="80" />
+        <dc:Bounds x="420" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1pc6qua_di" bpmnElement="foo_2">
-        <dc:Bounds x="550" y="80" width="100" height="80" />
+        <dc:Bounds x="550" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0g0alrr_di" bpmnElement="foo_1">
-        <dc:Bounds x="680" y="80" width="100" height="80" />
+        <dc:Bounds x="680" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0mbe5y4_di" bpmnElement="foo_0">
-        <dc:Bounds x="810" y="80" width="100" height="80" />
+        <dc:Bounds x="810" y="160" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0sxp2i6_di" bpmnElement="Association_1">
+        <di:waypoint x="248" y="160" />
+        <di:waypoint x="296" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1gmudwp_di" bpmnElement="Association_2">
+        <di:waypoint x="378" y="160" />
+        <di:waypoint x="426" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0g5dnhq_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="260" y="80" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_17bv75f_di" bpmnElement="TextAnnotation_2">
+        <dc:Bounds x="390" y="80" width="100" height="30" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
### Proposed Changes

Elements like associations don't have any label which we could use for comparison when sorting the search results.

![brave_D6YdY33A8m](https://github.com/user-attachments/assets/82f85f40-6855-4528-a1f5-25bba8f920f1)

Closes https://github.com/bpmn-io/bpmn-js/issues/2232

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
