### PR TITLE
Event references not removed when element is replaced

### DIFF
--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -4,12 +4,13 @@ import {
   has,
   isArray,
   isDefined,
-  isFunction,
   isObject,
   matchPattern,
   reduce,
   sortBy
 } from 'min-dash';
+
+import { is } from '../../util/ModelUtil';
 
 var DISALLOWED_PROPERTIES = [
   'artifacts',
@@ -269,8 +270,4 @@ export function getPropertyNames(descriptor, keepDefaultProperties) {
 
     return properties.concat(property.name);
   }, []);
-}
-
-function is(element, type) {
-  return element && isFunction(element.$instanceOf) && element.$instanceOf(type);
 }

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -12,7 +12,7 @@ import {
 
 import { is } from '../../util/ModelUtil';
 
-var DISALLOWED_PROPERTIES = [
+const DISALLOWED_PROPERTIES = [
   'artifacts',
   'dataInputAssociations',
   'dataOutputAssociations',
@@ -24,7 +24,7 @@ var DISALLOWED_PROPERTIES = [
   'categoryValue'
 ];
 
-var ALLOWED_REFERENCES = [
+const ALLOWED_REFERENCES = [
   'errorRef',
   'escalationRef',
   'messageRef',
@@ -52,24 +52,27 @@ export default function ModdleCopy(eventBus, bpmnFactory, moddle) {
   this._moddle = moddle;
 
   // copy extension elements last
-  eventBus.on('moddleCopy.canCopyProperties', function(context) {
-    var propertyNames = context.propertyNames;
+  eventBus.on('moddleCopy.canCopyProperties', (context) => {
+    const { propertyNames } = context;
 
     if (!propertyNames || !propertyNames.length) {
       return;
     }
 
-    return sortBy(propertyNames, function(propertyName) {
+    return sortBy(propertyNames, (propertyName) => {
       return propertyName === 'extensionElements';
     });
   });
 
   // default check whether property can be copied
-  eventBus.on('moddleCopy.canCopyProperty', function(context) {
-    var parent = context.parent,
-        parentDescriptor = isObject(parent) && parent.$descriptor,
-        propertyName = context.propertyName,
-        property = context.property;
+  eventBus.on('moddleCopy.canCopyProperty', (context) => {
+    const {
+      parent,
+      property,
+      propertyName
+    } = context;
+
+    const parentDescriptor = isObject(parent) && parent.$descriptor;
 
     if (propertyName && ALLOWED_REFERENCES.includes(propertyName)) {
 
@@ -93,8 +96,8 @@ export default function ModdleCopy(eventBus, bpmnFactory, moddle) {
   });
 
   // do NOT allow to copy empty extension elements
-  eventBus.on('moddleCopy.canSetCopiedProperty', function(context) {
-    var property = context.property;
+  eventBus.on('moddleCopy.canSetCopiedProperty', (context) => {
+    const { property } = context;
 
     if (is(property, 'bpmn:ExtensionElements') && (!property.values || !property.values.length)) {
 
@@ -121,15 +124,13 @@ ModdleCopy.$inject = [
  * @return {ModdleElement}
  */
 ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, propertyNames, clone = false) {
-  var self = this;
-
   if (propertyNames && !isArray(propertyNames)) {
     propertyNames = [ propertyNames ];
   }
 
   propertyNames = propertyNames || getPropertyNames(sourceElement.$descriptor);
 
-  var canCopyProperties = this._eventBus.fire('moddleCopy.canCopyProperties', {
+  const canCopyProperties = this._eventBus.fire('moddleCopy.canCopyProperties', {
     propertyNames: propertyNames,
     sourceElement: sourceElement,
     targetElement: targetElement,
@@ -145,20 +146,20 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
   }
 
   // copy properties
-  forEach(propertyNames, function(propertyName) {
-    var sourceProperty;
+  forEach(propertyNames, (propertyName) => {
+    let sourceProperty;
 
     if (has(sourceElement, propertyName)) {
       sourceProperty = sourceElement.get(propertyName);
     }
 
-    var copiedProperty = self.copyProperty(sourceProperty, targetElement, propertyName, clone);
+    const copiedProperty = this.copyProperty(sourceProperty, targetElement, propertyName, clone);
 
     if (!isDefined(copiedProperty)) {
       return;
     }
 
-    var canSetProperty = self._eventBus.fire('moddleCopy.canSetCopiedProperty', {
+    const canSetProperty = this._eventBus.fire('moddleCopy.canSetCopiedProperty', {
       parent: targetElement,
       property: copiedProperty,
       propertyName: propertyName
@@ -187,10 +188,9 @@ ModdleCopy.prototype.copyElement = function(sourceElement, targetElement, proper
  * @return {any}
  */
 ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clone = false) {
-  var self = this;
 
   // allow others to copy property
-  var copiedProperty = this._eventBus.fire('moddleCopy.canCopyProperty', {
+  let copiedProperty = this._eventBus.fire('moddleCopy.canCopyProperty', {
     parent: parent,
     property: property,
     propertyName: propertyName,
@@ -210,7 +210,7 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clo
     return copiedProperty;
   }
 
-  var propertyDescriptor = this._moddle.getPropertyDescriptor(parent, propertyName);
+  const propertyDescriptor = this._moddle.getPropertyDescriptor(parent, propertyName);
 
   // do NOT copy references
   if (propertyDescriptor.isReference) {
@@ -224,10 +224,10 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clo
 
   // copy arrays
   if (isArray(property)) {
-    return reduce(property, function(childProperties, childProperty) {
+    return reduce(property, (childProperties, childProperty) => {
 
       // recursion
-      copiedProperty = self.copyProperty(childProperty, parent, propertyName, clone);
+      const copiedProperty = this.copyProperty(childProperty, parent, propertyName, clone);
 
       // copying might NOT be allowed
       if (copiedProperty) {
@@ -244,12 +244,12 @@ ModdleCopy.prototype.copyProperty = function(property, parent, propertyName, clo
       return;
     }
 
-    copiedProperty = self._bpmnFactory.create(property.$type);
+    copiedProperty = this._bpmnFactory.create(property.$type);
 
     copiedProperty.$parent = parent;
 
     // recursion
-    copiedProperty = self.copyElement(property, copiedProperty, null, clone);
+    copiedProperty = this.copyElement(property, copiedProperty, null, clone);
 
     return copiedProperty;
   }
@@ -276,7 +276,7 @@ ModdleCopy.prototype._copyId = function(id, element, clone = false) {
 // helpers //////////
 
 export function getPropertyNames(descriptor, keepDefaultProperties) {
-  return reduce(descriptor.properties, function(properties, property) {
+  return reduce(descriptor.properties, (properties, property) => {
 
     if (keepDefaultProperties && property.default) {
       return properties;

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -10,7 +10,9 @@ import {
   sortBy
 } from 'min-dash';
 
-import { is } from '../../util/ModelUtil';
+import { is, isAny } from '../../util/ModelUtil';
+
+import { hasAnyEventDefinition } from '../../util/ModelUtil';
 
 var DISALLOWED_PROPERTIES = [
   'artifacts',
@@ -61,7 +63,14 @@ export default function ModdleCopy(eventBus, bpmnFactory, moddle) {
   eventBus.on('moddleCopy.canCopyProperty', function(context) {
     var parent = context.parent,
         parentDescriptor = isObject(parent) && parent.$descriptor,
-        propertyName = context.propertyName;
+        propertyName = context.propertyName,
+        property = context.property;
+
+    // allow specific referenced elements to be copied
+    // check whether the property is a reference and belongs to event definition
+    if (isRefPropertyAllowed(property, parent)) {
+      return property;
+    }
 
     if (propertyName && DISALLOWED_PROPERTIES.indexOf(propertyName) !== -1) {
 
@@ -270,4 +279,23 @@ export function getPropertyNames(descriptor, keepDefaultProperties) {
 
     return properties.concat(property.name);
   }, []);
+}
+
+function isRefPropertyAllowed(property, parent) {
+  const allowedEventDefTypes = [
+    'bpmn:ErrorEventDefinition',
+    'bpmn:EscalationEventDefinition',
+    'bpmn:MessageEventDefinition',
+    'bpmn:SignalEventDefinition'
+  ];
+
+  const allowedPropertyTypes = [
+    'bpmn:Error',
+    'bpmn:Message',
+    'bpmn:Signal',
+    'bpmn:Escalation'
+  ];
+
+  return hasAnyEventDefinition(parent, allowedEventDefTypes) &&
+         isAny(property, allowedPropertyTypes);
 }

--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -10,9 +10,7 @@ import {
   sortBy
 } from 'min-dash';
 
-import { is, isAny } from '../../util/ModelUtil';
-
-import { hasAnyEventDefinition } from '../../util/ModelUtil';
+import { is } from '../../util/ModelUtil';
 
 var DISALLOWED_PROPERTIES = [
   'artifacts',
@@ -24,6 +22,13 @@ var DISALLOWED_PROPERTIES = [
   'incoming',
   'outgoing',
   'categoryValue'
+];
+
+var ALLOWED_REFERENCES = [
+  'errorRef',
+  'escalationRef',
+  'messageRef',
+  'signalRef'
 ];
 
 /**
@@ -66,13 +71,13 @@ export default function ModdleCopy(eventBus, bpmnFactory, moddle) {
         propertyName = context.propertyName,
         property = context.property;
 
-    // allow specific referenced elements to be copied
-    // check whether the property is a reference and belongs to event definition
-    if (isRefPropertyAllowed(property, parent)) {
+    if (propertyName && ALLOWED_REFERENCES.includes(propertyName)) {
+
+      // allow copying reference
       return property;
     }
 
-    if (propertyName && DISALLOWED_PROPERTIES.indexOf(propertyName) !== -1) {
+    if (propertyName && DISALLOWED_PROPERTIES.includes(propertyName)) {
 
       // disallow copying property
       return false;
@@ -279,23 +284,4 @@ export function getPropertyNames(descriptor, keepDefaultProperties) {
 
     return properties.concat(property.name);
   }, []);
-}
-
-function isRefPropertyAllowed(property, parent) {
-  const allowedEventDefTypes = [
-    'bpmn:ErrorEventDefinition',
-    'bpmn:EscalationEventDefinition',
-    'bpmn:MessageEventDefinition',
-    'bpmn:SignalEventDefinition'
-  ];
-
-  const allowedPropertyTypes = [
-    'bpmn:Error',
-    'bpmn:Message',
-    'bpmn:Signal',
-    'bpmn:Escalation'
-  ];
-
-  return hasAnyEventDefinition(parent, allowedEventDefTypes) &&
-         isAny(property, allowedPropertyTypes);
 }

--- a/lib/util/ModelUtil.js
+++ b/lib/util/ModelUtil.js
@@ -1,5 +1,6 @@
 import {
-  some
+  some,
+  isArray
 } from 'min-dash';
 
 /**
@@ -56,4 +57,20 @@ export function getBusinessObject(element) {
  */
 export function getDi(element) {
   return element && element.di;
+}
+
+/**
+ * @param {ModdleElement} moddleElement
+ * @param {string[]} types
+ *
+ * @return {boolean}
+ */
+export function hasAnyEventDefinition(moddleElement, types) {
+  if (!isArray(types)) {
+    types = [ types ];
+  }
+
+  return some(types, function(type) {
+    return is(moddleElement, type);
+  });
 }

--- a/lib/util/ModelUtil.js
+++ b/lib/util/ModelUtil.js
@@ -1,6 +1,5 @@
 import {
-  some,
-  isArray
+  some
 } from 'min-dash';
 
 /**
@@ -57,20 +56,4 @@ export function getBusinessObject(element) {
  */
 export function getDi(element) {
   return element && element.di;
-}
-
-/**
- * @param {ModdleElement} moddleElement
- * @param {string[]} types
- *
- * @return {boolean}
- */
-export function hasAnyEventDefinition(moddleElement, types) {
-  if (!isArray(types)) {
-    types = [ types ];
-  }
-
-  return some(types, function(type) {
-    return is(moddleElement, type);
-  });
 }

--- a/test/spec/features/copy-paste/ModdleCopySpec.js
+++ b/test/spec/features/copy-paste/ModdleCopySpec.js
@@ -823,6 +823,162 @@ describe('features/copy-paste/ModdleCopy', function() {
       expect(newGroup.categoryValueRef.$parent).to.equal(newCategory);
     }));
 
+
+    describe('default events', function() {
+
+      describe('allowed references', function() {
+
+        it('should copy error reference', inject(function(moddle, moddleCopy) {
+
+          // given
+          var boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              errorEventDefinition = moddle.create('bpmn:ErrorEventDefinition');
+
+          errorEventDefinition.$parent = boundaryEvent;
+
+          boundaryEvent.eventDefinitions = [ errorEventDefinition ];
+
+          var error = moddle.create('bpmn:Error');
+
+          errorEventDefinition.errorRef = error;
+
+          // when
+          var boundaryEventCopy = moddleCopy.copyElement(boundaryEvent, moddle.create('bpmn:BoundaryEvent'));
+
+          // then
+          expect(boundaryEventCopy.eventDefinitions).to.have.length(1);
+          expect(boundaryEventCopy.eventDefinitions[0]).not.to.equal(errorEventDefinition);
+          expect(boundaryEventCopy.eventDefinitions[0].$type).to.equal('bpmn:ErrorEventDefinition');
+          expect(boundaryEventCopy.eventDefinitions[0].errorRef).to.exist;
+          expect(boundaryEventCopy.eventDefinitions[0].errorRef).to.equal(error);
+        }));
+
+
+        it('should copy escalation reference', inject(function(moddle, moddleCopy) {
+
+          // given
+          var boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              escalationEventDefinition = moddle.create('bpmn:EscalationEventDefinition');
+
+          escalationEventDefinition.$parent = boundaryEvent;
+
+          boundaryEvent.eventDefinitions = [ escalationEventDefinition ];
+
+          var error = moddle.create('bpmn:Escalation');
+
+          escalationEventDefinition.escalationRef = error;
+
+          // when
+          var boundaryEventCopy = moddleCopy.copyElement(boundaryEvent, moddle.create('bpmn:BoundaryEvent'));
+
+          // then
+          expect(boundaryEventCopy.eventDefinitions).to.have.length(1);
+          expect(boundaryEventCopy.eventDefinitions[0]).not.to.equal(escalationEventDefinition);
+          expect(boundaryEventCopy.eventDefinitions[0].$type).to.equal('bpmn:EscalationEventDefinition');
+          expect(boundaryEventCopy.eventDefinitions[0].escalationRef).to.exist;
+          expect(boundaryEventCopy.eventDefinitions[0].escalationRef).to.equal(error);
+        }));
+
+
+        it('should copy message reference (event)', inject(function(moddle, moddleCopy) {
+
+          // given
+          var boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              messageEventDefinition = moddle.create('bpmn:MessageEventDefinition');
+
+          messageEventDefinition.$parent = boundaryEvent;
+
+          boundaryEvent.eventDefinitions = [ messageEventDefinition ];
+
+          var message = moddle.create('bpmn:Message');
+
+          messageEventDefinition.messageRef = message;
+
+          // when
+          var boundaryEventCopy = moddleCopy.copyElement(boundaryEvent, moddle.create('bpmn:BoundaryEvent'));
+
+          // then
+          expect(boundaryEventCopy.eventDefinitions).to.have.length(1);
+          expect(boundaryEventCopy.eventDefinitions[0]).not.to.equal(messageEventDefinition);
+          expect(boundaryEventCopy.eventDefinitions[0].$type).to.equal('bpmn:MessageEventDefinition');
+          expect(boundaryEventCopy.eventDefinitions[0].messageRef).to.exist;
+          expect(boundaryEventCopy.eventDefinitions[0].messageRef).to.equal(message);
+        }));
+
+
+        it('should copy message reference (receive task)', inject(function(moddle, moddleCopy) {
+
+          // given
+          var receiveTask = moddle.create('bpmn:ReceiveTask');
+
+          var message = moddle.create('bpmn:Message');
+
+          receiveTask.messageRef = message;
+
+          // when
+          var receiveTaskCopy = moddleCopy.copyElement(receiveTask, moddle.create('bpmn:ReceiveTask'));
+
+          // then
+          expect(receiveTaskCopy.messageRef).to.exist;
+          expect(receiveTaskCopy.messageRef).to.equal(message);
+        }));
+
+
+        it('should copy signal reference', inject(function(moddle, moddleCopy) {
+
+          // given
+          var boundaryEvent = moddle.create('bpmn:BoundaryEvent'),
+              signalEventDefinition = moddle.create('bpmn:SignalEventDefinition');
+
+          signalEventDefinition.$parent = boundaryEvent;
+
+          boundaryEvent.eventDefinitions = [ signalEventDefinition ];
+
+          var signal = moddle.create('bpmn:Signal');
+
+          signalEventDefinition.signalRef = signal;
+
+          // when
+          var boundaryEventCopy = moddleCopy.copyElement(boundaryEvent, moddle.create('bpmn:BoundaryEvent'));
+
+          // then
+          expect(boundaryEventCopy.eventDefinitions).to.have.length(1);
+          expect(boundaryEventCopy.eventDefinitions[0]).not.to.equal(signalEventDefinition);
+          expect(boundaryEventCopy.eventDefinitions[0].$type).to.equal('bpmn:SignalEventDefinition');
+          expect(boundaryEventCopy.eventDefinitions[0].signalRef).to.exist;
+          expect(boundaryEventCopy.eventDefinitions[0].signalRef).to.equal(signal);
+        }));
+
+      });
+
+
+      describe('disallowed properties', function() {
+
+        it('should NOT copy incoming and outgoing', inject(function(moddle, moddleCopy) {
+
+          // given
+          var incoming = moddle.create('bpmn:SequenceFlow'),
+              outgoing = moddle.create('bpmn:SequenceFlow'),
+              task = moddle.create('bpmn:Task', {
+                incoming: [ incoming ],
+                outgoing: [ outgoing ]
+              });
+
+          expect(task.get('incoming')).to.have.length(1);
+          expect(task.get('outgoing')).to.have.length(1);
+
+          // when
+          var taskCopy = moddleCopy.copyElement(task, moddle.create('bpmn:Task'));
+
+          // then
+          expect(taskCopy.get('incoming')).to.have.length(0);
+          expect(taskCopy.get('outgoing')).to.have.length(0);
+        }));
+
+      });
+
+    });
+
   });
 
 

--- a/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
@@ -64,7 +64,7 @@ describe('features/modeling/behavior - boundary event', function() {
   });
 
 
-  describe.skip('should keep root element reference on replace', function() {
+  describe('should keep root element reference on replace', function() {
 
     describe('interrupting to non-interrupting', function() {
 
@@ -85,7 +85,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
+        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'messageRef');
       }));
 
 
@@ -106,7 +106,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'escalationRef')).to.equal(escalation);
+        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'escalationRef');
       }));
 
 
@@ -127,7 +127,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'errorRef')).to.equal(error);
+        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'errorRef');
       }));
 
 
@@ -148,7 +148,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'signalRef')).to.equal(signal);
+        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'signalRef');
       }));
 
     });
@@ -173,7 +173,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
+        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'messageRef');
       }));
 
     });
@@ -190,4 +190,13 @@ function getReferencedRootElement(element, propertyName) {
       eventDefinition = businessObject.eventDefinitions[ 0 ];
 
   return eventDefinition.get(propertyName);
+}
+
+function expectRefEquals(element, newElement, propertyName) {
+  const previousRefElement = getReferencedRootElement(element, propertyName);
+  const newRefElement = getReferencedRootElement(newElement, propertyName);
+
+  // expect name to be same
+  expect(previousRefElement).to.equal(newRefElement);
+
 }

--- a/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/BoundaryEventBehaviorSpec.js
@@ -85,7 +85,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'messageRef');
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
       }));
 
 
@@ -106,7 +106,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'escalationRef');
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'escalationRef')).to.equal(escalation);
       }));
 
 
@@ -127,7 +127,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'errorRef');
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'errorRef')).to.equal(error);
       }));
 
 
@@ -148,7 +148,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'signalRef');
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'signalRef')).to.equal(signal);
       }));
 
     });
@@ -173,7 +173,7 @@ describe('features/modeling/behavior - boundary event', function() {
         });
 
         // then
-        expectRefEquals(interruptingBoundaryEvent, nonInterruptingBoundaryEvent, 'messageRef');
+        expect(getReferencedRootElement(nonInterruptingBoundaryEvent, 'messageRef')).to.equal(message);
       }));
 
     });
