### PR TITLE
fix:Adapted the ctrl+z combination for the German keyboard (closes #2…

### DIFF
--- a/lib/features/keyboard/BpmnKeyboardBindings.js
+++ b/lib/features/keyboard/BpmnKeyboardBindings.js
@@ -35,6 +35,44 @@ BpmnKeyboardBindings.prototype.registerBindings = function(keyboard, editorActio
   // inherit default bindings
   KeyboardBindings.prototype.registerBindings.call(this, keyboard, editorActions);
 
+  // Undo: Ctrl+Z 
+  if (editorActions.isRegistered('undo')) {
+    keyboard.addListener((context) => {
+      const event = context.keyEvent;
+      const isUndo = (
+        (event.key.toLowerCase() === 'z' ||  // QWERTY
+         event.key.toLowerCase() === 'y' ||  // QWERTZ 
+         event.key.toLowerCase() === 'я' ||  // ЙЦУКЕН
+         event.code === 'KeyZ') &&          // Physical key Z
+        keyboard.isCmd(event) &&
+        !event.shiftKey
+      );
+
+      if (isUndo) {
+        editorActions.trigger('undo');
+        return true;
+      }
+    });
+  }
+
+  // Redo: Ctrl+Shift+Z / Ctrl+Y (german)
+  if (editorActions.isRegistered('redo')) {
+    keyboard.addListener((context) => {
+      const event = context.keyEvent;
+      const isRedo = (
+        (event.key.toLowerCase() === 'y' ||  // German
+         event.code === 'KeyZ') &&           // Physical key
+        keyboard.isCmd(event) &&
+        event.shiftKey
+      );
+
+      if (isRedo) {
+        editorActions.trigger('redo');
+        return true;
+      }
+    });
+  }
+
   /**
    * Add keyboard binding if respective editor action
    * is registered.
@@ -48,6 +86,8 @@ BpmnKeyboardBindings.prototype.registerBindings = function(keyboard, editorActio
       keyboard.addListener(fn);
     }
   }
+
+  
 
   // select all elements
   // CTRL + A
@@ -176,5 +216,7 @@ BpmnKeyboardBindings.prototype.registerBindings = function(keyboard, editorActio
       return true;
     }
   });
+
+  
 
 };


### PR DESCRIPTION
## Описание изменений

### Что было исправлено:
1. Добавлена проверка `event.code`, теперь система учитывает физическую клавишу `Z` (`event.code === 'KeyZ'`), независимо от раскладки.
2. Добавлена поддержка немецкой (QWERTZ) раскладки:
   - Для **Undo** (`Ctrl+Z`)
   - Для **Redo** (`Ctrl+Shift+Z`)

### Исправление позволяет:
1. Работать `Ctrl+Z`/`Ctrl+Y` на всех раскладках  
2.  Учитывать физическое расположение клавиш (`event.code`)  
3.  Сохранить обратную совместимость  

### Тестирование:
Проверено на следующих раскладках:
- Английская (QWERTY) - `Ctrl+Z`/`Ctrl+Shift+Z`
- Немецкая (QWERTZ) - `Ctrl+Y`/`Ctrl+Shift+Y`

### Связанные Issue:
Fixes #2108 (Проблема с горячими клавишами на альтернативных раскладках)