### PR TITLE
WiP feat: link external label with its parent

### DIFF
--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -26,6 +26,7 @@ import InteractionEventsModule from './features/interaction-events';
 import KeyboardModule from './features/keyboard';
 import KeyboardMoveSelectionModule from 'diagram-js/lib/features/keyboard-move-selection';
 import LabelEditingModule from './features/label-editing';
+import LabelLink from './features/label-link';
 import ModelingModule from './features/modeling';
 import ModelingFeedbackModule from './features/modeling-feedback';
 import MoveModule from 'diagram-js/lib/features/move';
@@ -181,6 +182,7 @@ Modeler.prototype._modelingModules = [
   KeyboardModule,
   KeyboardMoveSelectionModule,
   LabelEditingModule,
+  LabelLink,
   ModelingModule,
   ModelingFeedbackModule,
   MoveModule,

--- a/lib/features/label-link/LabelLink.js
+++ b/lib/features/label-link/LabelLink.js
@@ -1,0 +1,79 @@
+import { createLine } from 'diagram-js/lib/util/RenderUtil';
+import { queryAll as domQueryAll } from 'min-dom';
+import {
+  append as svgAppend,
+  remove as svgRemove
+} from 'tiny-svg';
+
+import { is, isAny } from '../modeling/util/ModelingUtil';
+
+/**
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('diagram-js/lib/core/Canvas').default} Canvas
+ */
+
+/**
+ * @param {EventBus} eventBus
+ * @param {Canvas} canvas
+ */
+export default function LabelLink(eventBus, canvas) {
+
+  // TODO: The links are not shown in subprocesses. Find the proper layer.
+  const defaultLayer = canvas.getDefaultLayer();
+
+  eventBus.on('selection.changed', function({ newSelection }) {
+
+    removeAllLinks(defaultLayer);
+
+    newSelection
+      .filter(element => isAny(element, [ 'bpmn:Event', 'bpmn:SequenceFlow' ]))
+
+      // when both label and target are selected
+      .filter(element => !newSelection.some(i => i.labelTarget === element))
+      .forEach(element => {
+
+        const target = element.labelTarget || element.labels[0];
+
+        if (!target) return;
+
+        const points = [
+          getMiddle(element),
+          getMiddle(target)
+        ];
+
+        const line = createLine(
+          points,
+          {
+            class: 'bjs-label-link',
+            stroke: 'hsl(225, 10%, 15%)',
+            strokeDasharray: '1, 5'
+          }
+        );
+
+        svgAppend(defaultLayer, line);
+
+      });
+  });
+}
+
+LabelLink.$inject = [ 'eventBus', 'canvas' ];
+
+// TODO: Works kinda weird with complicated sequence flows.
+function getMiddle(element) {
+  if (is(element, 'bpmn:SequenceFlow') && element.waypoints) {
+    return {
+      x: (element.waypoints[0].x + element.waypoints[1].x) / 2,
+      y: (element.waypoints[0].y + element.waypoints[1].y) / 2,
+    };
+  }
+
+  return {
+    x: element.x + element.width / 2,
+    y: element.y + element.height / 2
+  };
+}
+
+function removeAllLinks(contaienr) {
+  const links = domQueryAll('.bjs-label-link', contaienr);
+  links.forEach(svgRemove);
+}

--- a/lib/features/label-link/index.js
+++ b/lib/features/label-link/index.js
@@ -1,0 +1,12 @@
+import SelectionModule from 'diagram-js/lib/features/selection';
+import LabelLink from './LabelLink';
+
+export default {
+  __depends__: [
+    SelectionModule
+  ],
+  __init__: [
+    'labelLink'
+  ],
+  labelLink: [ 'type', LabelLink ]
+};

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -621,6 +621,7 @@ describe('Modeler', function() {
         expect(modeler.get('keyboard')).to.exist;
         expect(modeler.get('keyboardMoveSelection')).to.exist;
         expect(modeler.get('labelEditingProvider')).to.exist;
+        expect(modeler.get('labelLink')).to.exist;
         expect(modeler.get('modeling')).to.exist;
         expect(modeler.get('move')).to.exist;
         expect(modeler.get('paletteProvider')).to.exist;


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/369

### Proposed Changes

Show a dotted link between an external label and its parent when it's selected.

![link-labels](https://github.com/user-attachments/assets/02c67dfa-6fef-423d-967a-1fc711d444ed)

### To do

- [ ] Find the proper layer to draw the lines on for non-root planes (e.g. expanded subprocesses)
- [ ] Find a better "middle point" for sequence flows with complicated shapes (not a straight line)
- [ ] Add tests
- [ ] Make the line more delicate

### Try

Run `npm start` on this branch and try it out.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