@@ -190,13 +190,4 @@ function getReferencedRootElement(element, propertyName) {
       eventDefinition = businessObject.eventDefinitions[ 0 ];
 
   return eventDefinition.get(propertyName);
-}
-
-function expectRefEquals(element, newElement, propertyName) {
-  const previousRefElement = getReferencedRootElement(element, propertyName);
-  const newRefElement = getReferencedRootElement(newElement, propertyName);
-
-  // expect name to be same
-  expect(previousRefElement).to.equal(newRefElement);
-
 }


### PR DESCRIPTION
Closes #2249, #1906
Related to: https://github.com/camunda/camunda-modeler/issues/4863, https://github.com/camunda/camunda-modeler/issues/4567
### Proposed Changes
Event references now retain the same reference even when the associated element is changed.

Specifically handled event definitions:

- `bpmn:ErrorEventDefinition`
- `bpmn:EscalationEventDefinition`
- `bpmn:MessageEventDefinition`
- `bpmn:SignalEventDefinition`

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 
![Apr-15-2025 19-53-02](https://github.com/user-attachments/assets/90fe08db-fd66-4b39-b12b-d5509be4f65f)

You can try it out via 
```
npx @bpmn-io/sr camunda/camunda-bpmn-js -l bpmn-io/bpmn-js#event-refs
```
### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
