### PR TITLE
feat: allow copy/paste between browser windows

### DIFF
--- a/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
@@ -1,0 +1,103 @@
+
+/**
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('../../model/Types').Moddle} Moddle
+ * @typedef {import('diagram-js/lib/features/clipboard/Clipboard').default} Clipboard
+ */
+
+import { isObject } from 'min-dash';
+
+/**
+ * Cross-window copy-paste
+ *
+ * @param {EventBus} eventBus
+ * @param {Moddle} moddle
+ * @param {Clipboard} clipboard
+ */
+export default function BpmnCrossWindowCopyPaste(
+    eventBus,
+    moddle,
+    clipboard
+) {
+    function testFunc() {
+        return true;
+    }
+
+    function createReviver(moddle) {
+
+        var elCache = {};
+
+        /**
+             * The actual reviewer that creates model instances
+             * for elements with a $type attribute.
+             *
+             * Elements with ids will be re-used, if already
+             * created.
+             *
+             * @param  {String} key
+             * @param  {Object} object
+             *
+             * @return {Object} actual element
+             */
+        return function (key, object) {
+
+            if (typeof object === 'object' && typeof object.$type === 'string') {
+
+                var objectId = object.id;
+
+                if (objectId && elCache[objectId]) {
+                    return elCache[objectId];
+                }
+
+                var type = object.$type;
+                var attrs = Object.assign({}, object);
+
+                delete attrs.$type;
+
+                var newEl = moddle.create(type, attrs);
+
+                if (objectId) {
+                    elCache[objectId] = newEl;
+                }
+
+                return newEl;
+            }
+
+            return object;
+        };
+    }
+
+    eventBus.on('copyPaste.elementsCopied', event => {
+        const { tree } = event;
+
+        navigator.clipboard.writeText(JSON.stringify(tree));
+    });
+
+    eventBus.on('canvas.focus.changed', event => {
+        const { focused } = event;
+        if (focused) {
+            navigator.clipboard.readText()
+                .then(text => {
+                    try {
+                        const parsedCopy = JSON.parse(text, createReviver(moddle));
+
+                        // checks if clipboard contents is a valid diagram object
+                        if (isObject(parsedCopy)) {
+
+                            // places diagram object into moddle clipboard.
+                            clipboard.set(parsedCopy);
+                        }
+                    } catch (error) { /* triggers when not valid JSON object due to JSON.parse */ }
+                })
+                .catch(err => {
+                    console.error('Failed to read clipboard contents: ', err);
+                });
+        }
+    });
+}
+
+BpmnCrossWindowCopyPaste.$inject = [
+    'eventBus',
+    'moddle',
+    'clipboard'
+];

