### PR TITLE
fix: center task markers; adjust position of multiple markers

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -951,7 +951,7 @@ export default function BpmnRenderer(
     taskMarkerRenderers[ type ](parentGfx, element, attrs);
   }
 
-  function renderTaskMarkers(parentGfx, element, taskMarkers, attrs = {}) {
+  function renderTaskMarkers(parentGfx, element, taskMarkers = [], attrs = {}) {
     attrs = {
       fill: attrs.fill,
       stroke: attrs.stroke,
@@ -961,14 +961,14 @@ export default function BpmnRenderer(
 
     var semantic = getSemantic(element);
 
-    var subprocess = taskMarkers && taskMarkers.includes('SubProcessMarker');
+    var subprocess = taskMarkers.includes('SubProcessMarker');
 
     if (subprocess) {
       attrs = {
         ...attrs,
         seq: -21,
         parallel: -22,
-        compensation: -42,
+        compensation: -25,
         loop: -18,
         adhoc: 10
       };
@@ -977,22 +977,22 @@ export default function BpmnRenderer(
         ...attrs,
         seq: -5,
         parallel: -6,
-        compensation: -27,
+        compensation: -7,
         loop: 0,
-        adhoc: 10
+        adhoc: -8
       };
     }
 
-    forEach(taskMarkers, function(marker) {
-      renderTaskMarker(marker, parentGfx, element, attrs);
-    });
-
     if (semantic.get('isForCompensation')) {
-      renderTaskMarker('CompensationMarker', parentGfx, element, attrs);
+      taskMarkers.push('CompensationMarker');
     }
 
     if (is(semantic, 'bpmn:AdHocSubProcess')) {
-      renderTaskMarker('AdhocMarker', parentGfx, element, attrs);
+      taskMarkers.push('AdhocMarker');
+
+      if (!subprocess) {
+        assign(attrs, { compensation: attrs.compensation - 18 });
+      }
     }
 
     var loopCharacteristics = semantic.get('loopCharacteristics'),
@@ -1000,18 +1000,40 @@ export default function BpmnRenderer(
 
     if (loopCharacteristics) {
 
+      assign(attrs, {
+        compensation: attrs.compensation - 18,
+      });
+
+      if (taskMarkers.includes('AdhocMarker')) {
+        assign(attrs, {
+          seq: -23,
+          loop: -18,
+          parallel: -24
+        });
+      }
+
       if (isSequential === undefined) {
-        renderTaskMarker('LoopMarker', parentGfx, element, attrs);
+        taskMarkers.push('LoopMarker');
       }
 
       if (isSequential === false) {
-        renderTaskMarker('ParallelMarker', parentGfx, element, attrs);
+        taskMarkers.push('ParallelMarker');
       }
 
       if (isSequential === true) {
-        renderTaskMarker('SequentialMarker', parentGfx, element, attrs);
+        taskMarkers.push('SequentialMarker');
       }
     }
+
+    if (taskMarkers.includes('CompensationMarker') && taskMarkers.length === 1) {
+      assign(attrs, {
+        compensation: -8
+      });
+    }
+
+    forEach(taskMarkers, function(marker) {
+      renderTaskMarker(marker, parentGfx, element, attrs);
+    });
   }
 
   function renderLabel(parentGfx, label, attrs = {}) {

--- a/test/fixtures/bpmn/draw/activity-markers-simple.bpmn
+++ b/test/fixtures/bpmn/draw/activity-markers-simple.bpmn
@@ -21,33 +21,51 @@
     <bpmn2:transaction id="Transaction" />
     <bpmn2:adHocSubProcess id="AdHocSubProcess" />
     <bpmn2:subProcess id="EventSubProcess" triggeredByEvent="true" />
+    <bpmn2:adHocSubProcess id="AdHocSubProcessExpanded" />
+    <bpmn2:subProcess id="SubProcessCollapsed" />
+    <bpmn2:task id="TaskCompensation" name="Task" isForCompensation="true"/>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="_BPMNShape_Task_4" bpmnElement="ParallelTask">
-        <dc:Bounds x="100" y="100" width="100" height="80" />
+        <dc:Bounds x="160" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_Task_5" bpmnElement="SequentialTask">
-        <dc:Bounds x="240" y="100" width="100" height="80" />
+        <dc:Bounds x="300" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_Task_6" bpmnElement="LoopTask">
-        <dc:Bounds x="384" y="100" width="100" height="80" />
+        <dc:Bounds x="444" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_Task_8" bpmnElement="Task">
-        <dc:Bounds x="528" y="100" width="100" height="80" />
+        <dc:Bounds x="588" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0378hpz" bpmnElement="TaskCompensation">
+        <dc:Bounds x="1000" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
-        <dc:Bounds x="101" y="224" width="350" height="200" />
+        <dc:Bounds x="161" y="224" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Transaction__di" bpmnElement="Transaction" isExpanded="true">
-        <dc:Bounds x="496" y="224" width="350" height="200" />
+        <dc:Bounds x="556" y="224" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="AdHocSubProcess_di" bpmnElement="AdHocSubProcess">
-        <dc:Bounds x="667" y="100" width="100" height="80" />
+        <dc:Bounds x="727" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_0oip8c9_di" bpmnElement="EventSubProcess" isExpanded="true">
-        <dc:Bounds x="101" y="474" width="350" height="200" />
+        <dc:Bounds x="161" y="474" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lpc84d_di" bpmnElement="AdHocSubProcessExpanded" isExpanded="true">
+        <dc:Bounds x="556" y="474" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qrv1en_di" bpmnElement="SubProcessCollapsed">
+        <dc:Bounds x="860" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="AdHocSubProcess" />
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0nsi3hh">
+    <bpmndi:BPMNPlane id="BPMNPlane_0mlallf" bpmnElement="SubProcessCollapsed" />
   </bpmndi:BPMNDiagram>
 </bpmn2:definitions>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -424,7 +424,7 @@ describe('draw - bpmn renderer', function() {
 
         const marker = domQuery('[data-marker=sub-process]', task);
 
-        expect(haveSameCenterX(task, marker)).to.be.true;
+        expectDistance(task, marker, { x: 0 });
       })();
     });
   });
@@ -445,7 +445,7 @@ describe('draw - bpmn renderer', function() {
 
         const marker = domQuery('[data-marker=compensation]', task);
 
-        expect(haveSameCenterX(task, marker)).to.be.true;
+        expectDistance(task, marker, { x: 0 });
       })();
     });
   });
