### PR TITLE
Create ad-hoc sub process via replace menu

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -231,6 +231,14 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
     return this._createEntries(target, filteredReplaceOptions);
   }
 
+  // expanded ad hoc sub processes
+  if (is(businessObject, 'bpmn:AdHocSubProcess') && isExpanded(target)) {
+
+    filteredReplaceOptions = filter(replaceOptions.AD_HOC_SUBPROCESS_EXPANDED, differentType);
+
+    return this._createEntries(target, filteredReplaceOptions);
+  }
+
   // expanded sub processes
   if (is(businessObject, 'bpmn:SubProcess') && isExpanded(target)) {
 
@@ -239,18 +247,16 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
     return this._createEntries(target, filteredReplaceOptions);
   }
 
-  // collapsed ad hoc sub processes
-  if (is(businessObject, 'bpmn:AdHocSubProcess') && !isExpanded(target)) {
+  // collapsed sub process or collapsed ad hoc sub process
+  if (is(businessObject, 'bpmn:SubProcess') && !isExpanded(target)) {
 
     filteredReplaceOptions = filter(replaceOptions.TASK, function(replaceOption) {
 
-      var target = replaceOption.target;
+      var isTargetSameType = replaceOption.target.type === target.type;
+      var isTargetExpanded = replaceOption.target.isExpanded === true;
 
-      var isTargetSubProcess = target.type === 'bpmn:SubProcess';
-
-      var isTargetExpanded = target.isExpanded === true;
-
-      return isDifferentType(target, target) && (!isTargetSubProcess || isTargetExpanded);
+      // Collapsed subprocess cannot be replaced with itself or expanded subprocess of different type.
+      return isTargetSameType === isTargetExpanded;
     });
 
     return this._createEntries(target, filteredReplaceOptions);
@@ -264,13 +270,6 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
   // flow nodes
   if (is(businessObject, 'bpmn:FlowNode')) {
     filteredReplaceOptions = filter(replaceOptions.TASK, differentType);
-
-    // collapsed sub process cannot be replaced with itself
-    if (is(businessObject, 'bpmn:SubProcess') && !isExpanded(target)) {
-      filteredReplaceOptions = filter(filteredReplaceOptions, function(replaceOption) {
-        return replaceOption.label !== 'Sub-process (collapsed)';
-      });
-    }
 
     return this._createEntries(target, filteredReplaceOptions);
   }
@@ -305,15 +304,6 @@ ReplaceMenuProvider.prototype.getPopupMenuHeaderEntries = function(target) {
     headerEntries = {
       ...headerEntries,
       ...this._getParticipantMultiplicityHeaderEntries(target)
-    };
-  }
-
-  if (is(target, 'bpmn:SubProcess') &&
-      !is(target, 'bpmn:Transaction') &&
-      !isEventSubProcess(target)) {
-    headerEntries = {
-      ...headerEntries,
-      ...this._getAdHocHeaderEntries(target)
     };
   }
 
@@ -620,6 +610,8 @@ ReplaceMenuProvider.prototype._getParticipantMultiplicityHeaderEntries = functio
  * @param  {PopupMenuTarget} element
  *
  * @return {PopupMenuHeaderEntries}
+ *
+ * @deprecated sinve v18.2.0 `bpmn:AdHocSubProcess` is available as a separate menu option.
  */
 ReplaceMenuProvider.prototype._getAdHocHeaderEntries = function(element) {
   var translate = this._translate;

--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -604,46 +604,6 @@ ReplaceMenuProvider.prototype._getParticipantMultiplicityHeaderEntries = functio
   };
 };
 
-/**
- * Get popup menu header entries for the ad-hoc property of the given BPMN element.
- *
- * @param  {PopupMenuTarget} element
- *
- * @return {PopupMenuHeaderEntries}
- *
- * @deprecated sinve v18.2.0 `bpmn:AdHocSubProcess` is available as a separate menu option.
- */
-ReplaceMenuProvider.prototype._getAdHocHeaderEntries = function(element) {
-  var translate = this._translate;
-  var businessObject = getBusinessObject(element);
-
-  var isAdHoc = is(businessObject, 'bpmn:AdHocSubProcess');
-
-  var replaceElement = this._bpmnReplace.replaceElement;
-
-  return {
-    'toggle-adhoc': {
-      className: 'bpmn-icon-ad-hoc-marker',
-      title: translate('Ad-hoc'),
-      active: isAdHoc,
-      action: function(event, entry) {
-        if (isAdHoc) {
-          return replaceElement(element, { type: 'bpmn:SubProcess' }, {
-            autoResize: false,
-            layoutConnection: false
-          });
-        } else {
-          return replaceElement(element, { type: 'bpmn:AdHocSubProcess' }, {
-            autoResize: false,
-            layoutConnection: false
-          });
-        }
-      }
-    }
-  };
-};
-
-
 ReplaceMenuProvider.prototype._getNonInterruptingHeaderEntries = function(element) {
   const translate = this._translate;
   const businessObject = getBusinessObject(element);

--- a/lib/features/replace/BpmnReplace.js
+++ b/lib/features/replace/BpmnReplace.js
@@ -145,7 +145,7 @@ export default function BpmnReplace(
     var type = targetElement.type,
         oldBusinessObject = element.businessObject;
 
-    if (isSubProcess(oldBusinessObject) && type === 'bpmn:SubProcess') {
+    if (isSubProcess(oldBusinessObject) && (type === 'bpmn:SubProcess' || type === 'bpmn:AdHocSubProcess')) {
       if (shouldToggleCollapsed(element, targetElement)) {
 
         // expanding or collapsing process

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -428,11 +428,63 @@ export var SUBPROCESS_EXPANDED = [
     }
   },
   {
+    label: 'Ad-hoc sub-process',
+    actionName: 'replace-with-ad-hoc-subprocess',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
+      isExpanded: true
+    }
+  },
+  {
     label: 'Sub-process (collapsed)',
     actionName: 'replace-with-collapsed-subprocess',
     className: 'bpmn-icon-subprocess-collapsed',
     target: {
       type: 'bpmn:SubProcess',
+      isExpanded: false
+    }
+  }
+];
+
+/**
+ * @type {ReplaceOption[]}
+ */
+export var AD_HOC_SUBPROCESS_EXPANDED = [
+  {
+    label: 'Sub-process',
+    actionName: 'replace-with-subprocess',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:SubProcess',
+      isExpanded: true
+    }
+  },
+  {
+    label: 'Transaction',
+    actionName: 'replace-with-transaction',
+    className: 'bpmn-icon-transaction',
+    target: {
+      type: 'bpmn:Transaction',
+      isExpanded: true
+    }
+  },
+  {
+    label: 'Event sub-process',
+    actionName: 'replace-with-event-subprocess',
+    className: 'bpmn-icon-event-subprocess-expanded',
+    target: {
+      type: 'bpmn:SubProcess',
+      triggeredByEvent: true,
+      isExpanded: true
+    }
+  },
+  {
+    label: 'Ad-hoc sub-process (collapsed)',
+    actionName: 'replace-with-collapsed-ad-hoc-subprocess',
+    className: 'bpmn-icon-subprocess-collapsed',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
       isExpanded: false
     }
   }
@@ -457,6 +509,15 @@ export var TRANSACTION = [
     className: 'bpmn-icon-subprocess-expanded',
     target: {
       type: 'bpmn:SubProcess',
+      isExpanded: true
+    }
+  },
+  {
+    label: 'Ad-hoc sub-process',
+    actionName: 'replace-with-ad-hoc-subprocess',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
       isExpanded: true
     }
   },
@@ -568,6 +629,24 @@ export var TASK = [
     className: 'bpmn-icon-subprocess-expanded',
     target: {
       type: 'bpmn:SubProcess',
+      isExpanded: true
+    }
+  },
+  {
+    label: 'Ad-hoc sub-process (collapsed)',
+    actionName: 'replace-with-collapsed-ad-hoc-subprocess',
+    className: 'bpmn-icon-subprocess-collapsed',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
+      isExpanded: false
+    }
+  },
+  {
+    label: 'Ad-hoc sub-process (expanded)',
+    actionName: 'replace-with-ad-hoc-subprocess',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
       isExpanded: true
     }
   }

