### PR TITLE
Rules for non-interrupting StartEvents

### DIFF
--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -584,6 +584,11 @@ function canDrop(element, target) {
     return true;
   }
 
+  // allow non-interrupting start-events only in event sub processes
+  if (is(element, 'bpmn:StartEvent') &&
+          !isInterrupting(element)) {
+    return isEventSubProcess(target);
+  }
 
   // disallow to create elements on collapsed pools
   if (is(target, 'bpmn:Participant') && !isExpanded(target)) {
@@ -849,8 +854,7 @@ function canReplace(elements, target, position) {
     if (!isEventSubProcess(target)) {
 
       if (is(element, 'bpmn:StartEvent') &&
-          element.type !== 'label' &&
-          canDrop(element, target)) {
+          element.type !== 'label') {
 
         // replace a non-interrupting start event by a blank interrupting start event
         // when the target is not an event sub process
@@ -861,31 +865,34 @@ function canReplace(elements, target, position) {
           });
         }
 
-        // replace an error/escalation/compensate start event by a blank interrupting start event
-        // when the target is not an event sub process
-        if (hasErrorEventDefinition(element) ||
+        if (canDrop(element, target)) {
+
+          // replace an error/escalation/compensate start event by a blank interrupting start event
+          // when the target is not an event sub process
+          if (hasErrorEventDefinition(element) ||
             hasEscalationEventDefinition(element) ||
             hasCompensateEventDefinition(element)) {
-          canExecute.replacements.push({
-            oldElementId: element.id,
-            newElementType: 'bpmn:StartEvent'
-          });
-        }
+            canExecute.replacements.push({
+              oldElementId: element.id,
+              newElementType: 'bpmn:StartEvent'
+            });
+          }
 
-        // replace a typed start event by a blank interrupting start event
-        // when the target is a sub process but not an event sub process
-        if (hasOneOfEventDefinitions(element,
-          [
-            'bpmn:MessageEventDefinition',
-            'bpmn:TimerEventDefinition',
-            'bpmn:SignalEventDefinition',
-            'bpmn:ConditionalEventDefinition'
-          ]) &&
+          // replace a typed start event by a blank interrupting start event
+          // when the target is a sub process but not an event sub process
+          if (hasOneOfEventDefinitions(element,
+            [
+              'bpmn:MessageEventDefinition',
+              'bpmn:TimerEventDefinition',
+              'bpmn:SignalEventDefinition',
+              'bpmn:ConditionalEventDefinition'
+            ]) &&
             is(target, 'bpmn:SubProcess')) {
-          canExecute.replacements.push({
-            oldElementId: element.id,
-            newElementType: 'bpmn:StartEvent'
-          });
+            canExecute.replacements.push({
+              oldElementId: element.id,
+              newElementType: 'bpmn:StartEvent'
+            });
+          }
         }
       }
     }

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1894,6 +1894,55 @@ describe('features/modeling/rules - BpmnRules', function() {
   });
 
 
+  describe('non-interrupting start events', function() {
+    var testXML = require('./BpmnRules.process.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+    it('should not create on Process', inject(function(elementFactory) {
+
+      // given
+      var nonInterruptingMessageStartEvent = elementFactory.createShape({
+        type: 'bpmn:StartEvent',
+        eventDefinitionType: 'bpmn:MessageEventDefinition',
+        isInterrupting: false
+      });
+
+      // then
+      expectCanCreate(nonInterruptingMessageStartEvent, 'Process', false);
+    }));
+
+
+    it('should not create on SubProcess', inject(function(elementFactory) {
+
+      // given
+      var nonInterruptingMessageStartEvent = elementFactory.createShape({
+        type: 'bpmn:StartEvent',
+        eventDefinitionType: 'bpmn:MessageEventDefinition',
+        isInterrupting: false
+      });
+
+      // then
+      expectCanCreate(nonInterruptingMessageStartEvent, 'SubProcess', false);
+    }));
+
+
+    it('should create on EventSubProcess', inject(function(elementFactory) {
+
+      // given
+      var nonInterruptingMessageStartEvent = elementFactory.createShape({
+        type: 'bpmn:StartEvent',
+        eventDefinitionType: 'bpmn:MessageEventDefinition',
+        isInterrupting: false
+      });
+
+      // then
+      expectCanCreate(nonInterruptingMessageStartEvent, 'EventSubProcess', true);
+    }));
+
+  });
+
+
   describe('lanes', function() {
 
     var testXML = require('./BpmnRules.collaboration-lanes.bpmn');


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js-create-append-anything/issues/4

### Proposed Changes

Only allow non-interrupting start-events on event subprocesses. If you try to move the start event out of the event subprocess it gets replaced with a normal none start event.

### Try Out
```
npx @bpmn-io/sr bpmn-io/bpmn-js-create-append-anything#non-interrupting-start-events -l bpmn-io/bpmn-js#rules-for-non-interrupting-start-events
```
<img width="575" alt="image" src="https://github.com/user-attachments/assets/11c7d8c3-929c-4782-ac32-31ca54a14d83" />

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