@@ -465,7 +465,7 @@ describe('draw - bpmn renderer', function() {
 
         const marker = domQuery('[data-marker=adhoc]', task);
 
-        expect(haveSameCenterX(task, marker)).to.be.true;
+        expectDistance(task, marker, { x: 0 });
       })();
     });
   });
@@ -973,12 +973,35 @@ function isCollapsedSubProcess(element) {
   ]) && !isExpanded(element);
 }
 
-function haveSameCenterX(element, element2) {
-  const bbox1 = element.getBoundingClientRect();
+/**
+ * Expect distance between two elements.
+ *
+ * @param {SVGAElement} element1
+ * @param {SVGAElement} element2
+ * @param { { x: number; y: number } } distance
+ * @param {number} [tolerance=3]
+ *
+ * @returns {void}
+ */
+function expectDistance(element1, element2, distance, tolerance = 3) {
+  const {
+    x = Infinity,
+    y = Infinity
+  } = distance;
+
+  const bbox1 = element1.getBoundingClientRect();
   const bbox2 = element2.getBoundingClientRect();
 
-  const center1 = bbox1.left + (bbox1.width / 2);
-  const center2 = bbox2.left + (bbox2.width / 2);
+  const center1 = {
+    x: bbox1.left + (bbox1.width / 2),
+    y: bbox1.top + (bbox1.height / 2)
+  };
 
-  return Math.abs(center1 - center2) < 3;
+  const center2 = {
+    x: bbox2.left + (bbox2.width / 2),
+    y: bbox2.top + (bbox2.height / 2)
+  };
+
+  expect(Math.abs(center1.x - center2.x)).to.be.lessThan(x + tolerance);
+  expect(Math.abs(center1.y - center2.y)).to.be.lessThan(y + tolerance);
 }

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -409,6 +409,68 @@ describe('draw - bpmn renderer', function() {
   });
 
 
+  it('should render collapsed subprocess marker centered', function() {
+    var xml = require('../../fixtures/bpmn/draw/activity-markers-simple.bpmn');
+
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      var err = result.error;
+
+      expect(err).not.to.exist;
+
+      inject(function(elementRegistry) {
+
+        var task = elementRegistry.getGraphics('SubProcessCollapsed');
+
+        const marker = domQuery('[data-marker=sub-process]', task);
+
+        expect(haveSameCenterX(task, marker)).to.be.true;
+      })();
+    });
+  });
+
+
+  it('should render compensation marker centered', function() {
+    var xml = require('../../fixtures/bpmn/draw/activity-markers-simple.bpmn');
+
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      var err = result.error;
+
+      expect(err).not.to.exist;
+
+      inject(function(elementRegistry) {
+
+        var task = elementRegistry.getGraphics('TaskCompensation');
+
+        const marker = domQuery('[data-marker=compensation]', task);
+
+        expect(haveSameCenterX(task, marker)).to.be.true;
+      })();
+    });
+  });
+
+  it('should render ad-hoc marker centered on expanded subprocess', function() {
+    var xml = require('../../fixtures/bpmn/draw/activity-markers-simple.bpmn');
+
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      var err = result.error;
+
+      expect(err).not.to.exist;
+
+      inject(function(elementRegistry) {
+
+        var task = elementRegistry.getGraphics('AdHocSubProcessExpanded');
+
+        const marker = domQuery('[data-marker=adhoc]', task);
+
+        expect(haveSameCenterX(task, marker)).to.be.true;
+      })();
+    });
+  });
+
+
   it('should properly render connection markers (2)', function() {
     var xml = require('./BpmnRenderer.connection-colors.bpmn');
 
@@ -909,4 +971,14 @@ function isCollapsedSubProcess(element) {
     'bpmn:AdHocSubProcess',
     'bpmn:Transaction'
   ]) && !isExpanded(element);
+}
+
+function haveSameCenterX(element, element2) {
+  const bbox1 = element.getBoundingClientRect();
+  const bbox2 = element2.getBoundingClientRect();
+
+  const center1 = bbox1.left + (bbox1.width / 2);
+  const center2 = bbox2.left + (bbox2.width / 2);
+
+  return Math.abs(center1 - center2) < 3;
 }


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Center a task marker if it's the only marker on a task.

Correctly position multiple markers close to the center if there are multiple. We don't try to center all markers together, just put new markers to the sides of already existing ones, as close to the center as possible.

The tests are a little nilly-willy, cause there are too many combinations, so I mostly rely on manual testing.

![image](https://github.com/user-attachments/assets/c31e85ab-6ec8-4598-9a16-c283c8af0e7a)

Closes https://github.com/bpmn-io/bpmn-js/issues/1995 
Related to https://github.com/camunda/camunda-modeler/issues/4806

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