--- a/test/spec/features/modeling/behavior/ToggleElementCollapseBehaviour.bpmn
+++ b/test/spec/features/modeling/behavior/ToggleElementCollapseBehaviour.bpmn
@@ -43,17 +43,17 @@
     <bpmn2:startEvent id="StartEvent_4">
       <bpmn2:outgoing>SequenceFlow_9</bpmn2:outgoing>
     </bpmn2:startEvent>
-    <bpmn2:sequenceFlow id="SequenceFlow_9" sourceRef="StartEvent_4" targetRef="SubProcess_2" />
+    <bpmn2:sequenceFlow id="SequenceFlow_9" sourceRef="StartEvent_4" targetRef="AdHocSubProcess_1" />
     <bpmn2:endEvent id="EndEvent_5">
       <bpmn2:incoming>SequenceFlow_8</bpmn2:incoming>
     </bpmn2:endEvent>
-    <bpmn2:sequenceFlow id="SequenceFlow_8" sourceRef="SubProcess_2" targetRef="EndEvent_5" />
+    <bpmn2:sequenceFlow id="SequenceFlow_8" sourceRef="AdHocSubProcess_1" targetRef="EndEvent_5" />
     <bpmn2:subProcess id="SubProcess_3" />
     <bpmn2:adHocSubProcess id="SubProcess_4">
       <bpmn2:multiInstanceLoopCharacteristics />
       <bpmn2:startEvent id="StartEvent_5" />
     </bpmn2:adHocSubProcess>
