### PR TITLE
fix: move text annotations when a participant is resized by space tool

### DIFF
--- a/lib/features/space-tool/BpmnSpaceTool.js
+++ b/lib/features/space-tool/BpmnSpaceTool.js
@@ -2,7 +2,9 @@ import inherits from 'inherits-browser';
 
 import SpaceTool from 'diagram-js/lib/features/space-tool/SpaceTool';
 
-import { getBusinessObject, is } from '../../util/ModelUtil';
+import { getEnclosedElements, getBBox } from 'diagram-js/lib/util/Elements';
+
+import { getBusinessObject, is, isAny } from '../../util/ModelUtil';
 
 import { isHorizontal } from '../../util/DiUtil';
 
@@ -37,7 +39,32 @@ inherits(BpmnSpaceTool, SpaceTool);
  * @return {Object}
  */
 BpmnSpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start) {
-  var adjustments = SpaceTool.prototype.calculateAdjustments.call(this, elements, axis, delta, start);
+
+  // Make sure elements positioned on the root (e.g. text annotations)
+  // are moved when the participant enclosing them is resized.
+  const shapesToMove = [ 'bpmn:TextAnnotation' ];
+  const participants = elements.filter(shape => is(shape, 'bpmn:Participant'));
+
+  const rootElements = participants.reduce((result, participant) => {
+
+    const rootChildren = participant.parent.children;
+
+    const elementsToMove = rootChildren.filter(child => isAny(child, shapesToMove));
+
+    if (!elementsToMove.length) {
+      return result;
+    }
+
+    const bbox = getBBox(participant);
+
+    const enclosed = Object.values(getEnclosedElements(elementsToMove, bbox));
+
+    return [ ...result, ...enclosed ];
+  }, []);
+
+  const elementsToMove = [ ...elements, ...rootElements ];
+
+  var adjustments = SpaceTool.prototype.calculateAdjustments.call(this, elementsToMove, axis, delta, start);
 
   // do not resize:
   //

--- a/lib/features/space-tool/BpmnSpaceTool.js
+++ b/lib/features/space-tool/BpmnSpaceTool.js
@@ -4,12 +4,14 @@ import SpaceTool from 'diagram-js/lib/features/space-tool/SpaceTool';
 
 import { getEnclosedElements, getBBox } from 'diagram-js/lib/util/Elements';
 
-import { getBusinessObject, is, isAny } from '../../util/ModelUtil';
+import { getBusinessObject, is } from '../../util/ModelUtil';
 
 import { isHorizontal } from '../../util/DiUtil';
+import { values } from 'min-dash';
 
 /**
  * @typedef {import('didi').Injector} Injector
+ * @typedef {import('diagram-js/lib/core/Canvas').default} Canvas
  *
  * @typedef {import('../../model/Types').Shape} Shape
  *
@@ -19,13 +21,17 @@ import { isHorizontal } from '../../util/DiUtil';
 
 /**
  * @param {Injector} injector
+ * @param {Canvas} canvas
  */
-export default function BpmnSpaceTool(injector) {
+export default function BpmnSpaceTool(injector, canvas) {
   injector.invoke(SpaceTool, this);
+
+  this._canvas = canvas;
 }
 
 BpmnSpaceTool.$inject = [
-  'injector'
+  'injector',
+  'canvas'
 ];
 
 inherits(BpmnSpaceTool, SpaceTool);
@@ -40,29 +46,23 @@ inherits(BpmnSpaceTool, SpaceTool);
  */
 BpmnSpaceTool.prototype.calculateAdjustments = function(elements, axis, delta, start) {
 
-  // Make sure elements positioned on the root (e.g. text annotations)
-  // are moved when the participant enclosing them is resized.
-  const shapesToMove = [ 'bpmn:TextAnnotation' ];
-  const participants = elements.filter(shape => is(shape, 'bpmn:Participant'));
+  var canvasRoot = this._canvas.getRootElement(),
+      spaceRoot = elements[0] === canvasRoot ? null : elements[0],
+      enclosedArtifacts = [];
 
-  const rootElements = participants.reduce((result, participant) => {
+  // ensure
+  if (spaceRoot) {
+    enclosedArtifacts = values(
+      getEnclosedElements(
+        canvasRoot.children.filter(
+          (child) => is(child, 'bpmn:Artifact')
+        ),
+        getBBox(spaceRoot)
+      )
+    );
+  }
 
-    const rootChildren = participant.parent.children;
-
-    const elementsToMove = rootChildren.filter(child => isAny(child, shapesToMove));
-
-    if (!elementsToMove.length) {
-      return result;
-    }
-
-    const bbox = getBBox(participant);
-
-    const enclosed = Object.values(getEnclosedElements(elementsToMove, bbox));
-
-    return [ ...result, ...enclosed ];
-  }, []);
-
-  const elementsToMove = [ ...elements, ...rootElements ];
+  const elementsToMove = [ ...elements, ...enclosedArtifacts ];
 
   var adjustments = SpaceTool.prototype.calculateAdjustments.call(this, elementsToMove, axis, delta, start);
 

--- a/test/spec/features/space-tool/BpmnSpaceTool.artifacts.bpmn
+++ b/test/spec/features/space-tool/BpmnSpaceTool.artifacts.bpmn
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14kk48y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0-rc.0">
+  <bpmn:collaboration id="COLLABORATION">
+    <bpmn:participant id="PARTICIPANT" name="PARTICIPANT" processRef="PROCESS" />
+    <bpmn:textAnnotation id="ANNOTATION_1">
+      <bpmn:text>ANNOTATION_1</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="ANNOTATION_3">
+      <bpmn:text>ANNOTATION_3</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="ANNOTATION_2">
+      <bpmn:text>ANNOTATION_2</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:group id="GROUP_CONTAINED_PARTICIPANT" categoryValueRef="CategoryValue_1fn4md7" />
+    <bpmn:group id="GROUP_OUTSIDE" categoryValueRef="CategoryValue_0w429b8" />
+    <bpmn:group id="GROUP_CONTAINED_SUB" categoryValueRef="CategoryValue_0l3p581" />
+    <bpmn:textAnnotation id="ANNOTATION_4">
+      <bpmn:text>ANNOTATION_4</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1iiawtv" associationDirection="None" sourceRef="ANNOTATION_4" targetRef="GROUP_CONTAINED_SUB" />
+    <bpmn:association id="Association_180iz30" associationDirection="None" sourceRef="TASK" targetRef="ANNOTATION_1" />
+    <bpmn:association id="Association_08csipe" associationDirection="None" sourceRef="TASK" targetRef="ANNOTATION_3" />
+    <bpmn:textAnnotation id="ANNOTATION_5">
+      <bpmn:text>ANNOTATION_5</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:group id="GROUP_OUTSIDE_SUB" categoryValueRef="CategoryValue_1rcl2uo" />
+  </bpmn:collaboration>
+  <bpmn:process id="PROCESS" isExecutable="false">
+    <bpmn:laneSet id="LaneSet_04jep3i" />
+    <bpmn:task id="TASK" name="TASK" />
+    <bpmn:subProcess id="SUB" name="SUB" />
+  </bpmn:process>
+  <bpmn:category id="Category_0tto0k6">
+    <bpmn:categoryValue id="CategoryValue_1fn4md7" value="GROUP_CONTAINED_PARTICIPANT" />
+  </bpmn:category>
+  <bpmn:category id="Category_002evdo">
+    <bpmn:categoryValue id="CategoryValue_0w429b8" value="GROUP_OUTSIDE" />
+  </bpmn:category>
+  <bpmn:category id="Category_1u7ocho">
+    <bpmn:categoryValue id="CategoryValue_0l3p581" value="GROUP_CONTAINED_SUB" />
+  </bpmn:category>
+  <bpmn:category id="Category_00robw0">
+    <bpmn:categoryValue id="CategoryValue_1rcl2uo" value="GROUP_OUTSIDE_SUB" />
+  </bpmn:category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COLLABORATION">
+      <bpmndi:BPMNShape id="Participant_0lm71nu_di" bpmnElement="PARTICIPANT" isHorizontal="true">
+        <dc:Bounds x="160" y="130" width="900" height="420" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g8l8sp_di" bpmnElement="TASK">
+        <dc:Bounds x="280" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mtvx36_di" bpmnElement="SUB" isExpanded="true">
+        <dc:Bounds x="650" y="200" width="350" height="280" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_180iz30_di" bpmnElement="Association_180iz30">
+        <di:waypoint x="379" y="287" />
+        <di:waypoint x="494" y="209" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_08csipe_di" bpmnElement="Association_08csipe">
+        <di:waypoint x="336" y="360" />
+        <di:waypoint x="378" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1iiawtv_di" bpmnElement="Association_1iiawtv">
+        <di:waypoint x="869" y="410" />
+        <di:waypoint x="850" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0kurhwc_di" bpmnElement="ANNOTATION_1">
+        <dc:Bounds x="470" y="170" width="109.99999237060547" height="39" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1vsrf4d" bpmnElement="ANNOTATION_2">
+        <dc:Bounds x="450" y="430" width="110" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1q5j3c0_di" bpmnElement="GROUP_CONTAINED_PARTICIPANT">
+        <dc:Bounds x="240" y="190" width="170" height="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="282" y="197" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8gbmr" bpmnElement="GROUP_OUTSIDE">
+        <dc:Bounds x="210" y="80" width="370" height="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="355" y="87" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0r40zjh_di" bpmnElement="ANNOTATION_3">
+        <dc:Bounds x="330" y="650" width="110" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0887xry_di" bpmnElement="GROUP_CONTAINED_SUB">
+        <dc:Bounds x="690" y="240" width="200" height="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="748" y="247" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0hnq4f9" bpmnElement="ANNOTATION_4">
+        <dc:Bounds x="820" y="410" width="110" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0m4uhit_di" bpmnElement="GROUP_OUTSIDE_SUB">
+        <dc:Bounds x="725" y="140" width="300" height="390" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="837" y="147" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0t9rdue" bpmnElement="ANNOTATION_5">
+        <dc:Bounds x="870" y="490" width="109.99999237060547" height="25.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/space-tool/BpmnSpaceTool.participants.bpmn
+++ b/test/spec/features/space-tool/BpmnSpaceTool.participants.bpmn
@@ -1,25 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14kk48y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14kk48y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.1">
   <bpmn:collaboration id="Collaboration_0ci7cuj">
     <bpmn:participant id="Participant_1" name="Expanded Pool" processRef="Process_1" />
     <bpmn:participant id="Participant_2" name="Empty Pool" />
-    <bpmn:participant id="Participant_3" name="Pool with text annotations" processRef="Process_3" />
-    <bpmn:textAnnotation id="TextAnnotation_1">
-      <bpmn:text>text 1</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:textAnnotation id="TextAnnotation_2">
-      <bpmn:text>text 2</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:textAnnotation id="TextAnnotation_3">
-      <bpmn:text>text 3</bpmn:text>
-    </bpmn:textAnnotation>
   </bpmn:collaboration>
   <bpmn:process id="Process_1" isExecutable="true" />
-  <bpmn:process id="Process_3" isExecutable="false">
-    <bpmn:task id="Activity_1" />
-    <bpmn:association id="Association_180iz30" associationDirection="None" sourceRef="Activity_1" targetRef="TextAnnotation_1" />
-    <bpmn:association id="Association_08csipe" associationDirection="None" sourceRef="Activity_1" targetRef="TextAnnotation_2" />
-  </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ci7cuj">
       <bpmndi:BPMNShape id="Participant_0f6z5qz_di" bpmnElement="Participant_1" isHorizontal="true">
@@ -28,33 +13,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Participant_1pw3o1x_di" bpmnElement="Participant_2" isHorizontal="true">
         <dc:Bounds x="160" y="170" width="600" height="60" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Participant_0lm71nu_di" bpmnElement="Participant_3" isHorizontal="true">
-        <dc:Bounds x="160" y="250" width="600" height="250" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1g8l8sp_di" bpmnElement="Activity_1">
-        <dc:Bounds x="310" y="340" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_180iz30_di" bpmnElement="Association_180iz30">
-        <di:waypoint x="410" y="358" />
-        <di:waypoint x="496" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_08csipe_di" bpmnElement="Association_08csipe">
-        <di:waypoint x="393" y="420" />
-        <di:waypoint x="518" y="570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_0kurhwc_di" bpmnElement="TextAnnotation_1">
-        <dc:Bounds x="480" y="290" width="100" height="30" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_0r40zjh_di" bpmnElement="TextAnnotation_2">
-        <dc:Bounds x="480" y="570" width="100" height="30" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_05zy3rg" bpmnElement="TextAnnotation_3">
-        <dc:Bounds x="200" y="360" width="100" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/space-tool/BpmnSpaceTool.participants.bpmn
+++ b/test/spec/features/space-tool/BpmnSpaceTool.participants.bpmn
@@ -1,10 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14kk48y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14kk48y" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0">
   <bpmn:collaboration id="Collaboration_0ci7cuj">
     <bpmn:participant id="Participant_1" name="Expanded Pool" processRef="Process_1" />
     <bpmn:participant id="Participant_2" name="Empty Pool" />
+    <bpmn:participant id="Participant_3" name="Pool with text annotations" processRef="Process_3" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>text 1</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_2">
+      <bpmn:text>text 2</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_3">
+      <bpmn:text>text 3</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:collaboration>
   <bpmn:process id="Process_1" isExecutable="true" />
+  <bpmn:process id="Process_3" isExecutable="false">
+    <bpmn:task id="Activity_1" />
+    <bpmn:association id="Association_180iz30" associationDirection="None" sourceRef="Activity_1" targetRef="TextAnnotation_1" />
+    <bpmn:association id="Association_08csipe" associationDirection="None" sourceRef="Activity_1" targetRef="TextAnnotation_2" />
+  </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ci7cuj">
       <bpmndi:BPMNShape id="Participant_0f6z5qz_di" bpmnElement="Participant_1" isHorizontal="true">
@@ -13,6 +28,33 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Participant_1pw3o1x_di" bpmnElement="Participant_2" isHorizontal="true">
         <dc:Bounds x="160" y="170" width="600" height="60" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0lm71nu_di" bpmnElement="Participant_3" isHorizontal="true">
+        <dc:Bounds x="160" y="250" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g8l8sp_di" bpmnElement="Activity_1">
+        <dc:Bounds x="310" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_180iz30_di" bpmnElement="Association_180iz30">
+        <di:waypoint x="410" y="358" />
+        <di:waypoint x="496" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_08csipe_di" bpmnElement="Association_08csipe">
+        <di:waypoint x="393" y="420" />
+        <di:waypoint x="518" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0kurhwc_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="480" y="290" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0r40zjh_di" bpmnElement="TextAnnotation_2">
+        <dc:Bounds x="480" y="570" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_05zy3rg" bpmnElement="TextAnnotation_3">
+        <dc:Bounds x="200" y="360" width="100" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/space-tool/BpmnSpaceToolSpec.js
+++ b/test/spec/features/space-tool/BpmnSpaceToolSpec.js
@@ -553,6 +553,167 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
   });
 
+
+  describe('artifacts', function() {
+
+    var diagramXML = require('./BpmnSpaceTool.artifacts.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules
+    }));
+
+    beforeEach(inject(function(dragging) {
+      dragging.setOptions({ manual: true });
+    }));
+
+
+    describe('should move visually contained', function() {
+
+      it('in participant', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_1');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_CONTAINED_PARTICIPANT');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf(group), { dx: 100 }, false, 'PARTICIPANT');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X + 100);
+        expect(group.x).to.equal(group_X + 100);
+      }));
+
+
+      it('in subprocess', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_4');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_CONTAINED_SUB');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf(group), { dx: 100 }, false, 'SUB');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X + 100);
+        expect(group.x).to.equal(group_X + 100);
+      }));
+
+
+      it('on root', inject(function() {
+
+        // given
+        var textAnnotation_in_PARTICIPANT = $element('ANNOTATION_1');
+        var textAnnotation_in_PARTICIPANT_X = textAnnotation_in_PARTICIPANT.x;
+
+        var textAnnotation_in_SUB = $element('ANNOTATION_4');
+        var textAnnotation_in_SUB_X = textAnnotation_in_SUB.x;
+
+        var group_in_PARTICIPANT = $element('GROUP_CONTAINED_PARTICIPANT');
+        var group_in_PARTICIPANT_X = group_in_PARTICIPANT.x;
+
+        var group_in_SUB = $element('GROUP_CONTAINED_SUB');
+        var group_in_SUB_X = group_in_SUB.x;
+
+        // when
+        makeSpace(leftOf('PARTICIPANT'), { dx: 100 }, false);
+
+        // then
+        expect(textAnnotation_in_PARTICIPANT.x).to.equal(textAnnotation_in_PARTICIPANT_X + 100);
+        expect(textAnnotation_in_SUB.x).to.equal(textAnnotation_in_SUB_X + 100);
+        expect(group_in_PARTICIPANT.x).to.equal(group_in_PARTICIPANT_X + 100);
+        expect(group_in_SUB.x).to.equal(group_in_SUB_X + 100);
+      }));
+
+    });
+
+
+    describe('should ignore outside of containment', function() {
+
+      it('in participant', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_3');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_OUTSIDE');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf('TASK'), { dx: 100 }, false, 'PARTICIPANT');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X);
+        expect(group.x).to.equal(group_X);
+      }));
+
+
+      it('in subprocess', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_5');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_OUTSIDE_SUB');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf('GROUP_CONTAINED_SUB'), { dx: 100 }, false, 'SUB');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X);
+        expect(group.x).to.equal(group_X);
+      }));
+
+    });
+
+
+    describe('should ignore unaffected inside of containment', function() {
+
+      it('in participant', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_1');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_CONTAINED_PARTICIPANT');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf(group), { dx: -100 }, true, 'PARTICIPANT');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X);
+        expect(group.x).to.equal(group_X);
+      }));
+
+
+      it('in subprocess', inject(function() {
+
+        // given
+        var textAnnotation = $element('ANNOTATION_4');
+        var textAnnotation_X = textAnnotation.x;
+
+        var group = $element('GROUP_CONTAINED_SUB');
+        var group_X = group.x;
+
+        // when
+        makeSpace(leftOf(group), { dx: -100 }, true, 'SUB');
+
+        // then
+        expect(textAnnotation.x).to.equal(textAnnotation_X);
+        expect(group.x).to.equal(group_X);
+      }));
+
+    });
+
+  });
+
 });
 
 
