### PR TITLE
Fix issue with moving elements beyond border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
-* `DEPS`: update to `bpmn-moddle@9` ([#2114](https://github.com/bpmn-io/bpmn-js/pull/2114)
+* `DEPS`: update to `bpmn-moddle@9` ([#2114](https://github.com/bpmn-io/bpmn-js/pull/2114))
 
 ### Breaking Changes
 

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -928,7 +928,7 @@ function canMove(elements, target) {
   }
 
   // allow default move check to start move operation
-  if (!target) {
+  if (target === undefined) {
     return true;
   }
 

--- a/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
@@ -715,6 +715,38 @@ describe('features/snapping - BpmnCreateMoveSnapping', function() {
 
   });
 
+  describe('dragging elements', function() {
+    var diagramXML = require('./BpmnCreateMoveSnapping.process.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules
+    }));
+
+    it('should limit movement when attempting to drag outside the viewport', inject(function(elementRegistry, move, dragging, canvas) {
+
+      var task = elementRegistry.get('Task_1');
+      var viewbox = canvas.viewbox();
+      var initialX = task.x;
+      var initialY = task.y;
+
+      // when
+      move.start(canvasEvent({ x: task.x + task.width / 2, y: task.y + task.height / 2 }), task);
+
+      // Attempt to move far outside the viewport
+      var farAwayX = viewbox.x + viewbox.width * 2;
+      var farAwayY = viewbox.y + viewbox.height * 2;
+      dragging.move(canvasEvent({ x: farAwayX, y: farAwayY }));
+
+      dragging.end();
+
+      // then
+      expect(task.x).to.be.above(initialX, 'Task should have moved right');
+      expect(task.y).to.be.above(initialY, 'Task should have moved down');
+      expect(task.x).to.be.below(farAwayX, 'Task should not have moved as far right as attempted');
+      expect(task.y).to.be.below(farAwayY, 'Task should not have moved as far down as attempted');
+    }));
+  });
+
 });
 
 // helpers //////////


### PR DESCRIPTION
[See original issue for context](https://github.com/bpmn-io/bpmn-js/issues/2210)

### Proposed Changes

Change one line of code in `lib/features/rules/BpmnRules.js` in the `canMove` function:
```
- if (!target)
+ if (target === undefined)
```

### Reasoning
If a user starts dragging an element, the target is undefined. If a user drags an element outside the canvas, the target is null. Since both cases are considered nullish, they will both return true (meaning the user can drop the element). We want the latter case to return false.

### Steps to reproduce
![bpmn-demo](https://github.com/user-attachments/assets/ab74ec03-3717-446f-9881-d0a1ba264da1)

1. Wrap elements in a pool
2. Try dragging an element within the pool.
  a. If dragged within, should be successful
  b. If dragged outside the element but within the canvas, should fail
  c. If dragged outside the element AND outside the canvas, should fail