-    <bpmn2:adHocSubProcess id="SubProcess_2">
+    <bpmn2:adHocSubProcess id="AdHocSubProcess_1">
       <bpmn2:incoming>SequenceFlow_9</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_8</bpmn2:outgoing>
       <bpmn2:multiInstanceLoopCharacteristics />
@@ -143,7 +143,7 @@
       <bpmndi:BPMNShape id="AdHocSubProcess_0ojckgh_di" bpmnElement="SubProcess_4" isExpanded="false">
         <dc:Bounds x="541" y="652" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="AdHocSubProcess_128w1vu_di" bpmnElement="SubProcess_2" isExpanded="true">
+      <bpmndi:BPMNShape id="AdHocSubProcess_128w1vu_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
         <dc:Bounds x="407" y="335" width="385" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1s8bqj4_di" bpmnElement="SequenceFlow_11">

--- a/test/spec/features/modeling/behavior/ToggleElementCollapseBehaviourSpec.js
+++ b/test/spec/features/modeling/behavior/ToggleElementCollapseBehaviourSpec.js
@@ -89,7 +89,7 @@ describe('features/modeling - collapse and expand elements', function() {
         // when
         var expandedAdHocSubProcess = bpmnReplace.replaceElement(collapsedAdHocSubProcess,
           {
-            type: 'bpmn:SubProcess',
+            type: 'bpmn:AdHocSubProcess',
             isExpanded: true
           }
         );
@@ -322,12 +322,12 @@ describe('features/modeling - collapse and expand elements', function() {
       inject(function(elementRegistry, bpmnReplace) {
 
         // given
-        var expandedSubProcess = elementRegistry.get('SubProcess_2');
+        var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
 
         // when
         var collapsedSubProcess = bpmnReplace.replaceElement(expandedSubProcess,
           {
-            type: 'bpmn:SubProcess',
+            type: 'bpmn:AdHocSubProcess',
             isExpanded: false
           }
         );
@@ -342,12 +342,12 @@ describe('features/modeling - collapse and expand elements', function() {
       inject(function(elementRegistry, bpmnReplace) {
 
         // given
-        var expandedSubProcess = elementRegistry.get('SubProcess_2');
+        var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
 
         // when
         var collapsedSubProcess = bpmnReplace.replaceElement(expandedSubProcess,
           {
-            type: 'bpmn:SubProcess',
+            type: 'bpmn:AdHocSubProcess',
             isExpanded: false
           }
         );
@@ -364,7 +364,7 @@ describe('features/modeling - collapse and expand elements', function() {
       inject(function(elementRegistry, bpmnReplace) {
 
         // given
-        var expandedSubProcess = elementRegistry.get('SubProcess_2');
+        var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
         var originalChildren = expandedSubProcess.children.slice();
 
         // when
@@ -376,7 +376,7 @@ describe('features/modeling - collapse and expand elements', function() {
         );
 
         // then
-        var plane = elementRegistry.get('SubProcess_2_plane');
+        var plane = elementRegistry.get('AdHocSubProcess_1_plane');
         originalChildren.forEach(function(c) {
           expect(plane.children).to.include(c);
         });
@@ -390,7 +390,7 @@ describe('features/modeling - collapse and expand elements', function() {
         inject(function(elementRegistry, bpmnReplace) {
 
           // given
-          var expandedSubProcess = elementRegistry.get('SubProcess_2');
+          var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
           var oldMid = {
             x: expandedSubProcess.x + expandedSubProcess.width / 2,
             y: expandedSubProcess.y + expandedSubProcess.height / 2
@@ -399,7 +399,7 @@ describe('features/modeling - collapse and expand elements', function() {
           // when
           var collapsedSubProcess = bpmnReplace.replaceElement(expandedSubProcess,
             {
-              type: 'bpmn:SubProcess',
+              type: 'bpmn:AdHocSubProcess',
               isExpanded: false
             }
           );
@@ -426,10 +426,10 @@ describe('features/modeling - collapse and expand elements', function() {
         inject(function(elementRegistry, bpmnReplace, commandStack) {
 
           // given
-          var expandedSubProcess = elementRegistry.get('SubProcess_2');
+          var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
           var collapsedSubProcess = bpmnReplace.replaceElement(expandedSubProcess,
             {
-              type: 'bpmn:SubProcess',
+              type: 'bpmn:AdHocSubProcess',
               isExpanded: false
             }
           );
@@ -447,7 +447,7 @@ describe('features/modeling - collapse and expand elements', function() {
         inject(function(elementRegistry, bpmnReplace, commandStack) {
 
           // given
-          var expandedSubProcess = elementRegistry.get('SubProcess_2');
+          var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
           var originalBounds = {
             x: expandedSubProcess.x,
             y: expandedSubProcess.y,
@@ -457,7 +457,7 @@ describe('features/modeling - collapse and expand elements', function() {
 
           bpmnReplace.replaceElement(expandedSubProcess,
             {
-              type: 'bpmn:SubProcess',
+              type: 'bpmn:AdHocSubProcess',
               isExpanded: false
             }
           );
@@ -475,12 +475,12 @@ describe('features/modeling - collapse and expand elements', function() {
         inject(function(elementRegistry, bpmnReplace, commandStack) {
 
           // given
-          var expandedSubProcess = elementRegistry.get('SubProcess_2');
+          var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
           var originalChildren = expandedSubProcess.children.slice();
 
           bpmnReplace.replaceElement(expandedSubProcess,
             {
-              type: 'bpmn:SubProcess',
+              type: 'bpmn:AdHocSubProcess',
               isExpanded: false
             }
           );
@@ -589,7 +589,7 @@ describe('features/modeling - collapse and expand elements', function() {
         inject(function(eventBus, bpmnReplace, elementRegistry) {
 
           // given
-          var expandedSubProcess = elementRegistry.get('SubProcess_2');
+          var expandedSubProcess = elementRegistry.get('AdHocSubProcess_1');
 
           // should not be called
           eventBus.once('commandStack.shape.toggleCollapse.execute', function(e) {

--- a/test/spec/features/popup-menu/ReplaceMenuProvider.subProcesses.bpmn
+++ b/test/spec/features/popup-menu/ReplaceMenuProvider.subProcesses.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:subProcess id="SubProcess_1">
+      <bpmn:task id="Activity_0j5zj2x" />
+    </bpmn:subProcess>
+    <bpmn:adHocSubProcess id="AdhocSubProcess_1">
+      <bpmn:task id="Activity_1j5hq1s" />
+    </bpmn:adHocSubProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="SubProcess_0loe8m1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="60" width="360" height="210" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j5zj2x_di" bpmnElement="Activity_0j5zj2x">
+        <dc:Bounds x="290" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AdHocSubProcess_0lfb35q_di" bpmnElement="AdhocSubProcess_1" isExpanded="true">
+        <dc:Bounds x="600" y="65" width="360" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_14akb0e" bpmnElement="Activity_1j5hq1s">
+        <dc:Bounds x="740" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -361,72 +361,6 @@ describe('features/popup-menu - replace menu provider', function() {
         expect(toggleActive('toggle-loop')).to.be.true;
       }));
 
-
-      it('should be true for ad hoc marker', inject(function(elementRegistry) {
-
-        // given
-        var AdHocSubProcess = elementRegistry.get('AdHocSubProcess');
-
-        // when
-        openPopup(AdHocSubProcess);
-
-        // then
-        expect(toggleActive('toggle-adhoc')).to.be.true;
-      }));
-
-    });
-
-
-    describe('exclusive toggle buttons', function() {
-
-      it('should not toggle non exclusive buttons off', inject(function(elementRegistry) {
-        var subProcess = elementRegistry.get('AdHocSubProcess');
-
-        openPopup(subProcess);
-
-        // when
-        triggerAction('toggle-parallel-mi');
-
-        openPopup(subProcess);
-
-        // then
-        expect(domClasses(queryEntry('toggle-adhoc')).has('active')).to.be.true;
-      }));
-
-    });
-
-
-    describe('non exclusive toggle buttons', function() {
-
-      it('should not toggle exclusive buttons off',
-        inject(function(elementRegistry) {
-
-          // given
-          var subProcess = elementRegistry.get('SubProcess');
-
-          // when
-
-          // toggle parallel on
-          openPopup(subProcess);
-
-          triggerAction('toggle-parallel-mi');
-
-          // toggle ad hoc on
-          openPopup(subProcess);
-
-          var adHocSubProcess = triggerAction('toggle-adhoc');
-
-          openPopup(adHocSubProcess);
-
-          // then
-          var parallelEntry = queryEntry('toggle-parallel-mi');
-          var adHocEntry = queryEntry('toggle-adhoc');
-
-          expect(domClasses(parallelEntry).has('active')).to.be.true;
-          expect(domClasses(adHocEntry).has('active')).to.be.true;
-        })
-      );
-
     });
 
 
@@ -1105,6 +1039,23 @@ describe('features/popup-menu - replace menu provider', function() {
       })
     );
 
+
+    it('should replace sub processes -> ad hoc sub process',
+      inject(function(elementRegistry) {
+
+        // given
+        var subprocess = elementRegistry.get('SubProcess');
+
+        openPopup(subprocess);
+
+        // when
+        var adHocSubProcess = triggerAction('replace-with-ad-hoc-subprocess');
+
+        // then
+        expect(adHocSubProcess.type).to.equal('bpmn:AdHocSubProcess');
+      })
+    );
+
   });
 
 
@@ -1672,26 +1623,272 @@ describe('features/popup-menu - replace menu provider', function() {
     });
 
 
+    describe('subprocesses', function() {
+
+      var diagramXML = require('./ReplaceMenuProvider.subProcesses.bpmn');
+
+      beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+      describe('subprocess', function() {
+
+        it('options do not include subprocess itself', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+
+        it('options include collapsed subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options include ad hoc subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-ad-hoc-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options do not include collapsed ad hoc subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('SubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-ad-hoc-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+      });
+
+      describe('ad hoc subprocess', function() {
+
+        it('options do not include ad hoc subprocess itself', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-ad-hoc-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+
+        it('options include collapsed subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-ad-hoc-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options include subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options do not include collapsed subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+      });
+
+    });
+
+
     describe('collapsed subprocesses', function() {
 
       var diagramXML = require('./ReplaceMenuProvider.collapsedSubProcess.bpmn');
 
       beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
+      describe('collapsed subprocess', function() {
 
-      it('options do not include collapsed subprocesses itself', inject(function(elementRegistry) {
+        it('options do not include collapsed subprocess itself', inject(function(elementRegistry) {
 
-        // given
-        var collapsedSubProcess = elementRegistry.get('Task_1');
+          // given
+          var collapsedSubProcess = elementRegistry.get('Task_1');
 
-        // when
-        openPopup(collapsedSubProcess);
+          // when
+          openPopup(collapsedSubProcess);
 
-        var collapsedSubProcessEntry = queryEntry('replace-with-collapsed-subprocess');
+          var entry = queryEntry('replace-with-collapsed-subprocess');
 
-        // then
-        expect(collapsedSubProcessEntry).not.to.exist;
-      }));
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+
+        it('options include collapsed ad hoc subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('Task_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-ad-hoc-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options include expanded subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('Task_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-expanded-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options do not include ad hoc subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('Task_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-ad-hoc-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+      });
+
+      describe('collapsed ad hoc subprocess', function() {
+
+        it('options do not include collapsed ad hoc subprocess itself', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-ad-hoc-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+
+        it('options include collapsed subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-collapsed-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options include expanded ad hoc subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-ad-hoc-subprocess');
+
+          // then
+          expect(entry).to.exist;
+        }));
+
+
+        it('options do not include expanded subprocess', inject(function(elementRegistry) {
+
+          // given
+          var collapsedSubProcess = elementRegistry.get('AdhocSubProcess_1');
+
+          // when
+          openPopup(collapsedSubProcess);
+
+          var entry = queryEntry('replace-with-subprocess');
+
+          // then
+          expect(entry).not.to.exist;
+        }));
+
+      });
 
     });
 
@@ -2485,7 +2682,7 @@ describe('features/popup-menu - replace menu provider', function() {
 
     describe('adhoc sub process', function() {
 
-      var diagramXML = require('./ReplaceMenuProvider.collapsedSubProcess.bpmn');
+      var diagramXML = require('./ReplaceMenuProvider.subProcesses.bpmn');
 
       beforeEach(bootstrapModeler(diagramXML, {
         modules: testModules.concat(autoResizeModule)
@@ -2499,15 +2696,14 @@ describe('features/popup-menu - replace menu provider', function() {
           // given
           var subProcess = elementRegistry.get('SubProcess_1');
 
-          var resizeShapeSpy = sinon.spy(modeling, 'resizeShape');
-
           // when
           openPopup(subProcess);
 
-          triggerAction('toggle-adhoc');
+          const adHocSubProcess = triggerAction('replace-with-ad-hoc-subprocess');
 
           // then
-          expect(resizeShapeSpy).not.to.have.been.called;
+          const sizeChanged = didSizeChange(subProcess, adHocSubProcess);
+          expect(sizeChanged).to.be.false;
         }));
 
 
@@ -2521,7 +2717,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // when
           openPopup(subProcess);
 
-          triggerAction('toggle-adhoc');
+          triggerAction('replace-with-ad-hoc-subprocess');
 
           // then
           expect(layoutConnectionSpy).not.to.have.been.called;
@@ -2536,15 +2732,14 @@ describe('features/popup-menu - replace menu provider', function() {
           // given
           var adhocSubProcess = elementRegistry.get('AdhocSubProcess_1');
 
-          var resizeShapeSpy = sinon.spy(modeling, 'resizeShape');
-
           // when
           openPopup(adhocSubProcess);
 
-          triggerAction('toggle-adhoc');
+          const subprocess = triggerAction('replace-with-subprocess');
 
           // then
-          expect(resizeShapeSpy).not.to.have.been.called;
+          const sizeChanged = didSizeChange(adhocSubProcess, subprocess);
+          expect(sizeChanged).to.be.false;
         }));
 
 
@@ -2558,7 +2753,7 @@ describe('features/popup-menu - replace menu provider', function() {
           // when
           openPopup(adhocSubProcess);
 
-          triggerAction('toggle-adhoc');
+          triggerAction('replace-with-subprocess');
 
           // then
           expect(layoutConnectionSpy).not.to.have.been.called;
@@ -2787,4 +2982,9 @@ function triggerAction(id) {
 function getMenuContainer() {
   const popup = getBpmnJS().get('popupMenu');
   return popup._current.container;
+}
+
+function didSizeChange(element, newElement) {
+  return element.di.bounds.width !== newElement.di.bounds.width ||
+          element.di.bounds.height !== newElement.di.bounds.height;
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4801

### Proposed Changes

Make ad-hoc subprocess available as a replace menu entry.

https://github.com/user-attachments/assets/459386fd-e4be-4999-8ebe-49fcca2b40cf

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
