### PR TITLE
fix(BaseViewer): swap canvas and project logo

### DIFF
--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -157,13 +157,13 @@ export default function BaseViewer(options) {
    */
   this._container = this._createContainer(options);
 
+  this._init(this._container, this._moddle, options);
+
   /* <project-logo> */
 
   addProjectLogo(this._container);
 
   /* </project-logo> */
-
-  this._init(this._container, this._moddle, options);
 }
 
 inherits(BaseViewer, Diagram);

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -1,5 +1,9 @@
 import { expectToBeAccessible } from '@bpmn-io/a11y';
 
+import {
+  query as domQuery
+} from 'min-dom';
+
 import TestContainer from 'mocha-test-container-support';
 
 import Diagram from 'diagram-js/lib/Diagram';
@@ -390,9 +394,9 @@ describe('Viewer', function() {
     function verifyDrilldown(xml) {
 
       return createViewer(container, Viewer, xml).then(function() {
-        var drilldown = container.querySelector('.bjs-drilldown');
-        var breadcrumbs = container.querySelector('.bjs-breadcrumbs');
-        var djsContainer = container.querySelector('.djs-container');
+        var drilldown = domQuery('.bjs-drilldown', container);
+        var breadcrumbs = domQuery('.bjs-breadcrumbs', container);
+        var djsContainer = domQuery('.djs-container', container);
 
         // assume
         expect(drilldown).to.exist;
@@ -1546,12 +1550,12 @@ describe('Viewer', function() {
           throw err;
         }
 
-        var svgDoc = viewer._container.childNodes[1].childNodes[1];
+        var svgDoc = domQuery('svg', viewer._container);
 
         appendTestRect(svgDoc);
         appendTestRect(svgDoc);
 
-        expect(svgDoc.querySelectorAll('.outer-bound-marker')).to.exist;
+        expect(domQuery('.outer-bound-marker', svgDoc)).to.exist;
 
         // when
         return viewer.saveSVG();
@@ -1564,7 +1568,7 @@ describe('Viewer', function() {
 
         // then
         expect(validSVG(svg)).to.be.true;
-        expect(svgDoc.querySelector('.outer-bound-marker')).to.be.null;
+        expect(domQuery('.outer-bound-marker', svgDoc)).not.to.exist;
 
       });
     });


### PR DESCRIPTION
### Proposed Changes

Ensures that the canvas is first in the focus / accessibility hierarchy of the browser:

![capture GkFwUK_optimized](https://github.com/user-attachments/assets/765ea60c-f103-434e-8c47-7d35baf62baa)

Without the fix the browser would tab through the diagram like this:

```
bpmn.io logo
canvas
```


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
