### PR TITLE
Ensure attributes are passed to createElement

### DIFF
--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -163,7 +163,7 @@ ElementFactory.prototype.createElement = function(elementType, attrs) {
       throw new Error('no shape type specified');
     }
 
-    businessObject = this._bpmnFactory.create(attrs.type);
+    businessObject = this._bpmnFactory.create(attrs.type, attrs);
 
     ensureCompatDiRef(businessObject);
   }


### PR DESCRIPTION
Updated the logic to pass the attributes directly to the create function as it expects both the type and the attributes. This simplifies the code and ensures better flexibility and maintainability.

**The issue**  :
When calling the createElement method, the source and target attributes 
were lost because they were not passed correctly. This fix ensures that 
these attributes are properly transmitted during the element creation, 
ensuring correct and complete behavior.

