### PR TITLE
wip: fix missing null check that blocks multi-tab copy-paste

### DIFF
--- a/lib/features/copy-paste/ModdleCopy.js
+++ b/lib/features/copy-paste/ModdleCopy.js
@@ -276,6 +276,10 @@ ModdleCopy.prototype._copyId = function(id, element, clone = false) {
 // helpers //////////
 
 export function getPropertyNames(descriptor, keepDefaultProperties) {
+  if (!descriptor?.properties) {
+    return [];
+  }
+
   return reduce(descriptor.properties, (properties, property) => {
 
     if (keepDefaultProperties && property.default) {


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

⚠️ Adds a condition to avoid breaking the library during a multi-tab copy-paste

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
