### PR TITLE
Selection outline reverted. Available via modeler only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FIX`: re-add outline in viewer and removed from modeler (outline can be accessed via viewer) ([#2302](https://github.com/bpmn-io/bpmn-js/issues/2302))
-
 ## 18.6.1
 
 * `FIX`: copy error, escalation, message and signal references when copying elements ([#1906](https://github.com/bpmn-io/bpmn-js/issues/1906), [#2249](https://github.com/bpmn-io/bpmn-js/issues/2249), [#2301](https://github.com/bpmn-io/bpmn-js/pull/2301))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ ___Note:__ Yet to be released changes appear here._
 * Require `Node >= 20`
 * `Canvas` is now a focusable element and provides better support for native browser behaviors. Focus can be controlled with new `focus` and `restoreFocus` APIs ([bpmn-io/diagram-js#662](https://github.com/bpmn-io/diagram-js/pull/662)).
 * Keyboard is now implicitly bound to canvas SVG element. Calls to `keyboard.bind` and `keyboard.bindTo` now result with a descriptive console error and have no effect ([bpmn-io/diagram-js#662](https://github.com/bpmn-io/diagram-js/pull/662)).
+* Selection outline is no longer included in the viewer. If needed, add it as an additional module ([#2253](https://github.com/bpmn-io/bpmn-js/pull/2253)).
 
 ## 17.11.1
 

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -34,6 +34,7 @@ import ReplacePreviewModule from './features/replace-preview';
 import ResizeModule from 'diagram-js/lib/features/resize';
 import SnappingModule from './features/snapping';
 import SearchModule from './features/search';
+import OutlineModule from './features/outline';
 
 var initialDiagram =
   '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -188,6 +189,7 @@ Modeler.prototype._modelingModules = [
   ResizeModule,
   SnappingModule,
   SearchModule,
+  OutlineModule
 ];
 
 

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -5,7 +5,7 @@ import DrilldownModdule from './features/drilldown';
 import OverlaysModule from 'diagram-js/lib/features/overlays';
 import SelectionModule from 'diagram-js/lib/features/selection';
 import TranslateModule from 'diagram-js/lib/i18n/translate';
-import OutlineModule from './features/outline';
+
 import BaseViewer from './BaseViewer';
 
 
@@ -69,7 +69,6 @@ Viewer.prototype._modules = [
   CoreModule,
   DrilldownModdule,
   OverlaysModule,
-  OutlineModule,
   SelectionModule,
   TranslateModule
 ];

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -215,13 +215,13 @@ describe('Modeler', function() {
   });
 
 
-  it('should include Outline module by default from Viewer', function() {
+  it('should include Outline module by default', function() {
 
     // given
-    var viewer = new Modeler.Viewer();
+    var modeler = new Modeler();
 
     // when
-    var outline = viewer.get('outline', false);
+    var outline = modeler.get('outline', false);
 
     // then
     expect(outline).to.exist;

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -85,7 +85,7 @@ describe('Viewer', function() {
   });
 
 
-  it('should include Outline module by default', function() {
+  it('should not include Outline module by default', function() {
 
     // given
     var viewer = new Viewer();
@@ -94,7 +94,7 @@ describe('Viewer', function() {
     var outline = viewer.get('outline', false);
 
     // then
-    expect(outline).to.exist;
+    expect(outline).not.to.exist;
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Reverted selection outline in viewer. (ref. https://github.com/bpmn-io/bpmn-js/pull/2316, https://camunda.slack.com/archives/GP70M0J6M/p1747036031927819)

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
