### PR TITLE
fix(Modeler): re-add outline feature

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -34,6 +34,7 @@ import ReplacePreviewModule from './features/replace-preview';
 import ResizeModule from 'diagram-js/lib/features/resize';
 import SnappingModule from './features/snapping';
 import SearchModule from './features/search';
+import OutlineModule from './features/outline';
 
 var initialDiagram =
   '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -187,7 +188,8 @@ Modeler.prototype._modelingModules = [
   ReplacePreviewModule,
   ResizeModule,
   SnappingModule,
-  SearchModule
+  SearchModule,
+  OutlineModule
 ];
 
 

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -215,6 +215,19 @@ describe('Modeler', function() {
   });
 
 
+  it('should include Outline module by default', function() {
+
+    // given
+    var modeler = new Modeler();
+
+    // when
+    var outline = modeler.get('outline', false);
+
+    // then
+    expect(outline).to.exist;
+  });
+
+
   describe('overlay support', function() {
 
     it('should allow to add overlays', function() {

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -84,7 +84,7 @@ describe('Viewer', function() {
   it('should not include Outline module by default', function() {
 
     // given
-    var viewer = new Viewer({ container: container });
+    var viewer = new Viewer();
 
     // when
     var outline = viewer.get('outline', false);


### PR DESCRIPTION
### Proposed Changes

Turns out our custom outlines got missing with 583195a, time to restore them (for modeling).

#### Before

![image](https://github.com/user-attachments/assets/db091985-59e6-4818-b8c0-faa098a290a0)

#### After (fixed)

![image](https://github.com/user-attachments/assets/fab0dfc5-3586-4399-8901-8a8157ad3fe9)

Related to #2135

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
