### PR TITLE
fix: empty whitespaces label in group

### DIFF
--- a/lib/util/LabelUtil.js
+++ b/lib/util/LabelUtil.js
@@ -251,7 +251,11 @@ export function setLabel(element, text) {
   if (attr) {
 
     if (attr === 'categoryValueRef') {
-      semantic['categoryValueRef'].value = text;
+      if (!semantic[attr]) {
+        return element;
+      }
+
+      semantic[attr].value = text;
     } else {
       semantic[attr] = text;
     }

--- a/test/spec/features/modeling/UpdateLabel.bpmn
+++ b/test/spec/features/modeling/UpdateLabel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="StartEvent_1" name="Foo" />
     <bpmn:startEvent id="StartEvent_2" />
@@ -10,9 +10,10 @@
       <bpmn:text></bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
+    <bpmn:group id="Group_2" />
   </bpmn:process>
   <bpmn:category id="Category_1">
-    <bpmn:categoryValue id="CategoryValue_1" />
+    <bpmn:categoryValue id="CategoryValue_1" value="Group 1" />
   </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -32,14 +33,17 @@
         <dc:Bounds x="460" y="80" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
-        <dc:Bounds x="426" y="220" width="100" height="30" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_13podyk_di" bpmnElement="Subprocess_1">
         <dc:Bounds x="600" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="426" y="220" width="100" height="30" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
         <dc:Bounds x="165" y="190" width="150" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1txvenf_di" bpmnElement="Group_2">
+        <dc:Bounds x="490" y="190" width="150" height="115" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -165,17 +165,45 @@ describe('features/modeling - update label', function() {
   ));
 
 
-  it('should change value of group', inject(function(modeling, elementRegistry) {
+  it('should update group label', inject(function(modeling, elementRegistry) {
 
     // given
-    var group_1 = elementRegistry.get('Group_1');
+    var group = elementRegistry.get('Group_1');
 
     // when
-    modeling.updateLabel(group_1, 'foo');
+    modeling.updateLabel(group, 'bar');
 
     // then
-    expect(group_1.businessObject.categoryValueRef.value).to.equal('foo');
-    expect(group_1.label).to.exist;
+    expect(group.businessObject.categoryValueRef.value).to.equal('bar');
+    expect(group.label).to.exist;
+  }));
+
+
+  it('should create group label', inject(function(modeling, elementRegistry) {
+
+    // given
+    var group = elementRegistry.get('Group_2');
+
+    // when
+    modeling.updateLabel(group, 'foo');
+
+    // then
+    expect(group.businessObject.categoryValueRef.value).to.equal('foo');
+    expect(group.label).to.exist;
+  }));
+
+
+  it('should not create group label on empty text', inject(function(modeling, elementRegistry) {
+
+    // given
+    var group = elementRegistry.get('Group_2');
+
+    // when
+    modeling.updateLabel(group, null);
+
+    // then
+    expect(group.businessObject.categoryValueRef).to.not.exist;
+    expect(group.label).to.not.exist;
   }));
 
 


### PR DESCRIPTION
Closes #2231

### Proposed Changes

- Enter whitespaces in group labels doesn't crash modeler 
- Whitespaces will be treated as no label
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