@@ -600,7 +761,6 @@ function $element(id) {
   });
 }
 
-// eslint-disable-next-line "no-unused-vars"
 function leftOf(element) {
 
   element = $element(element);

--- a/test/spec/features/space-tool/BpmnSpaceToolSpec.js
+++ b/test/spec/features/space-tool/BpmnSpaceToolSpec.js
@@ -551,6 +551,102 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       });
     }));
 
+
+    it('should move text annotations in a participant', inject(function(dragging, elementRegistry, spaceTool) {
+
+      // given
+      var textAnnotation = elementRegistry.get('TextAnnotation_1');
+      var textAnnotationX = textAnnotation.x;
+
+      var task = elementRegistry.get('Activity_1');
+      var taskMid = getMid(task);
+      var rightOfTask = task.x + task.width + 10;
+
+      // when
+      var element = elementRegistry.get('Participant_3');
+      var gfx = elementRegistry.getGraphics(element);
+      var hover = { element, gfx };
+
+      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
+
+      // then
+      expect(textAnnotation.x).to.equal(textAnnotationX + 100);
+    }));
+
+
+    it('should only move text annotations in space tool range', inject(function(dragging, elementRegistry, spaceTool) {
+
+      // given
+      var textAnnotationToMove = elementRegistry.get('TextAnnotation_1');
+      var textAnnotationToMove_X = textAnnotationToMove.x;
+
+      var textAnnotationToStay = elementRegistry.get('TextAnnotation_3');
+      var textAnnotationToStay_X = textAnnotationToStay.x;
+
+      var task = elementRegistry.get('Activity_1');
+      var taskMid = getMid(task);
+      var rightOfTask = task.x + task.width + 10;
+
+      // when
+      var element = elementRegistry.get('Participant_3');
+      var gfx = elementRegistry.getGraphics(element);
+      var hover = { element, gfx };
+
+      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
+
+      // then
+      expect(textAnnotationToMove.x).to.equal(textAnnotationToMove_X + 100);
+      expect(textAnnotationToStay.x).to.equal(textAnnotationToStay_X);
+    }));
+
+
+    it('should only move text annotations in space tool range (inverted)', inject(function(dragging, elementRegistry, spaceTool) {
+
+      // given
+      var textAnnotationToMove = elementRegistry.get('TextAnnotation_3');
+      var textAnnotationToMove_X = textAnnotationToMove.x;
+
+      var textAnnotationToStay = elementRegistry.get('TextAnnotation_1');
+      var textAnnotationToStay_X = textAnnotationToStay.x;
+
+      var task = elementRegistry.get('Activity_1');
+      var taskMid = getMid(task);
+      var rightOfTask = task.x + task.width + 10;
+
+      // when
+      var element = elementRegistry.get('Participant_3');
+      var gfx = elementRegistry.getGraphics(element);
+      var hover = { element, gfx };
+
+      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: -100 }, true, hover);
+
+      // then
+      expect(textAnnotationToMove.x).to.equal(textAnnotationToMove_X - 100);
+      expect(textAnnotationToStay.x).to.equal(textAnnotationToStay_X);
+    }));
+
+
+    it('should not move text annotations outside of participant', inject(function(dragging, elementRegistry, spaceTool) {
+
+      // given
+      var textAnnotation = elementRegistry.get('TextAnnotation_2');
+      var textAnnotationX = textAnnotation.x;
+
+      var task = elementRegistry.get('Activity_1');
+      var taskMid = getMid(task);
+      var rightOfTask = task.x + task.width + 10;
+
+      // when
+      var element = elementRegistry.get('Participant_3');
+      var gfx = elementRegistry.getGraphics(element);
+      var hover = { element, gfx };
+
+      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
+
+      // then
+      expect(textAnnotation.x).to.equal(textAnnotationX);
+    }));
+
   });
 
 });
