### PR TITLE
chore: remove redundant eslintrc

### DIFF
--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "globals": {
-    "sinon": true
-  }
-}


### PR DESCRIPTION
### Proposed Changes

It looks that we forgot to remove it in the eslint@9 migration.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
