### PR TITLE
Remove default start event for ad-hoc subprocess

### DIFF
--- a/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
+++ b/lib/features/modeling/behavior/SubProcessStartEventBehavior.js
@@ -26,6 +26,7 @@ export default function SubProcessStartEventBehavior(injector, modeling) {
 
     if (
       !is(newShape, 'bpmn:SubProcess') ||
+      is(newShape,'bpmn:AdHocSubProcess') ||
       ! (is(oldShape, 'bpmn:Task') || is(oldShape, 'bpmn:CallActivity')) ||
       !isExpanded(newShape)
     ) {

--- a/test/spec/features/modeling/behavior/SubProcessStartEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/SubProcessStartEventBehaviorSpec.js
@@ -74,6 +74,30 @@ describe('features/modeling/behavior - subprocess start event', function() {
     });
 
 
+    describe('task -> adhoc subprocess', function() {
+
+      it('should NOT add start event child to adhoc subprocess', inject(
+        function(elementRegistry, bpmnReplace) {
+
+          // given
+          var task = elementRegistry.get('Task_1'),
+              collapsedSubProcess,
+              startEvents;
+
+          // when
+          collapsedSubProcess = bpmnReplace.replaceElement(task, {
+            type: 'bpmn:AdHocSubProcess',
+            isExpanded: true
+          });
+
+          // then
+          startEvents = getChildStartEvents(collapsedSubProcess);
+
+          expect(startEvents).to.have.length(0);
+        }));
+    });
+
+
     describe('task -> collapsed subprocess', function() {
 
       it('should NOT add start event child to subprocess', inject(


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4858

### Proposed Changes

Start Event is not added automaticly for AdHocSubProcess
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