@@ -558,7 +654,7 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
 // helpers //////////
 
-function makeSpace(start, delta, invert) {
+function makeSpace(start, delta, invert, hover) {
   var modifier = invert ? invertModifier : {};
 
   var end = {
@@ -568,6 +664,8 @@ function makeSpace(start, delta, invert) {
 
   return getBpmnJS().invoke(function(spaceTool, dragging) {
     spaceTool.activateMakeSpace(canvasEvent(start));
+
+    hover && dragging.hover(hover);
 
     dragging.move(canvasEvent(end, modifier));
 

--- a/test/spec/features/space-tool/BpmnSpaceToolSpec.js
+++ b/test/spec/features/space-tool/BpmnSpaceToolSpec.js
@@ -551,102 +551,6 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       });
     }));
 
-
-    it('should move text annotations in a participant', inject(function(dragging, elementRegistry, spaceTool) {
-
-      // given
-      var textAnnotation = elementRegistry.get('TextAnnotation_1');
-      var textAnnotationX = textAnnotation.x;
-
-      var task = elementRegistry.get('Activity_1');
-      var taskMid = getMid(task);
-      var rightOfTask = task.x + task.width + 10;
-
-      // when
-      var element = elementRegistry.get('Participant_3');
-      var gfx = elementRegistry.getGraphics(element);
-      var hover = { element, gfx };
-
-      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
-
-      // then
-      expect(textAnnotation.x).to.equal(textAnnotationX + 100);
-    }));
-
-
-    it('should only move text annotations in space tool range', inject(function(dragging, elementRegistry, spaceTool) {
-
-      // given
-      var textAnnotationToMove = elementRegistry.get('TextAnnotation_1');
-      var textAnnotationToMove_X = textAnnotationToMove.x;
-
-      var textAnnotationToStay = elementRegistry.get('TextAnnotation_3');
-      var textAnnotationToStay_X = textAnnotationToStay.x;
-
-      var task = elementRegistry.get('Activity_1');
-      var taskMid = getMid(task);
-      var rightOfTask = task.x + task.width + 10;
-
-      // when
-      var element = elementRegistry.get('Participant_3');
-      var gfx = elementRegistry.getGraphics(element);
-      var hover = { element, gfx };
-
-      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
-
-      // then
-      expect(textAnnotationToMove.x).to.equal(textAnnotationToMove_X + 100);
-      expect(textAnnotationToStay.x).to.equal(textAnnotationToStay_X);
-    }));
-
-
-    it('should only move text annotations in space tool range (inverted)', inject(function(dragging, elementRegistry, spaceTool) {
-
-      // given
-      var textAnnotationToMove = elementRegistry.get('TextAnnotation_3');
-      var textAnnotationToMove_X = textAnnotationToMove.x;
-
-      var textAnnotationToStay = elementRegistry.get('TextAnnotation_1');
-      var textAnnotationToStay_X = textAnnotationToStay.x;
-
-      var task = elementRegistry.get('Activity_1');
-      var taskMid = getMid(task);
-      var rightOfTask = task.x + task.width + 10;
-
-      // when
-      var element = elementRegistry.get('Participant_3');
-      var gfx = elementRegistry.getGraphics(element);
-      var hover = { element, gfx };
-
-      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: -100 }, true, hover);
-
-      // then
-      expect(textAnnotationToMove.x).to.equal(textAnnotationToMove_X - 100);
-      expect(textAnnotationToStay.x).to.equal(textAnnotationToStay_X);
-    }));
-
-
-    it('should not move text annotations outside of participant', inject(function(dragging, elementRegistry, spaceTool) {
-
-      // given
-      var textAnnotation = elementRegistry.get('TextAnnotation_2');
-      var textAnnotationX = textAnnotation.x;
-
-      var task = elementRegistry.get('Activity_1');
-      var taskMid = getMid(task);
-      var rightOfTask = task.x + task.width + 10;
-
-      // when
-      var element = elementRegistry.get('Participant_3');
-      var gfx = elementRegistry.getGraphics(element);
-      var hover = { element, gfx };
-
-      makeSpace({ x: rightOfTask, y: taskMid.y }, { dx: 100 }, false, hover);
-
-      // then
-      expect(textAnnotation.x).to.equal(textAnnotationX);
-    }));
-
   });
 
 });
