### PR TITLE
Selection outline is available by default from Viewer and not Modeler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: re-add outline in viewer and removed from modeler (outline can be accessed via viewer) ([#2302](https://github.com/bpmn-io/bpmn-js/issues/2302))
+
 ## 18.6.1
 
 * `FIX`: copy error, escalation, message and signal references when copying elements ([#2301](https://github.com/bpmn-io/diagram-js/pull/2301))

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -34,7 +34,6 @@ import ReplacePreviewModule from './features/replace-preview';
 import ResizeModule from 'diagram-js/lib/features/resize';
 import SnappingModule from './features/snapping';
 import SearchModule from './features/search';
-import OutlineModule from './features/outline';
 
 var initialDiagram =
   '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -189,7 +188,6 @@ Modeler.prototype._modelingModules = [
   ResizeModule,
   SnappingModule,
   SearchModule,
-  OutlineModule
 ];
 
 

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -5,7 +5,7 @@ import DrilldownModdule from './features/drilldown';
 import OverlaysModule from 'diagram-js/lib/features/overlays';
 import SelectionModule from 'diagram-js/lib/features/selection';
 import TranslateModule from 'diagram-js/lib/i18n/translate';
-
+import OutlineModule from './features/outline';
 import BaseViewer from './BaseViewer';
 
 
@@ -69,6 +69,7 @@ Viewer.prototype._modules = [
   CoreModule,
   DrilldownModdule,
   OverlaysModule,
+  OutlineModule,
   SelectionModule,
   TranslateModule
 ];

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -215,13 +215,13 @@ describe('Modeler', function() {
   });
 
 
-  it('should include Outline module by default', function() {
+  it('should include Outline module by default from Viewer', function() {
 
     // given
-    var modeler = new Modeler();
+    var viewer = new Modeler.Viewer();
 
     // when
-    var outline = modeler.get('outline', false);
+    var outline = viewer.get('outline', false);
 
     // then
     expect(outline).to.exist;

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -85,7 +85,7 @@ describe('Viewer', function() {
   });
 
 
-  it('should not include Outline module by default', function() {
+  it('should include Outline module by default', function() {
 
     // given
     var viewer = new Viewer();
@@ -94,7 +94,7 @@ describe('Viewer', function() {
     var outline = viewer.get('outline', false);
 
     // then
-    expect(outline).not.to.exist;
+    expect(outline).to.exist;
   });
 
 


### PR DESCRIPTION
Closes #2302 
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

## Viewer
![viewer](https://github.com/user-attachments/assets/ba26e8f4-a3ee-47d3-851e-bc006ec990ef)


#### Known bugs
- When I select the elements using `Cmd + Click`, some text is also selected along the way which is not the case with modeler.
- Flow elements are not selected when selected individually since they don't have outline.

![viewer-flow-elements-not-outlined](https://github.com/user-attachments/assets/dc7a1364-c6fb-4fea-b62d-a248987e7620)


## Modeler
![modeler](https://github.com/user-attachments/assets/16bb0aed-919e-46b9-9e65-c3401093d2dc)

- Modeler single element select. Can select flow elements but I guess it's not an outline.

![modeler-single](https://github.com/user-attachments/assets/ec17b869-f371-49ff-9abe-16d199c3f1cc)


### Steps to Try out

run `npm run start:viewer` to see outline is available in viewer
run `npm start` to see outline is available in the modeler (via viewer)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