--- a/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
@@ -19,9 +19,6 @@ export default function BpmnCrossWindowCopyPaste(
     moddle,
     clipboard
 ) {
-    function testFunc() {
-        return true;
-    }
 
     function createReviver(moddle) {
 

--- a/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
+++ b/lib/features/copy-paste/BpmnCrossWindowCopyPaste.js
@@ -1,4 +1,3 @@
-
 /**
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('../../model/Types').Moddle} Moddle
@@ -14,87 +13,79 @@ import { isObject } from 'min-dash';
  * @param {Moddle} moddle
  * @param {Clipboard} clipboard
  */
-export default function BpmnCrossWindowCopyPaste(
-    eventBus,
-    moddle,
-    clipboard
-) {
+export default function BpmnCrossWindowCopyPaste(eventBus, moddle, clipboard) {
+  function createReviver(moddle) {
+    var elCache = {};
 
-    function createReviver(moddle) {
+    /**
+     * The actual reviewer that creates model instances
+     * for elements with a $type attribute.
+     *
+     * Elements with ids will be re-used, if already
+     * created.
+     *
+     * @param  {String} key
+     * @param  {Object} object
+     *
+     * @return {Object} actual element
+     */
+    return function(key, object) {
+      if (typeof object === 'object' && typeof object.$type === 'string') {
+        var objectId = object.id;
 
-        var elCache = {};
-
-        /**
-             * The actual reviewer that creates model instances
-             * for elements with a $type attribute.
-             *
-             * Elements with ids will be re-used, if already
-             * created.
-             *
-             * @param  {String} key
-             * @param  {Object} object
-             *
-             * @return {Object} actual element
-             */
-        return function (key, object) {
-
-            if (typeof object === 'object' && typeof object.$type === 'string') {
-
-                var objectId = object.id;
-
-                if (objectId && elCache[objectId]) {
-                    return elCache[objectId];
-                }
-
-                var type = object.$type;
-                var attrs = Object.assign({}, object);
-
-                delete attrs.$type;
-
-                var newEl = moddle.create(type, attrs);
-
-                if (objectId) {
-                    elCache[objectId] = newEl;
-                }
-
-                return newEl;
-            }
-
-            return object;
-        };
-    }
-
-    eventBus.on('copyPaste.elementsCopied', event => {
-        const { tree } = event;
-
-        navigator.clipboard.writeText(JSON.stringify(tree));
-    });
-
-    eventBus.on('canvas.focus.changed', event => {
-        const { focused } = event;
-        if (focused) {
-            navigator.clipboard.readText()
-                .then(text => {
-                    try {
-                        const parsedCopy = JSON.parse(text, createReviver(moddle));
-
-                        // checks if clipboard contents is a valid diagram object
-                        if (isObject(parsedCopy)) {
-
-                            // places diagram object into moddle clipboard.
-                            clipboard.set(parsedCopy);
-                        }
-                    } catch (error) { /* triggers when not valid JSON object due to JSON.parse */ }
-                })
-                .catch(err => {
-                    console.error('Failed to read clipboard contents: ', err);
-                });
+        if (objectId && elCache[objectId]) {
+          return elCache[objectId];
         }
-    });
+
+        var type = object.$type;
+        var attrs = Object.assign({}, object);
+
+        delete attrs.$type;
+
+        var newEl = moddle.create(type, attrs);
+
+        if (objectId) {
+          elCache[objectId] = newEl;
+        }
+
+        return newEl;
+      }
+
+      return object;
+    };
+  }
+
+  eventBus.on('copyPaste.elementsCopied', (event) => {
+    const { tree } = event;
+
+    navigator.clipboard.writeText(JSON.stringify(tree));
+  });
+
+  eventBus.on('canvas.focus.changed', (event) => {
+    const { focused } = event;
+    if (focused) {
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          try {
+            const parsedCopy = JSON.parse(text, createReviver(moddle));
+
+            // checks if clipboard contents is a valid diagram object
+            if (isObject(parsedCopy)) {
+
+              // places diagram object into moddle clipboard.
+              clipboard.set(parsedCopy);
+            }
+          } catch (error) {
+
+            /* triggers when not valid JSON object due to JSON.parse */
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to read clipboard contents: ', err);
+        });
+    }
+  });
 }
 
-BpmnCrossWindowCopyPaste.$inject = [
-    'eventBus',
-    'moddle',
-    'clipboard'
-];
+BpmnCrossWindowCopyPaste.$inject = [ 'eventBus', 'moddle', 'clipboard' ];

--- a/lib/features/copy-paste/index.js
+++ b/lib/features/copy-paste/index.js
@@ -2,12 +2,14 @@ import CopyPasteModule from 'diagram-js/lib/features/copy-paste';
 
 import BpmnCopyPaste from './BpmnCopyPaste';
 import ModdleCopy from './ModdleCopy';
+import BpmnCrossWindowCopyPaste from './BpmnCrossWindowCopyPaste';
 
 export default {
   __depends__: [
     CopyPasteModule
   ],
-  __init__: [ 'bpmnCopyPaste', 'moddleCopy' ],
+  __init__: [ 'bpmnCopyPaste', 'moddleCopy', 'bpmnCrossWindowCopyPaste' ],
   bpmnCopyPaste: [ 'type', BpmnCopyPaste ],
-  moddleCopy: [ 'type', ModdleCopy ]
+  moddleCopy: [ 'type', ModdleCopy ],
+  bpmnCrossWindowCopyPaste: [ 'type', BpmnCrossWindowCopyPaste ]
 };

--- a/test/spec/features/copy-paste/BpmnCrossWindowCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCrossWindowCopyPasteSpec.js
@@ -1,70 +1,74 @@
-import {
-    inject,
-    bootstrapModeler,
-} from 'test/TestHelper';
+import { inject, bootstrapModeler } from 'test/TestHelper';
 
-import EventBus from 'diagram-js/lib/core/EventBus';
 import bpmnCrossWindowCopyPasteModule from 'lib/features/copy-paste/';
 import bpmnCopyPasteModule from 'lib/features/copy-paste';
 import copyPasteModule from 'diagram-js/lib/features/copy-paste';
 import coreModule from 'lib/core';
 import modelingModule from 'lib/features/modeling';
 
+describe('features/window-copy-paste', function() {
+  var testModules = [
+    bpmnCrossWindowCopyPasteModule,
+    bpmnCopyPasteModule,
+    copyPasteModule,
+    coreModule,
+    modelingModule,
+  ];
 
-describe.only('features/window-copy-paste', function () {
+  var basicXML = require('./basic.bpmn');
 
-    var testModules = [
-        bpmnCrossWindowCopyPasteModule,
-        bpmnCopyPasteModule,
-        copyPasteModule,
-        coreModule,
-        modelingModule
-    ];
+  beforeEach(
+    bootstrapModeler(basicXML, {
+      modules: testModules,
+    })
+  );
 
-    var basicXML = require('./basic.bpmn')
+  describe('revive string', function() {
+    it('should pass with valid JSON', inject(function(
+        elementRegistry,
+        moddle,
+        copyPaste,
+        clipboard,
+        eventBus
+    ) {
 
-    beforeEach(bootstrapModeler(basicXML, {
-        modules: testModules
+      // create event
+      var startEvent = elementRegistry.get('StartEvent_1');
+      copyPaste.copy(startEvent);
+
+      setTimeout(function() {
+        eventBus.fire('canvas.focus.changed', {
+          focused: true,
+        });
+      }, 1000);
+
+      // wait for 1 second to ensure clipboard is set
+      setTimeout(function() {
+        var revived = clipboard.get();
+
+        expect(revived).to.equal(startEvent);
+      }, 1000);
     }));
+  });
 
-    describe('revive string', function () {
+  // Test copy/paste into system cliboard
+  describe('copy/paste into system clipboard', function() {
+    it('should copy into system clipboard', inject(function(
+        elementRegistry,
+        copyPaste
+    ) {
 
-        it('should pass with valid JSON', inject(function (elementRegistry, moddle, copyPaste, clipboard, eventBus) {
+      // create mock JSON string
+      var startEvent = elementRegistry.get('StartEvent_1'),
+          mockString = JSON.stringify(startEvent);
 
-            // create event
-            var startEvent = elementRegistry.get('StartEvent_1'),
-                mockString = JSON.stringify(startEvent);
+      // triggers copy event, which triggers system copy.
+      copyPaste.copy(startEvent);
 
-            copyPaste.copy(startEvent);
-
-            eventBus.fire('canvas.focus.changed', {
-                focused: true
-            });
-
-            //wait for 1 second to ensure clipboard is set
-            setTimeout(function () {
-                var revived = clipboard.get();
-
-                expect(revived).to.equal(startEvent);
-            }, 1000);
-        }));
-    });
-
-    // Test copy/paste into system cliboard
-    describe('copy/paste into system clipboard', function () {
-
-        it('should copy into system clipboard', inject(function (elementRegistry, copyPaste) {
-
-            // create mock JSON string
-            var startEvent = elementRegistry.get('StartEvent_1'),
-                mockString = JSON.stringify(startEvent);
-
-            // triggers copy event, which triggers system copy.
-            copyPaste.copy(startEvent);
-
-            // checks that system copy is identical to the input string.
-            navigator.clipboard.readText().then(text => { expect(text).to.equal(mockString); });
-        }));
-
-    });
+      // checks that system copy is identical to the input string.
+      navigator.clipboard.readText().then((text) => {
+        expect(text).to.equal(mockString);
+      });
+    }));
+  });
 });

--- a/test/spec/features/copy-paste/BpmnCrossWindowCopyPasteSpec.js
+++ b/test/spec/features/copy-paste/BpmnCrossWindowCopyPasteSpec.js
@@ -1,0 +1,70 @@
+import {
+    inject,
+    bootstrapModeler,
+} from 'test/TestHelper';
+
+import EventBus from 'diagram-js/lib/core/EventBus';
+import bpmnCrossWindowCopyPasteModule from 'lib/features/copy-paste/';
+import bpmnCopyPasteModule from 'lib/features/copy-paste';
+import copyPasteModule from 'diagram-js/lib/features/copy-paste';
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+
+
+describe.only('features/window-copy-paste', function () {
+
+    var testModules = [
+        bpmnCrossWindowCopyPasteModule,
+        bpmnCopyPasteModule,
+        copyPasteModule,
+        coreModule,
+        modelingModule
+    ];
+
+    var basicXML = require('./basic.bpmn')
+
+    beforeEach(bootstrapModeler(basicXML, {
+        modules: testModules
+    }));
+
+    describe('revive string', function () {
+
+        it('should pass with valid JSON', inject(function (elementRegistry, moddle, copyPaste, clipboard, eventBus) {
+
+            // create event
+            var startEvent = elementRegistry.get('StartEvent_1'),
+                mockString = JSON.stringify(startEvent);
+
+            copyPaste.copy(startEvent);
+
+            eventBus.fire('canvas.focus.changed', {
+                focused: true
+            });
+
+            //wait for 1 second to ensure clipboard is set
+            setTimeout(function () {
+                var revived = clipboard.get();
+
+                expect(revived).to.equal(startEvent);
+            }, 1000);
+        }));
+    });
+
+    // Test copy/paste into system cliboard
+    describe('copy/paste into system clipboard', function () {
+
+        it('should copy into system clipboard', inject(function (elementRegistry, copyPaste) {
+
+            // create mock JSON string
+            var startEvent = elementRegistry.get('StartEvent_1'),
+                mockString = JSON.stringify(startEvent);
+
+            // triggers copy event, which triggers system copy.
+            copyPaste.copy(startEvent);
+
+            // checks that system copy is identical to the input string.
+            navigator.clipboard.readText().then(text => { expect(text).to.equal(mockString); });
+        }));
+
+    });
+});


### PR DESCRIPTION
added ability to copy and paste bpmn elemtents between browser window or different applications using the systems clipboard

implementation based on [this](https://forum.bpmn.io/t/contributing-as-part-of-the-informaticup-2025/14510/13?u=fabian1)

closes https://github.com/bpmn-io/bpmn-js/issues/1709