### PR TITLE
feat: render event subprocess icons

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -462,8 +462,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_MESSAGE', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: attrs.width || element.width,
+        containerHeight: attrs.height || element.height,
         position: {
           mx: 0.235,
           my: 0.315
@@ -487,17 +487,23 @@ export default function BpmnRenderer(
       return messagePath;
     },
     'bpmn:TimerEventDefinition': function(parentGfx, element, attrs = {}) {
-      var circle = drawCircle(parentGfx, element.width, element.height, 0.2 * element.height, {
+      var baseWidth = attrs.width || element.width;
+      var baseHeight = attrs.height || element.height;
+
+      // use a lighter stroke for event suprocess icons
+      var strokeWidth = attrs.width ? 1 : 2;
+
+      var circle = drawCircle(parentGfx, baseWidth, baseHeight, 0.2 * baseHeight, {
         fill: getFillColor(element, defaultFillColor, attrs.fill),
         stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
-        strokeWidth: 2
+        strokeWidth: strokeWidth
       });
 
       var pathData = pathMap.getScaledPath('EVENT_TIMER_WH', {
         xScaleFactor: 0.75,
         yScaleFactor: 0.75,
-        containerWidth: element.width,
-        containerHeight: element.height,
+        containerWidth: baseWidth,
+        containerHeight: baseHeight,
         position: {
           mx: 0.5,
           my: 0.5
@@ -506,23 +512,23 @@ export default function BpmnRenderer(
 
       drawPath(parentGfx, pathData, {
         stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
-        strokeWidth: 2
+        strokeWidth: strokeWidth
       });
 
       for (var i = 0; i < 12; i++) {
         var linePathData = pathMap.getScaledPath('EVENT_TIMER_LINE', {
           xScaleFactor: 0.75,
           yScaleFactor: 0.75,
-          containerWidth: element.width,
-          containerHeight: element.height,
+          containerWidth: baseWidth,
+          containerHeight: baseHeight,
           position: {
             mx: 0.5,
             my: 0.5
           }
         });
 
-        var width = element.width / 2,
-            height = element.height / 2;
+        var width = baseWidth / 2,
+            height = baseHeight / 2;
 
         drawPath(parentGfx, linePathData, {
           strokeWidth: 1,
@@ -537,8 +543,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_ESCALATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.5,
           my: 0.2
@@ -559,8 +565,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_CONDITIONAL', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.5,
           my: 0.222
@@ -599,8 +605,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_ERROR', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.2,
           my: 0.722
@@ -645,8 +651,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_COMPENSATION', {
         xScaleFactor: 1,
         yScaleFactor: 1,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.22,
           my: 0.5
@@ -667,8 +673,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_SIGNAL', {
         xScaleFactor: 0.9,
         yScaleFactor: 0.9,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.5,
           my: 0.2
@@ -689,10 +695,10 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_MULTIPLE', {
         xScaleFactor: 1.1,
         yScaleFactor: 1.1,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
-          mx: 0.222,
+          mx: 0.211,
           my: 0.36
         }
       });
@@ -703,6 +709,7 @@ export default function BpmnRenderer(
 
       return drawPath(parentGfx, pathData, {
         fill,
+        stroke: getStrokeColor(event, defaultStrokeColor, attrs.stroke),
         strokeWidth: 1
       });
     },
@@ -710,8 +717,8 @@ export default function BpmnRenderer(
       var pathData = pathMap.getScaledPath('EVENT_PARALLEL_MULTIPLE', {
         xScaleFactor: 1.2,
         yScaleFactor: 1.2,
-        containerWidth: event.width,
-        containerHeight: event.height,
+        containerWidth: attrs.width || event.width,
+        containerHeight: attrs.height || event.height,
         position: {
           mx: 0.458,
           my: 0.194
@@ -735,57 +742,59 @@ export default function BpmnRenderer(
     }
   };
 
-  function renderEventIcon(element, parentGfx, attrs = {}) {
+  function renderEventIcon(element, parentGfx, attrs = {}, proxyElement) {
     var semantic = getSemantic(element),
         isThrowing = isThrowEvent(semantic);
 
+    var nodeElement = proxyElement || element;
+
     if (semantic.get('eventDefinitions') && semantic.get('eventDefinitions').length > 1) {
       if (semantic.get('parallelMultiple')) {
-        return eventIconRenderers[ 'bpmn:ParallelMultipleEventDefinition' ](parentGfx, element, attrs, isThrowing);
+        return eventIconRenderers[ 'bpmn:ParallelMultipleEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
       }
       else {
-        return eventIconRenderers[ 'bpmn:MultipleEventDefinition' ](parentGfx, element, attrs, isThrowing);
+        return eventIconRenderers[ 'bpmn:MultipleEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
       }
     }
 
     if (isTypedEvent(semantic, 'bpmn:MessageEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:MessageEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:MessageEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:TimerEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:TimerEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:TimerEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:ConditionalEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:ConditionalEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:ConditionalEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:SignalEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:SignalEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:SignalEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:EscalationEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:EscalationEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:EscalationEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:LinkEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:LinkEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:LinkEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:ErrorEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:ErrorEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:ErrorEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:CancelEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:CancelEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:CancelEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:CompensateEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:CompensateEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:CompensateEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     if (isTypedEvent(semantic, 'bpmn:TerminateEventDefinition')) {
-      return eventIconRenderers[ 'bpmn:TerminateEventDefinition' ](parentGfx, element, attrs, isThrowing);
+      return eventIconRenderers[ 'bpmn:TerminateEventDefinition' ](parentGfx, nodeElement, attrs, isThrowing);
     }
 
     return null;
@@ -1207,14 +1216,23 @@ export default function BpmnRenderer(
   function renderSubProcess(parentGfx, element, attrs = {}) {
     var activity = renderActivity(parentGfx, element, attrs);
 
+    var expanded = isExpanded(element);
+
     if (isEventSubProcess(element)) {
       svgAttr(activity, {
         strokeDasharray: '0, 5.5',
         strokeWidth: 2.5
       });
-    }
 
-    var expanded = isExpanded(element);
+      if (!expanded) {
+        var flowElements = getSemantic(element).flowElements || [];
+        var startEvents = flowElements.filter(e => is(e, 'bpmn:StartEvent'));
+
+        if (startEvents.length === 1) {
+          renderEventSubProcessIcon(startEvents[0], parentGfx, attrs, element);
+        }
+      }
+    }
 
     renderEmbeddedLabel(parentGfx, element, expanded ? 'center-top' : 'center-middle', attrs);
 
@@ -1225,6 +1243,39 @@ export default function BpmnRenderer(
     }
 
     return activity;
+  }
+
+  function renderEventSubProcessIcon(startEvent, parentGfx, attrs, proxyElement) {
+    var iconSize = 22;
+
+    // match the colors of the enclosing subprocess
+    var proxyAttrs = {
+      fill: getFillColor(proxyElement, defaultFillColor, attrs.fill),
+      stroke: getStrokeColor(proxyElement, defaultStrokeColor, attrs.stroke),
+      width: iconSize,
+      height: iconSize
+    };
+
+    var interrupting = getSemantic(startEvent).isInterrupting;
+    var strokeDasharray = interrupting ? 0 : 3;
+
+    // better visibility for non-interrupting events
+    var strokeWidth = interrupting ? 1 : 1.2;
+
+    // make the icon look larger by drawing a smaller circle
+    var circleSize = 20;
+    var shift = (iconSize - circleSize) / 2;
+    var transform = 'translate(' + shift + ',' + shift + ')';
+
+    drawCircle(parentGfx, circleSize, circleSize, {
+      fill: proxyAttrs.fill,
+      stroke: proxyAttrs.stroke,
+      strokeWidth,
+      strokeDasharray,
+      transform
+    });
+
+    renderEventIcon(startEvent, parentGfx, proxyAttrs, proxyElement);
   }
 
   function renderTask(parentGfx, element, attrs = {}) {

--- a/test/fixtures/bpmn/draw/event-subprocess-icons.bpmn
+++ b/test/fixtures/bpmn/draw/event-subprocess-icons.bpmn
@@ -1,0 +1,956 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_078jjxu" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_0xjmw8h" isExecutable="true">
+    <bpmn:subProcess id="EmptyEventSubprocess_1" name="Empty" triggeredByEvent="true" />
+    <bpmn:subProcess id="MessageEventSubprocess_1" name="Message" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_01">
+        <bpmn:incoming>Flow_01</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_01" sourceRef="StartEvent_01" targetRef="EndEvent_01" />
+      <bpmn:startEvent id="StartEvent_01">
+        <bpmn:outgoing>Flow_01</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0ac908l" messageRef="Message_29lp64i" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubprocess_1" name="Timer" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_02">
+        <bpmn:incoming>Flow_02</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_02" sourceRef="StartEvent_02" targetRef="EndEvent_02" />
+      <bpmn:startEvent id="StartEvent_02">
+        <bpmn:outgoing>Flow_02</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_01rfbnh">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT30S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ConditionalEventSubprocess_1" name="Conditional" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_03">
+        <bpmn:incoming>Flow_03</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_03" sourceRef="StartEvent_03" targetRef="EndEvent_03" />
+      <bpmn:startEvent id="StartEvent_03">
+        <bpmn:outgoing>Flow_03</bpmn:outgoing>
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1nu82qy">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SignalEventSubprocess_1" name="Signal" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_04">
+        <bpmn:incoming>Flow_04</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_04" sourceRef="StartEvent_04" targetRef="EndEvent_04" />
+      <bpmn:startEvent id="StartEvent_04">
+        <bpmn:outgoing>Flow_04</bpmn:outgoing>
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1lwnii4" signalRef="Signal_0hep2se" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EscalationEventSubprocess_1" name="Escalation" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_05">
+        <bpmn:incoming>Flow_05</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_05" sourceRef="StartEvent_05" targetRef="EndEvent_05" />
+      <bpmn:startEvent id="StartEvent_05">
+        <bpmn:outgoing>Flow_05</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1fy1cw9" escalationRef="Escalation_3hkjg83" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ErrorEventSubprocess_1" name="Error" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_06">
+        <bpmn:incoming>Flow_06</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_06" sourceRef="StartEvent_06" targetRef="EndEvent_06" />
+      <bpmn:startEvent id="StartEvent_06">
+        <bpmn:outgoing>Flow_06</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1pwap7i" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="CompensateEventSubprocess_1" name="Compensate" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_07">
+        <bpmn:incoming>Flow_07</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_07" sourceRef="StartEvent_07" targetRef="EndEvent_07" />
+      <bpmn:startEvent id="StartEvent_07">
+        <bpmn:outgoing>Flow_07</bpmn:outgoing>
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1tldbzy" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MultipleEventSubprocess_1" name="Multiple" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_08">
+        <bpmn:incoming>Flow_08</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_08" sourceRef="StartEvent_08" targetRef="EndEvent_08" />
+      <bpmn:startEvent id="StartEvent_08">
+        <bpmn:outgoing>Flow_08</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0tz0p6p" messageRef="Message_362sps0" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_14rdhs1-A" messageRef="Message_2l12mbt" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ParallelEventSubprocess_1" name="Parallel" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_09">
+        <bpmn:incoming>Flow_09</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_09" sourceRef="StartEvent_09" targetRef="EndEvent_09" />
+      <bpmn:startEvent id="StartEvent_09" parallelMultiple="true">
+        <bpmn:outgoing>Flow_09</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_14rdhs1" messageRef="Message_2l12mbt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0tz0p6p-A" messageRef="Message_362sps0" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EmptyEventSubprocess_2" name="Empty" triggeredByEvent="true" />
+    <bpmn:subProcess id="MessageEventSubprocess_2" name="Message" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_11">
+        <bpmn:incoming>Flow_11</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_11">
+        <bpmn:outgoing>Flow_11</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0m14bsv" messageRef="Message_29lp64i" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_11" sourceRef="StartEvent_11" targetRef="EndEvent_11" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubprocess_2" name="Timer" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_12">
+        <bpmn:incoming>Flow_12</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_12">
+        <bpmn:outgoing>Flow_12</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1ifp4eu" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_12" sourceRef="StartEvent_12" targetRef="EndEvent_12" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ConditionalEventSubprocess_2" name="Conditional" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_13">
+        <bpmn:incoming>Flow_13</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_13">
+        <bpmn:outgoing>Flow_13</bpmn:outgoing>
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_02m3fte">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_13" sourceRef="StartEvent_13" targetRef="EndEvent_13" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SignalEventSubprocess_2" name="Signal" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_14">
+        <bpmn:incoming>Flow_14</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_14">
+        <bpmn:outgoing>Flow_14</bpmn:outgoing>
+        <bpmn:signalEventDefinition id="SignalEventDefinition_0vos3ec" signalRef="Signal_0hep2se" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_14" sourceRef="StartEvent_14" targetRef="EndEvent_14" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EscalationEventSubprocess_2" name="Escalation" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_15">
+        <bpmn:incoming>Flow_15</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_15">
+        <bpmn:outgoing>Flow_15</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0boh29i" escalationRef="Escalation_3hkjg83" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_15" sourceRef="StartEvent_15" targetRef="EndEvent_15" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ErrorEventSubprocess_2" name="Error" triggeredByEvent="true">
+      <bpmn:endEvent id="StartEvent_16">
+        <bpmn:incoming>Flow_16</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_03pa4sf">
+        <bpmn:outgoing>Flow_16</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0ol28hl" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_16" sourceRef="StartEvent_03pa4sf" targetRef="StartEvent_16" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="CompensateEventSubprocess_2" name="Compensate" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_17">
+        <bpmn:incoming>Flow_17</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_17">
+        <bpmn:outgoing>Flow_17</bpmn:outgoing>
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_0dmp2i6" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_17" sourceRef="StartEvent_17" targetRef="EndEvent_17" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MultipleEventSubprocess_2" name="Multiple" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_18">
+        <bpmn:incoming>Flow_18</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_0bj9g61">
+        <bpmn:outgoing>Flow_18</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_007w4n6" messageRef="Message_362sps0" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_12mvrbw" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_18" sourceRef="StartEvent_0bj9g61" targetRef="EndEvent_18" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ParallelEventSubprocess_2" name="Parallel" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_19">
+        <bpmn:incoming>Flow_19</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_19" parallelMultiple="true">
+        <bpmn:outgoing>Flow_19</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1lf6aie" messageRef="Message_2l12mbt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1sry3re" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_19" sourceRef="StartEvent_19" targetRef="EndEvent_19" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MessageEventSubprocess_3" name="Message" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_31">
+        <bpmn:incoming>Flow_31</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_31" isInterrupting="false">
+        <bpmn:outgoing>Flow_31</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1u1314g" messageRef="Message_29lp64i" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_31" sourceRef="StartEvent_31" targetRef="EndEvent_31" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubprocess_3" name="Timer" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_32">
+        <bpmn:incoming>Flow_32</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_32" isInterrupting="false">
+        <bpmn:outgoing>Flow_32</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1jlw9l5" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_32" sourceRef="StartEvent_32" targetRef="EndEvent_32" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ConditionalEventSubprocess_3" name="Conditional" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_33">
+        <bpmn:incoming>Flow_33</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_33" isInterrupting="false">
+        <bpmn:outgoing>Flow_33</bpmn:outgoing>
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1fopagy">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_33" sourceRef="StartEvent_33" targetRef="EndEvent_33" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SignalEventSubprocess_3" name="Signal" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_34">
+        <bpmn:incoming>Flow_34</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_34" isInterrupting="false">
+        <bpmn:outgoing>Flow_34</bpmn:outgoing>
+        <bpmn:signalEventDefinition id="SignalEventDefinition_11qvvj4" signalRef="Signal_0hep2se" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_34" sourceRef="StartEvent_34" targetRef="EndEvent_34" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EscalationEventSubprocess_3" name="Escalation" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_35">
+        <bpmn:incoming>Flow_35</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_35" isInterrupting="false">
+        <bpmn:outgoing>Flow_35</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_09phx5i" escalationRef="Escalation_3hkjg83" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_35" sourceRef="StartEvent_35" targetRef="EndEvent_35" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MultipleEventSubprocess_3" name="Multiple" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_38">
+        <bpmn:incoming>Flow_38</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_38" isInterrupting="false">
+        <bpmn:outgoing>Flow_38</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1797tr7" messageRef="Message_362sps0" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_18ze9w6" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_38" sourceRef="StartEvent_38" targetRef="EndEvent_38" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ParallelEventSubprocess_3" name="Parallel" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_39">
+        <bpmn:incoming>Flow_39</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_39" parallelMultiple="true" isInterrupting="false">
+        <bpmn:outgoing>Flow_39</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_109r69y" messageRef="Message_2l12mbt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_03jeso5" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_39" sourceRef="StartEvent_39" targetRef="EndEvent_39" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MessageEventSubprocess_4" name="Message" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_41">
+        <bpmn:incoming>Flow_41</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_41" isInterrupting="false">
+        <bpmn:outgoing>Flow_41</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1c78qdn" messageRef="Message_29lp64i" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_41" sourceRef="StartEvent_41" targetRef="EndEvent_41" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubprocess_4" name="Timer" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_42">
+        <bpmn:incoming>Flow_42</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_42" isInterrupting="false">
+        <bpmn:outgoing>Flow_42</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_0hrbp0m" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_42" sourceRef="StartEvent_42" targetRef="EndEvent_42" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ConditionalEventSubprocess_4" name="Conditional" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_43">
+        <bpmn:incoming>Flow_43</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_0putbmu" isInterrupting="false">
+        <bpmn:outgoing>Flow_43</bpmn:outgoing>
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1mt7ov6">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_43" sourceRef="StartEvent_0putbmu" targetRef="EndEvent_43" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SignalEventSubprocess_4" name="Signal" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_44">
+        <bpmn:incoming>Flow_44</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_44" isInterrupting="false">
+        <bpmn:outgoing>Flow_44</bpmn:outgoing>
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1vh2wet" signalRef="Signal_0hep2se" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_44" sourceRef="StartEvent_44" targetRef="EndEvent_44" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="EscalationEventSubprocess_4" name="Escalation" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_45">
+        <bpmn:incoming>Flow_45</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_45" isInterrupting="false">
+        <bpmn:outgoing>Flow_45</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0t8a587" escalationRef="Escalation_3hkjg83" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_45" sourceRef="StartEvent_45" targetRef="EndEvent_45" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MultipleEventSubprocess_4" name="Multiple" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_48">
+        <bpmn:incoming>Flow_48</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_48" isInterrupting="false">
+        <bpmn:outgoing>Flow_48</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0biiba6" messageRef="Message_362sps0" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0tb2lhz" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_48" sourceRef="StartEvent_48" targetRef="EndEvent_48" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="ParallelEventSubprocess_4" name="Parallel" triggeredByEvent="true">
+      <bpmn:endEvent id="EndEvent_49">
+        <bpmn:incoming>Flow_49</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_49" parallelMultiple="true" isInterrupting="false">
+        <bpmn:outgoing>Flow_49</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1q2h7pd" messageRef="Message_2l12mbt" />
+        <bpmn:messageEventDefinition id="MessageEventDefinition_0fyepe2" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_49" sourceRef="StartEvent_49" targetRef="EndEvent_49" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_29lp64i" name="Message_29lp64i">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=123" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:signal id="Signal_0hep2se" name="Signal_0hep2se" />
+  <bpmn:escalation id="Escalation_3hkjg83" name="Escalation_3hkjg83" escalationCode="456" />
+  <bpmn:message id="Message_362sps0" name="Message_362sps0">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=231" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_2l12mbt" name="Message_2l12mbt">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=312" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0xjmw8h">
+      <bpmndi:BPMNShape id="Activity_0hen5q2_di" bpmnElement="EmptyEventSubprocess_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0jcmhjh" bpmnElement="MessageEventSubprocess_1">
+        <dc:Bounds x="280" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1gtyp1f" bpmnElement="TimerEventSubprocess_1">
+        <dc:Bounds x="400" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hcy7lc" bpmnElement="ConditionalEventSubprocess_1">
+        <dc:Bounds x="520" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_12odj22" bpmnElement="SignalEventSubprocess_1">
+        <dc:Bounds x="640" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1elhik7" bpmnElement="EscalationEventSubprocess_1">
+        <dc:Bounds x="760" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qs14wl" bpmnElement="ErrorEventSubprocess_1">
+        <dc:Bounds x="880" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nicozt" bpmnElement="CompensateEventSubprocess_1">
+        <dc:Bounds x="1000" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1jivg2x" bpmnElement="MultipleEventSubprocess_1">
+        <dc:Bounds x="1120" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15ux34v" bpmnElement="ParallelEventSubprocess_1">
+        <dc:Bounds x="1240" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_043s9em" bpmnElement="EmptyEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="160" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_10ag685" bpmnElement="MessageEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="280" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1wdf1hc" bpmnElement="TimerEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="400" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0zz83t5" bpmnElement="ConditionalEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="520" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_07cvdpx" bpmnElement="SignalEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="640" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_17taftv" bpmnElement="EscalationEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="760" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_042thfb" bpmnElement="ErrorEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="880" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_12necze" bpmnElement="CompensateEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="1000" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15piti0" bpmnElement="MultipleEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="1120" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0bugsis" bpmnElement="ParallelEventSubprocess_2" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="1240" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_05f9sgk" bpmnElement="MessageEventSubprocess_3">
+        <dc:Bounds x="280" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0uyb03m" bpmnElement="TimerEventSubprocess_3">
+        <dc:Bounds x="400" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1l0dzcu" bpmnElement="ConditionalEventSubprocess_3">
+        <dc:Bounds x="520" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0e9ibml" bpmnElement="SignalEventSubprocess_3">
+        <dc:Bounds x="640" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0g0g0hr" bpmnElement="EscalationEventSubprocess_3">
+        <dc:Bounds x="760" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1l25lo3" bpmnElement="MultipleEventSubprocess_3">
+        <dc:Bounds x="1120" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1bdof66" bpmnElement="ParallelEventSubprocess_3">
+        <dc:Bounds x="1240" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0woimk9" bpmnElement="MessageEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="280" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1yqkxl8" bpmnElement="TimerEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="400" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hqnghm" bpmnElement="ConditionalEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="520" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0fqggs2" bpmnElement="SignalEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="640" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0wnl7zz" bpmnElement="EscalationEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="760" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_155cxe9" bpmnElement="MultipleEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="1120" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_033u6mg" bpmnElement="ParallelEventSubprocess_4" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
+        <dc:Bounds x="1240" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0bv318f">
+    <bpmndi:BPMNPlane id="BPMNPlane_0ydhvf4" bpmnElement="EmptyEventSubprocess_1" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1dzrl1g">
+    <bpmndi:BPMNPlane id="BPMNPlane_0zgxuun" bpmnElement="MessageEventSubprocess_1">
+      <bpmndi:BPMNShape id="StartEvent_0qo4btx_di" bpmnElement="EndEvent_01">
+        <dc:Bounds x="352" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0c7hd4s_di" bpmnElement="StartEvent_01">
+        <dc:Bounds x="262" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nb49xa_di" bpmnElement="Flow_01">
+        <di:waypoint x="298" y="250" />
+        <di:waypoint x="352" y="250" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_08x40vs">
+    <bpmndi:BPMNPlane id="BPMNPlane_03roui6" bpmnElement="TimerEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_09wz407" bpmnElement="EndEvent_02">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_18wobcn_di" bpmnElement="StartEvent_02">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_12vlggv" bpmnElement="Flow_02">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_17hwo2s">
+    <bpmndi:BPMNPlane id="BPMNPlane_0jl8zs6" bpmnElement="ConditionalEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_03quoqd" bpmnElement="EndEvent_03">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1ehjo3c_di" bpmnElement="StartEvent_03">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_071k350" bpmnElement="Flow_03">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_00jvaiu">
+    <bpmndi:BPMNPlane id="BPMNPlane_0h8tmnu" bpmnElement="SignalEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_10c3wz2" bpmnElement="EndEvent_04">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0lxtult_di" bpmnElement="StartEvent_04">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1um7kf9" bpmnElement="Flow_04">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_17f5iar">
+    <bpmndi:BPMNPlane id="BPMNPlane_1dn7cek" bpmnElement="EscalationEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_1i7ll6n" bpmnElement="EndEvent_05">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0u0v8q7_di" bpmnElement="StartEvent_05">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1u53rec" bpmnElement="Flow_05">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0sg6wfr">
+    <bpmndi:BPMNPlane id="BPMNPlane_1fbbqlc" bpmnElement="ErrorEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_1o57n77" bpmnElement="EndEvent_06">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1oa9l9q_di" bpmnElement="StartEvent_06">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1y8vf2y" bpmnElement="Flow_06">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1v26qk3">
+    <bpmndi:BPMNPlane id="BPMNPlane_0mz0f65" bpmnElement="CompensateEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_0gsylcc" bpmnElement="EndEvent_07">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0xxd4wt_di" bpmnElement="StartEvent_07">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1fmrefo" bpmnElement="Flow_07">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1f5lho1">
+    <bpmndi:BPMNPlane id="BPMNPlane_0nvrvh8" bpmnElement="MultipleEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_0bew5cd" bpmnElement="EndEvent_08">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_13s2nm2_di" bpmnElement="StartEvent_08">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1s2p6hr" bpmnElement="Flow_08">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1kx4ffc">
+    <bpmndi:BPMNPlane id="BPMNPlane_0fuhpdv" bpmnElement="ParallelEventSubprocess_1">
+      <bpmndi:BPMNShape id="BPMNShape_0hibjm4" bpmnElement="EndEvent_09">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_03ogur4_di" bpmnElement="StartEvent_09">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1u7npnt" bpmnElement="Flow_09">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0emiza0">
+    <bpmndi:BPMNPlane id="BPMNPlane_07eigk5" bpmnElement="EmptyEventSubprocess_2" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1j580xh">
+    <bpmndi:BPMNPlane id="BPMNPlane_1hysows" bpmnElement="MessageEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_0evmy6c" bpmnElement="EndEvent_11">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ym6gg4" bpmnElement="StartEvent_11">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0302dv6" bpmnElement="Flow_11">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1sfvg3a">
+    <bpmndi:BPMNPlane id="BPMNPlane_0syn7f7" bpmnElement="TimerEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_0x8shuh" bpmnElement="EndEvent_12">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_137ezul" bpmnElement="StartEvent_12">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0crmyo4" bpmnElement="Flow_12">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0wlqq9r">
+    <bpmndi:BPMNPlane id="BPMNPlane_14mwifw" bpmnElement="ConditionalEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_13l2xpt" bpmnElement="EndEvent_13">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hlvw06" bpmnElement="StartEvent_13">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_07mj1ng" bpmnElement="Flow_13">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1unhbc0">
+    <bpmndi:BPMNPlane id="BPMNPlane_0sgndmv" bpmnElement="SignalEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_0vjq4vk" bpmnElement="EndEvent_14">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03n2gip" bpmnElement="StartEvent_14">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_064dqni" bpmnElement="Flow_14">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1rtdmnc">
+    <bpmndi:BPMNPlane id="BPMNPlane_0s5pphe" bpmnElement="EscalationEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_1bzaw6h" bpmnElement="EndEvent_15">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15yywug" bpmnElement="StartEvent_15">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0a7lusj" bpmnElement="Flow_15">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1oopd56">
+    <bpmndi:BPMNPlane id="BPMNPlane_1xtlgia" bpmnElement="ErrorEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_1t6mz0e" bpmnElement="StartEvent_16">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1vslx52" bpmnElement="StartEvent_03pa4sf">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_01txrvj" bpmnElement="Flow_16">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0g2b74j">
+    <bpmndi:BPMNPlane id="BPMNPlane_0l68ynb" bpmnElement="CompensateEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_1ms8s1z" bpmnElement="EndEvent_17">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_067d3kh" bpmnElement="StartEvent_17">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1j7vtin" bpmnElement="Flow_17">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1go1ktz">
+    <bpmndi:BPMNPlane id="BPMNPlane_17jo8ew" bpmnElement="MultipleEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_06vy6fl" bpmnElement="EndEvent_18">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0vitx52" bpmnElement="StartEvent_0bj9g61">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1a5av3l" bpmnElement="Flow_18">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0rgnlci">
+    <bpmndi:BPMNPlane id="BPMNPlane_14y9cyv" bpmnElement="ParallelEventSubprocess_2">
+      <bpmndi:BPMNShape id="BPMNShape_1bmwha3" bpmnElement="EndEvent_19">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ud8ief" bpmnElement="StartEvent_19">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1xacc1s" bpmnElement="Flow_19">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0zkbf4v">
+    <bpmndi:BPMNPlane id="BPMNPlane_1u6la4u" bpmnElement="MessageEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_00e3pa5" bpmnElement="EndEvent_31">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_112bhme" bpmnElement="StartEvent_31">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1v5mvj3" bpmnElement="Flow_31">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_14jrci5">
+    <bpmndi:BPMNPlane id="BPMNPlane_0swvp3k" bpmnElement="TimerEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_0axnqv6" bpmnElement="EndEvent_32">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0p0db0o" bpmnElement="StartEvent_32">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_013rr83" bpmnElement="Flow_32">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_10fx2ov">
+    <bpmndi:BPMNPlane id="BPMNPlane_0idag3f" bpmnElement="ConditionalEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_0oz29nv" bpmnElement="EndEvent_33">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0l5cm5g" bpmnElement="StartEvent_33">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1t69yn5" bpmnElement="Flow_33">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_179ab5j">
+    <bpmndi:BPMNPlane id="BPMNPlane_18tagmt" bpmnElement="SignalEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_1uenhuc" bpmnElement="EndEvent_34">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_039iy9j" bpmnElement="StartEvent_34">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0cm7lu5" bpmnElement="Flow_34">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0u5vy7a">
+    <bpmndi:BPMNPlane id="BPMNPlane_1xxrq64" bpmnElement="EscalationEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_03v6v4p" bpmnElement="EndEvent_35">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13tf07i" bpmnElement="StartEvent_35">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0e91mu1" bpmnElement="Flow_35">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1qgeb8j">
+    <bpmndi:BPMNPlane id="BPMNPlane_140c64h" bpmnElement="MultipleEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_1h7ea07" bpmnElement="EndEvent_38">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ea0a9a" bpmnElement="StartEvent_38">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1x8xvmq" bpmnElement="Flow_38">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_167cvn1">
+    <bpmndi:BPMNPlane id="BPMNPlane_0zo14pv" bpmnElement="ParallelEventSubprocess_3">
+      <bpmndi:BPMNShape id="BPMNShape_03pxbbp" bpmnElement="EndEvent_39">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_047y0wv" bpmnElement="StartEvent_39">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0qwzi1r" bpmnElement="Flow_39">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_106jzcb">
+    <bpmndi:BPMNPlane id="BPMNPlane_0syablr" bpmnElement="MessageEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_1u7hzph" bpmnElement="EndEvent_41">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0bvzjag" bpmnElement="StartEvent_41">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1d2nljj" bpmnElement="Flow_41">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1ejiinj">
+    <bpmndi:BPMNPlane id="BPMNPlane_0tpuuov" bpmnElement="TimerEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_1rvilhb" bpmnElement="EndEvent_42">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v9byke" bpmnElement="StartEvent_42">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0ls5322" bpmnElement="Flow_42">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1el42fh">
+    <bpmndi:BPMNPlane id="BPMNPlane_00u8sdn" bpmnElement="ConditionalEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_0bazhcf" bpmnElement="EndEvent_43">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ybkcay" bpmnElement="StartEvent_0putbmu">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_161y5wc" bpmnElement="Flow_43">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_19nnu0v">
+    <bpmndi:BPMNPlane id="BPMNPlane_1dy8st9" bpmnElement="SignalEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_15tjzu4" bpmnElement="EndEvent_44">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1dpjxx0" bpmnElement="StartEvent_44">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1467oob" bpmnElement="Flow_44">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1fifbp0">
+    <bpmndi:BPMNPlane id="BPMNPlane_0capd7d" bpmnElement="EscalationEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_1k6uy0v" bpmnElement="EndEvent_45">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0iybr7e" bpmnElement="StartEvent_45">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0b69mwn" bpmnElement="Flow_45">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0jhhd5d">
+    <bpmndi:BPMNPlane id="BPMNPlane_1ecns91" bpmnElement="MultipleEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_1fw6gu6" bpmnElement="EndEvent_48">
+        <dc:Bounds x="270" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0y64jze" bpmnElement="StartEvent_48">
+        <dc:Bounds x="180" y="80" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_189t5vp" bpmnElement="Flow_48">
+        <di:waypoint x="216" y="98" />
+        <di:waypoint x="270" y="98" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0k1s7qz">
+    <bpmndi:BPMNPlane id="BPMNPlane_0g54i56" bpmnElement="ParallelEventSubprocess_4">
+      <bpmndi:BPMNShape id="BPMNShape_09rj4b7" bpmnElement="EndEvent_49">
+        <dc:Bounds x="270" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1p4fe3j" bpmnElement="StartEvent_49">
+        <dc:Bounds x="180" y="160" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0e3iwa1" bpmnElement="Flow_49">
+        <di:waypoint x="216" y="178" />
+        <di:waypoint x="270" y="178" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -164,6 +164,15 @@ describe('draw - bpmn renderer', function() {
   });
 
 
+  it('should render event subprocess icons', function() {
+    var xml = require('../../fixtures/bpmn/draw/event-subprocess-icons.bpmn');
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      checkErrors(result.error, result.warnings);
+    });
+  });
+
+
   it('should render gateways', function() {
     var xml = require('../../fixtures/bpmn/draw/gateways.bpmn');
     return bootstrapViewer(xml).call(this).then(function(result) {


### PR DESCRIPTION
Closes #50

Draw event icons for collapsed event subprocesses.
No icon is drawn when a start event is missing or when there's more than one start event (forbidden by the spec).

Reuses existing code with few minor adjustments.

Demo (spec on the right):

![evsub-demo](https://github.com/user-attachments/assets/0d128b15-549d-4d73-9954-6bca0011e9f7)

[event-subprocess-icons.bpmn](https://github.com/sombrek/bpmn-js/blob/event-subprocess-icons/test/fixtures/bpmn/draw/event-subprocess-icons.bpmn) contains all possible icons.