@@ -654,7 +558,7 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
 // helpers //////////
 
-function makeSpace(start, delta, invert, hover) {
+function makeSpace(start, delta, invert) {
   var modifier = invert ? invertModifier : {};
 
   var end = {
@@ -664,8 +568,6 @@ function makeSpace(start, delta, invert, hover) {
 
   return getBpmnJS().invoke(function(spaceTool, dragging) {
     spaceTool.activateMakeSpace(canvasEvent(start));
-
-    hover && dragging.hover(hover);
 
     dragging.move(canvasEvent(end, modifier));
 

--- a/test/spec/features/space-tool/BpmnSpaceToolSpec.js
+++ b/test/spec/features/space-tool/BpmnSpaceToolSpec.js
@@ -14,7 +14,7 @@ import { createCanvasEvent as canvasEvent } from '../../../util/MockEvents';
 
 import { getMid } from 'diagram-js/lib/layout/LayoutUtil';
 
-import { pick } from 'min-dash';
+import { isString, pick } from 'min-dash';
 
 import { isMac } from 'diagram-js/lib/util/Platform';
 
@@ -53,10 +53,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
     describe('add space', function() {
 
-      it('should add space top', inject(function(elementRegistry) {
+      it('should add space top', inject(function() {
 
         // given
-        var subProcess1 = elementRegistry.get('SubProcess_1');
+        var subProcess1 = $element('SubProcess_1');
 
         var subProcess1Bounds = getBounds(subProcess1);
 
@@ -73,16 +73,16 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should add space right', inject(function(elementRegistry) {
+      it('should add space right', inject(function() {
 
         // given
-        var endEvent1 = elementRegistry.get('EndEvent_1'),
-            endEvent2 = elementRegistry.get('EndEvent_2'),
+        var endEvent1 = $element('EndEvent_1'),
+            endEvent2 = $element('EndEvent_2'),
             endEvent1Label = endEvent1.label,
             endEvent2Label = endEvent2.label,
-            sequenceFlow2 = elementRegistry.get('SequenceFlow_2'),
-            sequenceFlow4 = elementRegistry.get('SequenceFlow_4'),
-            subProcess1 = elementRegistry.get('SubProcess_1');
+            sequenceFlow2 = $element('SequenceFlow_2'),
+            sequenceFlow4 = $element('SequenceFlow_4'),
+            subProcess1 = $element('SubProcess_1');
 
         var endEvent1Mid = getMid(endEvent1),
             endEvent2Mid = getMid(endEvent2),
@@ -129,10 +129,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should add space bottom', inject(function(elementRegistry) {
+      it('should add space bottom', inject(function() {
 
         // given
-        var subProcess1 = elementRegistry.get('SubProcess_1');
+        var subProcess1 = $element('SubProcess_1');
 
         var subProcess1Bounds = getBounds(subProcess1);
 
@@ -149,16 +149,16 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should add space left', inject(function(elementRegistry) {
+      it('should add space left', inject(function() {
 
         // given
-        var startEvent1 = elementRegistry.get('StartEvent_1'),
-            startEvent2 = elementRegistry.get('StartEvent_2'),
+        var startEvent1 = $element('StartEvent_1'),
+            startEvent2 = $element('StartEvent_2'),
             startEvent1Label = startEvent1.label,
             startEvent2Label = startEvent2.label,
-            sequenceFlow1 = elementRegistry.get('SequenceFlow_1'),
-            sequenceFlow3 = elementRegistry.get('SequenceFlow_3'),
-            subProcess1 = elementRegistry.get('SubProcess_1');
+            sequenceFlow1 = $element('SequenceFlow_1'),
+            sequenceFlow3 = $element('SequenceFlow_3'),
+            subProcess1 = $element('SubProcess_1');
 
         var startEvent1Mid = getMid(startEvent1),
             startEvent2Mid = getMid(startEvent2),
@@ -209,10 +209,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
     describe('remove', function() {
 
-      it('should remove space top', inject(function(elementRegistry) {
+      it('should remove space top', inject(function() {
 
         // given
-        var subProcess1 = elementRegistry.get('SubProcess_1');
+        var subProcess1 = $element('SubProcess_1');
 
         var subProcess1Bounds = getBounds(subProcess1);
 
@@ -229,16 +229,16 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should remove space right', inject(function(elementRegistry) {
+      it('should remove space right', inject(function() {
 
         // given
-        var endEvent1 = elementRegistry.get('EndEvent_1'),
-            endEvent2 = elementRegistry.get('EndEvent_2'),
+        var endEvent1 = $element('EndEvent_1'),
+            endEvent2 = $element('EndEvent_2'),
             endEvent1Label = endEvent1.label,
             endEvent2Label = endEvent2.label,
-            sequenceFlow2 = elementRegistry.get('SequenceFlow_2'),
-            sequenceFlow4 = elementRegistry.get('SequenceFlow_4'),
-            subProcess1 = elementRegistry.get('SubProcess_1');
+            sequenceFlow2 = $element('SequenceFlow_2'),
+            sequenceFlow4 = $element('SequenceFlow_4'),
+            subProcess1 = $element('SubProcess_1');
 
         var endEvent1Mid = getMid(endEvent1),
             endEvent2Mid = getMid(endEvent2),
@@ -282,10 +282,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should remove space bottom', inject(function(elementRegistry) {
+      it('should remove space bottom', inject(function() {
 
         // given
-        var subProcess1 = elementRegistry.get('SubProcess_1');
+        var subProcess1 = $element('SubProcess_1');
 
         var subProcess1Bounds = getBounds(subProcess1);
 
@@ -302,16 +302,16 @@ describe('features/space-tool - BpmnSpaceTool', function() {
       }));
 
 
-      it('should remove space left', inject(function(elementRegistry) {
+      it('should remove space left', inject(function() {
 
         // given
-        var startEvent1 = elementRegistry.get('StartEvent_1'),
-            startEvent2 = elementRegistry.get('StartEvent_2'),
+        var startEvent1 = $element('StartEvent_1'),
+            startEvent2 = $element('StartEvent_2'),
             startEvent1Label = startEvent1.label,
             startEvent2Label = startEvent2.label,
-            sequenceFlow1 = elementRegistry.get('SequenceFlow_1'),
-            sequenceFlow3 = elementRegistry.get('SequenceFlow_3'),
-            subProcess1 = elementRegistry.get('SubProcess_1');
+            sequenceFlow1 = $element('SequenceFlow_1'),
+            sequenceFlow3 = $element('SequenceFlow_3'),
+            subProcess1 = $element('SubProcess_1');
 
         var startEvent1Mid = getMid(startEvent1),
             startEvent2Mid = getMid(startEvent2),
@@ -375,7 +375,7 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     it('should not resize text annotations', inject(function(dragging, elementRegistry, spaceTool) {
 
       // given
-      var textAnnotation = elementRegistry.get('TextAnnotation_1'),
+      var textAnnotation = $element('TextAnnotation_1'),
           textAnnotationMid = getMid(textAnnotation),
           textAnnotationWidth = textAnnotation.width;
 
@@ -406,10 +406,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should move boundary event when moving subprocess', inject(function(elementRegistry) {
+    it('should move boundary event when moving subprocess', inject(function() {
 
       // given
-      var boundaryEvent = elementRegistry.get('BoundaryEvent_2');
+      var boundaryEvent = $element('BoundaryEvent_2');
 
       var boundaryEventMid = getMid(boundaryEvent);
 
@@ -424,10 +424,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should move boundary event when resizing subprocess', inject(function(elementRegistry) {
+    it('should move boundary event when resizing subprocess', inject(function() {
 
       // given
-      var boundaryEvent = elementRegistry.get('BoundaryEvent_2');
+      var boundaryEvent = $element('BoundaryEvent_2');
 
       var boundaryEventMid = getMid(boundaryEvent);
 
@@ -442,10 +442,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should not move boundary event if subprocess not moving or resizing', inject(function(elementRegistry) {
+    it('should not move boundary event if subprocess not moving or resizing', inject(function() {
 
       // given
-      var boundaryEvent = elementRegistry.get('BoundaryEvent_2');
+      var boundaryEvent = $element('BoundaryEvent_2');
 
       var boundaryEventMid = getMid(boundaryEvent);
 
@@ -472,10 +472,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should resize an expanded pool horizontally', inject(function(elementRegistry) {
+    it('should resize an expanded pool horizontally', inject(function() {
 
       // given
-      var participant1 = elementRegistry.get('Participant_1');
+      var participant1 = $element('Participant_1');
 
       var participant1Bounds = getBounds(participant1);
 
@@ -492,10 +492,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should resize an expanded pool vertically', inject(function(elementRegistry) {
+    it('should resize an expanded pool vertically', inject(function() {
 
       // given
-      var participant1 = elementRegistry.get('Participant_1');
+      var participant1 = $element('Participant_1');
 
       var participant1Bounds = getBounds(participant1);
 
@@ -512,10 +512,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should resize an empty pool horizontally', inject(function(elementRegistry) {
+    it('should resize an empty pool horizontally', inject(function() {
 
       // given
-      var participant2 = elementRegistry.get('Participant_2');
+      var participant2 = $element('Participant_2');
 
       var participant2Bounds = getBounds(participant2);
 
@@ -532,10 +532,10 @@ describe('features/space-tool - BpmnSpaceTool', function() {
     }));
 
 
-    it('should not resize an empty pool vertically', inject(function(elementRegistry) {
+    it('should not resize an empty pool vertically', inject(function() {
 
       // given
-      var participant2 = elementRegistry.get('Participant_2');
+      var participant2 = $element('Participant_2');
 
       var participant2Bounds = getBounds(participant2);
 
@@ -558,7 +558,7 @@ describe('features/space-tool - BpmnSpaceTool', function() {
 
 // helpers //////////
 
-function makeSpace(start, delta, invert) {
+function makeSpace(start, delta, invert, target) {
   var modifier = invert ? invertModifier : {};
 
   var end = {
@@ -566,13 +566,64 @@ function makeSpace(start, delta, invert) {
     y: start.y + (delta.dy || 0)
   };
 
-  return getBpmnJS().invoke(function(spaceTool, dragging) {
+  return getBpmnJS().invoke(function(spaceTool, dragging, canvas) {
     spaceTool.activateMakeSpace(canvasEvent(start));
+
+    if (target) {
+      target = $element(target);
+
+      dragging.hover({
+        element: target,
+        gfx: canvas.getGraphics(target)
+      });
+    }
 
     dragging.move(canvasEvent(end, modifier));
 
     dragging.end();
   });
+}
+
+function $element(id) {
+
+  if (!isString(id)) {
+    return id;
+  }
+
+  return getBpmnJS().invoke(function(elementRegistry) {
+
+    const element = elementRegistry.get(id);
+
+    expect(element, `element <#${id}>`).to.exist;
+
+    return element;
+  });
+}
+
+// eslint-disable-next-line "no-unused-vars"
+function leftOf(element) {
+
+  element = $element(element);
+
+  const mid = getMid(element);
+
+  return {
+    x: element.x - 10,
+    y: mid.y
+  };
+}
+
+// eslint-disable-next-line "no-unused-vars"
+function rightOf(element) {
+
+  element = $element(element);
+
+  const mid = getMid(element);
+
+  return {
+    x: element.x + element.width + 10,
+    y: mid.y
+  };
 }
 
 function getBounds(shape) {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4172

### Proposed Changes

When using the space tool locally inside of a participant, it now moves text annotations that are enclosed by it.

Unlike labels, text annotations that are outside of the participant won't move even if their target is in the participant.

https://github.com/user-attachments/assets/03daff09-61d7-4f47-a848-82236ffd7e31


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
