### PR TITLE
1513 dynamic resizing labels

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1076,8 +1076,8 @@ export default function BpmnRenderer(
 
   function renderExternalLabel(parentGfx, element, attrs = {}) {
     var box = {
-      width: 90,
-      height: 30,
+      width: element.width,
+      height: element.height,
       x: element.width / 2 + element.x,
       y: element.height / 2 + element.y
     };

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1039,10 +1039,17 @@ export default function BpmnRenderer(
   }
 
   function renderLabel(parentGfx, label, attrs = {}) {
+
+    // additional Padding for left and right to stabilize the rendering
     attrs = assign({
       size: {
         width: 100
-      }
+      }, padding: {
+        top: 0,
+        left: -2,
+        right: -2,
+        bottom: 0
+      },
     }, attrs);
 
     var text = textRenderer.createText(label || '', attrs);
@@ -2307,6 +2314,11 @@ export default function BpmnRenderer(
       return task;
     },
     'label': function(parentGfx, element, attrs = {}) {
+      if (element.correctBounds) {
+        changeBounds(element.correctBounds, element);
+        element.correctBounds = undefined;
+      }
+
       return renderExternalLabel(parentGfx, element, attrs);
     }
   };
@@ -2417,4 +2429,11 @@ function pickAttrs(attrs, keys = []) {
 
     return pickedAttrs;
   }, {});
+}
+
+function changeBounds(newBounds, element) {
+  element.x = newBounds.x;
+  element.y = newBounds.y;
+  element.width = newBounds.width;
+  element.height = newBounds.height;
 }

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -65,6 +65,7 @@ import {
 import { Ids } from 'ids';
 
 import { black } from './BpmnRenderUtil';
+import { measureTextLines } from '../features/modeling/BpmnUpdater';
 
 var markerIds = new Ids();
 
@@ -1044,11 +1045,6 @@ export default function BpmnRenderer(
     attrs = assign({
       size: {
         width: 100
-      }, padding: {
-        top: 0,
-        left: -2,
-        right: -2,
-        bottom: 0
       },
     }, attrs);
 
@@ -1092,6 +1088,12 @@ export default function BpmnRenderer(
     return renderLabel(parentGfx, getLabel(element), {
       box: box,
       fitBox: true,
+      padding: {
+        top: 0,
+        left: -2,
+        right: -2,
+        bottom: 0
+      },
       style: assign(
         {},
         textRenderer.getExternalStyle(),
@@ -2173,6 +2175,10 @@ export default function BpmnRenderer(
       return renderTask(parentGfx, element, attrs);
     },
     'bpmn:TextAnnotation': function(parentGfx, element, attrs = {}) {
+      if (element.correctBounds) {
+        changeBounds(element.correctBounds, element);
+        element.correctBounds = undefined;
+      }
       attrs = pickAttrs(attrs, [
         'fill',
         'stroke',
@@ -2184,11 +2190,33 @@ export default function BpmnRenderer(
         width,
         height
       } = getBounds(element, attrs);
-
+      width = Math.ceil(width / 20) * 20;
       var textElement = drawRect(parentGfx, width, height, 0, 0, {
         fill: 'none',
         stroke: 'none'
       });
+
+      var semantic = getSemantic(element),
+          text = semantic.get('text') || '';
+      var renderedLabel = renderLabel(parentGfx, text, {
+        align: 'left-top',
+        box: getBounds(element, attrs),
+        padding: {
+          top: 2,
+          left: +2,
+          right: +5,
+          bottom: 0
+        },
+        style: {
+          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
+        }
+      });
+
+      height = getTextHeightForTextAnnotation(renderedLabel);
+      textElement.setAttribute('height', height);
+      width = getTextWidthForTextAnnotation(renderedLabel, width);
+      element.width = width;
+      textElement.setAttribute('width', width);
 
       var textPathData = pathMap.getScaledPath('TEXT_ANNOTATION', {
         xScaleFactor: 1,
@@ -2204,19 +2232,6 @@ export default function BpmnRenderer(
       drawPath(parentGfx, textPathData, {
         stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
-
-      var semantic = getSemantic(element),
-          text = semantic.get('text') || '';
-
-      renderLabel(parentGfx, text, {
-        align: 'left-top',
-        box: getBounds(element, attrs),
-        padding: 7,
-        style: {
-          fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor, attrs.stroke)
-        }
-      });
-
       return textElement;
     },
     'bpmn:Transaction': function(parentGfx, element, attrs = {}) {
@@ -2436,4 +2451,39 @@ function changeBounds(newBounds, element) {
   element.y = newBounds.y;
   element.width = newBounds.width;
   element.height = newBounds.height;
+}
+
+
+function getTextHeightForTextAnnotation(text) {
+  return Math.max(text.lastChild.y.animVal[0].value, 30) + 10;
+}
+
+function getTextWidthForTextAnnotation(text, width) {
+
+  if ((text.textContent === '')) {
+    return 100;
+  }
+
+  let lineLengths = Array.from(measureTextLines(text.textContent, getStyleFromTextannotation(text), width + 5, true))
+    .map(elem => elem.width);
+
+  return Math.round(Math.max(...lineLengths));
+}
+
+function getStyleFromTextannotation(text) {
+  const styleString = text.attributes.style.nodeValue;
+
+  let style = Object.fromEntries(
+    styleString
+      .split(';')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(part => {
+        const [ key, value ] = part.split(':').map(s => s.trim());
+        return [ key, value ];
+      })
+  );
+  style['lineHeight'] = text.attributes.lineHeight.nodeValue;
+
+  return style;
 }

--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -16,7 +16,10 @@ import {
 
 import {
   getLabel,
-  isLabel
+  isLabel,
+  getTextWidthForTextAnnotation,
+  changeBounds,
+  getTextAnnotationHeightFromElement,
 } from '../util/LabelUtil';
 
 import {
@@ -65,7 +68,6 @@ import {
 import { Ids } from 'ids';
 
 import { black } from './BpmnRenderUtil';
-import { measureTextLines } from '../features/modeling/BpmnUpdater';
 
 var markerIds = new Ids();
 
@@ -2212,7 +2214,7 @@ export default function BpmnRenderer(
         }
       });
 
-      height = getTextHeightForTextAnnotation(renderedLabel);
+      height = getTextAnnotationHeightFromElement(renderedLabel);
       textElement.setAttribute('height', height);
       width = getTextWidthForTextAnnotation(renderedLabel, width);
       element.width = width;
@@ -2444,46 +2446,4 @@ function pickAttrs(attrs, keys = []) {
 
     return pickedAttrs;
   }, {});
-}
-
-function changeBounds(newBounds, element) {
-  element.x = newBounds.x;
-  element.y = newBounds.y;
-  element.width = newBounds.width;
-  element.height = newBounds.height;
-}
-
-
-function getTextHeightForTextAnnotation(text) {
-  return Math.max(text.lastChild.y.animVal[0].value, 30) + 10;
-}
-
-function getTextWidthForTextAnnotation(text, width) {
-
-  if ((text.textContent === '')) {
-    return 100;
-  }
-
-  let lineLengths = Array.from(measureTextLines(text.textContent, getStyleFromTextannotation(text), width + 5, true))
-    .map(elem => elem.width);
-
-  return Math.round(Math.max(...lineLengths));
-}
-
-function getStyleFromTextannotation(text) {
-  const styleString = text.attributes.style.nodeValue;
-
-  let style = Object.fromEntries(
-    styleString
-      .split(';')
-      .map(part => part.trim())
-      .filter(Boolean)
-      .map(part => {
-        const [ key, value ] = part.split(':').map(s => s.trim());
-        return [ key, value ];
-      })
-  );
-  style['lineHeight'] = text.attributes.lineHeight.nodeValue;
-
-  return style;
 }

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -228,7 +228,8 @@ LabelEditingProvider.prototype.activate = function(element) {
   // external labels
   if (isLabelExternal(element)) {
     assign(options, {
-      autoResize: true
+      resizable: true,
+      autoResize: true,
     });
 
     // keep background and border for external labels
@@ -393,7 +394,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
     });
   }
 
-  var width = 90 * zoom,
+  var width = Math.max(90 * zoom, bbox.width),
       paddingTop = 7 * zoom,
       paddingBottom = 4 * zoom;
 

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -394,7 +394,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
     });
   }
 
-  var width = 90 * zoom,
+  var width = bbox.width + 10 * zoom,
       paddingTop = 7 * zoom,
       paddingBottom = 4 * zoom;
 
@@ -403,7 +403,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
     assign(bounds, {
       width: width,
       height: bbox.height + paddingTop + paddingBottom,
-      x: mid.x - width / 2,
+      x: bbox.x,
       y: bbox.y - paddingTop
     });
 

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -394,6 +394,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
     });
   }
 
+  // making sure that editing box is correct
   var width = bbox.width + 10 * zoom,
       paddingTop = 7 * zoom,
       paddingBottom = 4 * zoom;

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -394,7 +394,7 @@ LabelEditingProvider.prototype.getEditingBBox = function(element) {
     });
   }
 
-  var width = Math.max(90 * zoom, bbox.width),
+  var width = 90 * zoom,
       paddingTop = 7 * zoom,
       paddingBottom = 4 * zoom;
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -217,8 +217,7 @@ export default function BpmnUpdater(
     }
     let renderedLabelHeight = getTextHeightForLabel(event),
         renderedLabelWidth = getTextWidthForLabel(event);
-    if (hasDiff(element, renderedLabelHeight, renderedLabelWidth) &&
-        hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 4)) {
+    if (hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 4)) {
       return true;
     }
 
@@ -245,10 +244,6 @@ export default function BpmnUpdater(
     return Array.from(gfx.firstChild.firstChild.children)
       .map(child => child.textContent)
       .join('');
-  }
-
-  function hasDiff(element, height, width) {
-    return ((element.width + 1) !== width || (element.height + 1) !== height);
   }
 
   function hasMoreDiffThan(element, height, width, padding) {
@@ -496,37 +491,6 @@ BpmnUpdater.prototype.updateBounds = function(shape) {
     y: shape.y,
     width: shape.width,
     height: shape.height
-  });
-};
-
-
-BpmnUpdater.prototype.updateBoundsCoords = function(shape) {
-
-  var di = getDi(shape),
-      embeddedLabelBounds = getEmbeddedLabelBounds(shape);
-
-  // update embedded label bounds if possible
-  if (embeddedLabelBounds) {
-    var embeddedLabelBoundsDelta = delta(embeddedLabelBounds, di.get('bounds'));
-
-    assign(embeddedLabelBounds, {
-      x: shape.x + embeddedLabelBoundsDelta.x,
-      y: shape.y + embeddedLabelBoundsDelta.y
-    });
-  }
-
-  var target = isLabel(shape) ? this._getLabel(di) : di;
-
-  var bounds = target.bounds;
-
-  if (!bounds) {
-    bounds = this._bpmnFactory.createDiBounds();
-    target.set('bounds', bounds);
-  }
-
-  assign(bounds, {
-    x: shape.x,
-    y: shape.y
   });
 };
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -185,36 +185,16 @@ export default function BpmnUpdater(
 
   // Handle labels separately. This is necessary, because the label bounds have to be updated
   // every time its shape changes, not only on move, create and resize.
+
   eventBus.on('shape.changed', function(event) {
     if (event.element.type === 'label') {
-      const element = event.element,
-            currentlabel = getLabel(element).replaceAll(' ', ''),
-            gfxLabel = getGfxLabel(event.gfx, currentlabel).replaceAll(' ', '');
-
-      let renderedLabelHeight = getTextHeightForLabel(event),
-          renderedLabelWidth = getTextWidthForLabel(event);
-      if ((currentlabel !== gfxLabel) && (element.width > renderedLabelWidth || element.height > renderedLabelHeight)) {
-
-        // handles the height difference of new rendered Text
-        event.element.height = renderedLabelHeight;
-        event.element.width = renderedLabelWidth;
-        updateBounds({ context: { shape: event.element } });
-      } else {
-        if (((element.width + 1) !== renderedLabelWidth || (element.height + 1) !== renderedLabelHeight)) {
-
-          if (Math.abs(element.width - renderedLabelWidth) > 11 || Math.abs(element.height - renderedLabelHeight) > 11) {
-            event.element.height = renderedLabelHeight;
-            event.element.width = renderedLabelWidth;
-          }
-          updateBounds({ context: { shape: event.element } });
-        } else {
-          self.updateBoundsCoords(event.element);
-
-          return;
-        }
-        return;
+      if (canHandleLabelResize(event)) {
+        event.element.height = getTextHeightForLabel(event);
+        event.element.width = getTextWidthForLabel(event);
       }
+      updateBounds({ context: { shape: event.element } });
     }
+
 
     // handles height difference for TextAnnotations
     if (event.element.type === 'bpmn:TextAnnotation') {
@@ -223,6 +203,29 @@ export default function BpmnUpdater(
       eventBus.fire('connection.changed', { gfx: event.gfx, element: event.element });
     }
   });
+
+
+  function canHandleLabelResize(event) {
+    const element = event.element,
+
+          currentlabel = getLabel(element),
+
+          renderedLabel = getGfxLabel(event.gfx, currentlabel);
+
+    if (currentlabel !== renderedLabel) {
+      return true;
+    }
+    let renderedLabelHeight = getTextHeightForLabel(event),
+        renderedLabelWidth = getTextWidthForLabel(event);
+    if (hasDiff(element, renderedLabelHeight, renderedLabelWidth) &&
+        hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 4)) {
+      return true;
+    }
+
+    return false;
+
+
+  }
 
   function getTextHeightForTextAnnotation(event) {
     return event.gfx.firstChild.lastChild.lastChild.y.animVal[0].value;
@@ -238,10 +241,18 @@ export default function BpmnUpdater(
     return Math.round(Math.max(...lineLengths));
   }
 
-  function getGfxLabel(gfx, currentLabel) {
+  function getGfxLabel(gfx) {
     return Array.from(gfx.firstChild.firstChild.children)
       .map(child => child.textContent)
       .join('');
+  }
+
+  function hasDiff(element, height, width) {
+    return ((element.width + 1) !== width || (element.height + 1) !== height);
+  }
+
+  function hasMoreDiffThan(element, height, width, padding) {
+    return Math.abs(element.width - width) > padding || Math.abs(element.height - height) > padding;
   }
 
   // attach / detach connection
@@ -478,12 +489,6 @@ BpmnUpdater.prototype.updateBounds = function(shape) {
   if (!bounds) {
     bounds = this._bpmnFactory.createDiBounds();
     target.set('bounds', bounds);
-  }
-  if (shape.oldBounds) {
-    let oldBounds = shape.oldBounds;
-    shape.x = oldBounds.x;
-    shape.y = oldBounds.y;
-    shape.oldBounds = undefined;
   }
 
   assign(bounds, {

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -19,6 +19,7 @@ import {
 import { isAny } from './util/ModelingUtil';
 
 import {
+  DEFAULT_LABEL_SIZE,
   getLabel,
   isLabel,
   isLabelExternal
@@ -61,6 +62,8 @@ export default function BpmnUpdater(
   this._bpmnFactory = bpmnFactory;
 
   var self = this;
+
+  var textPadding = 2;
 
 
   // connection cropping //////////////////////
@@ -189,9 +192,16 @@ export default function BpmnUpdater(
     if (event.element.type === 'label') {
 
       // handles the height difference of new rendered Text
-      event.element.height = Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + 2);
-
+      event.element.height = Math.max(Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + textPadding), DEFAULT_LABEL_SIZE.height);
       updateBounds({ context: { shape: event.element } });
+    }
+
+    // handles height difference for TextAnnotations
+    if (event.element.type === 'bpmn:TextAnnotation') {
+      var currentHeight = Math.max(Math.ceil(event.gfx.firstChild.lastChild.lastChild.y.animVal[0].value + textPadding), 30);
+      event.element.height = currentHeight;
+      updateBounds({ context: { shape: event.element } });
+      eventBus.fire('connection.changed', { gfx: event.gfx, element: event.element });
     }
   });
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -1062,7 +1062,6 @@ export function measureTextLines(text, style, maxWidth, isTextAnnotation) {
     const line = layoutNext(lines, maxWidth, helperText, isTextAnnotation);
     results.push(line);
   }
-  console.log(results);
 
   svgRemove(helperText);
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -19,7 +19,6 @@ import {
 import { isAny } from './util/ModelingUtil';
 
 import {
-  DEFAULT_LABEL_SIZE,
   getLabel,
   isLabel,
   isLabelExternal
@@ -192,18 +191,25 @@ export default function BpmnUpdater(
     if (event.element.type === 'label') {
 
       // handles the height difference of new rendered Text
-      event.element.height = Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + textPadding);
+      event.element.height = Math.ceil(getTextHeightForLabel(event) + textPadding);
       updateBounds({ context: { shape: event.element } });
     }
 
     // handles height difference for TextAnnotations
     if (event.element.type === 'bpmn:TextAnnotation') {
-      var currentHeight = Math.max(Math.ceil(event.gfx.firstChild.lastChild.lastChild.y.animVal[0].value + textPadding), 30);
-      event.element.height = currentHeight;
+      event.element.height = Math.max(Math.ceil(getTextHeightForTextAnnotation(event) + textPadding), 30);
       updateBounds({ context: { shape: event.element } });
       eventBus.fire('connection.changed', { gfx: event.gfx, element: event.element });
     }
   });
+
+  function getTextHeightForTextAnnotation(event) {
+    return event.gfx.firstChild.lastChild.lastChild.y.animVal[0].value;
+  }
+
+  function getTextHeightForLabel(event) {
+    return event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value;
+  }
 
   // attach / detach connection
   function updateConnection(e) {

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -62,8 +62,6 @@ export default function BpmnUpdater(
 
   var self = this;
 
-  var textPadding = 3.5;
-
 
   // connection cropping //////////////////////
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -187,6 +187,10 @@ export default function BpmnUpdater(
   // every time its shape changes, not only on move, create and resize.
   eventBus.on('shape.changed', function(event) {
     if (event.element.type === 'label') {
+
+      // handles the height difference of new rendered Text
+      event.element.height = Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + 2);
+
       updateBounds({ context: { shape: event.element } });
     }
   });

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -189,15 +189,38 @@ export default function BpmnUpdater(
   // every time its shape changes, not only on move, create and resize.
   eventBus.on('shape.changed', function(event) {
     if (event.element.type === 'label') {
+      const element = event.element,
+            currentlabel = getLabel(element).replaceAll(' ', ''),
+            gfxLabel = getGfxLabel(event.gfx, currentlabel).replaceAll(' ', '');
 
-      // handles the height difference of new rendered Text
-      event.element.height = Math.ceil(getTextHeightForLabel(event) + textPadding);
-      updateBounds({ context: { shape: event.element } });
+      let renderedLabelHeight = getTextHeightForLabel(event),
+          renderedLabelWidth = getTextWidthForLabel(event);
+      if ((currentlabel !== gfxLabel) && (element.width > renderedLabelWidth || element.height > renderedLabelHeight)) {
+
+        // handles the height difference of new rendered Text
+        event.element.height = renderedLabelHeight;
+        event.element.width = renderedLabelWidth;
+        updateBounds({ context: { shape: event.element } });
+      } else {
+        if (((element.width + 1) !== renderedLabelWidth || (element.height + 1) !== renderedLabelHeight)) {
+
+          if (Math.abs(element.width - renderedLabelWidth) > 11 || Math.abs(element.height - renderedLabelHeight) > 11) {
+            event.element.height = renderedLabelHeight;
+            event.element.width = renderedLabelWidth;
+          }
+          updateBounds({ context: { shape: event.element } });
+        } else {
+          self.updateBoundsCoords(event.element);
+
+          return;
+        }
+        return;
+      }
     }
 
     // handles height difference for TextAnnotations
     if (event.element.type === 'bpmn:TextAnnotation') {
-      event.element.height = Math.max(Math.ceil(getTextHeightForTextAnnotation(event) + textPadding), 30);
+      event.element.height = Math.max(Math.round(getTextHeightForTextAnnotation(event)), 30);
       updateBounds({ context: { shape: event.element } });
       eventBus.fire('connection.changed', { gfx: event.gfx, element: event.element });
     }
@@ -208,7 +231,19 @@ export default function BpmnUpdater(
   }
 
   function getTextHeightForLabel(event) {
-    return event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value;
+    return Math.max(Math.round(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value), 15);
+  }
+
+  function getTextWidthForLabel(event) {
+    let lineLengths = Array.from(event.gfx.firstChild.firstChild.children)
+      .map(child => child.textLength.baseVal.value);
+    return Math.round(Math.max(...lineLengths));
+  }
+
+  function getGfxLabel(gfx, currentLabel) {
+    return Array.from(gfx.firstChild.firstChild.children)
+      .map(child => child.textContent)
+      .join('');
   }
 
   // attach / detach connection
@@ -316,12 +351,20 @@ export default function BpmnUpdater(
 
   function updateBPMNLabel(event) {
     const { element } = event.context,
-          label = getLabel(element);
+          label = getLabel(element),
+          newBounds = event.context.newBounds;
     const di = getDi(element),
           diLabel = di && di.get('label');
 
     if (isLabelExternal(element) || isPlane(element)) {
       return;
+    }
+
+    if (newBounds) {
+      element.x = newBounds.x;
+      element.y = newBounds.y;
+      element.width = newBounds.width;
+      element.height = newBounds.height;
     }
 
     if (label && !diLabel) {
@@ -438,12 +481,49 @@ BpmnUpdater.prototype.updateBounds = function(shape) {
     bounds = this._bpmnFactory.createDiBounds();
     target.set('bounds', bounds);
   }
+  if (shape.oldBounds) {
+    let oldBounds = shape.oldBounds;
+    shape.x = oldBounds.x;
+    shape.y = oldBounds.y;
+    shape.oldBounds = undefined;
+  }
 
   assign(bounds, {
     x: shape.x,
     y: shape.y,
     width: shape.width,
     height: shape.height
+  });
+};
+
+
+BpmnUpdater.prototype.updateBoundsCoords = function(shape) {
+
+  var di = getDi(shape),
+      embeddedLabelBounds = getEmbeddedLabelBounds(shape);
+
+  // update embedded label bounds if possible
+  if (embeddedLabelBounds) {
+    var embeddedLabelBoundsDelta = delta(embeddedLabelBounds, di.get('bounds'));
+
+    assign(embeddedLabelBounds, {
+      x: shape.x + embeddedLabelBoundsDelta.x,
+      y: shape.y + embeddedLabelBoundsDelta.y
+    });
+  }
+
+  var target = isLabel(shape) ? this._getLabel(di) : di;
+
+  var bounds = target.bounds;
+
+  if (!bounds) {
+    bounds = this._bpmnFactory.createDiBounds();
+    target.set('bounds', bounds);
+  }
+
+  assign(bounds, {
+    x: shape.x,
+    y: shape.y
   });
 };
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -1,34 +1,23 @@
-import {
-  assign,
-  forEach
-} from 'min-dash';
+import { assign, forEach } from 'min-dash';
 
 import inherits from 'inherits-browser';
 
-import {
-  add as collectionAdd,
-  remove as collectionRemove
-} from 'diagram-js/lib/util/Collections';
+import { add as collectionAdd, remove as collectionRemove } from 'diagram-js/lib/util/Collections';
 
-import {
-  getBusinessObject,
-  getDi,
-  is
-} from '../../util/ModelUtil';
+import { getBusinessObject, getDi, is } from '../../util/ModelUtil';
 
 import { isAny } from './util/ModelingUtil';
 
-import {
-  getLabel,
-  isLabel,
-  isLabelExternal
-} from '../../util/LabelUtil';
+import { getLabel, isLabel, isLabelExternal } from '../../util/LabelUtil';
+
+import { append as svgAppend, attr as svgAttr, create as svgCreate, remove as svgRemove } from 'tiny-svg';
 
 import { isPlane } from '../../util/DrilldownUtil';
 
 import { delta } from 'diagram-js/lib/util/PositionUtil';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+import { assignStyle } from 'min-dom';
 
 /**
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
@@ -196,14 +185,28 @@ export default function BpmnUpdater(
     }
 
 
-    // handles height difference for TextAnnotations
+    // handles difference for TextAnnotations
     if (event.element.type === 'bpmn:TextAnnotation') {
       event.element.height = Math.max(Math.round(getTextHeightForTextAnnotation(event)), 30);
       updateBounds({ context: { shape: event.element } });
-      eventBus.fire('connection.changed', { gfx: event.gfx, element: event.element });
-    }
-  });
+      event.element.incoming.forEach((connection) => {
+        if (event.element.oldWayPoint) {
+          let parentGfx = getConnectionGfx(event, connection);
 
+          connection.waypoints[1].x = event.element.oldWayPoint.x;
+          connection.waypoints[1].y = event.element.oldWayPoint.y;
+          connection.waypoints[1].original.x = event.element.oldWayPoint.original.x;
+          connection.waypoints[1].original.y = event.element.oldWayPoint.original.y;
+          eventBus.fire('element.changed', { element: connection , gfx: parentGfx });
+          event.element.oldWayPoint = undefined;
+        }
+
+      });
+
+
+    }
+
+  });
 
   function canHandleLabelResize(event) {
     const element = event.element,
@@ -217,26 +220,36 @@ export default function BpmnUpdater(
     }
     let renderedLabelHeight = getTextHeightForLabel(event),
         renderedLabelWidth = getTextWidthForLabel(event);
-    if (hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 4)) {
+    if (hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 5)) {
       return true;
     }
 
     return false;
+  }
 
-
+  function getConnectionGfx(event, connection) {
+    const children = event.gfx.parentElement.parentElement.children;
+    for (let child of children) {
+      const dataElementId = child.firstChild.attributes?.getNamedItem('data-element-id').value;
+      if (connection.id === dataElementId) {
+        return child;
+      }
+    }
   }
 
   function getTextHeightForTextAnnotation(event) {
-    return event.gfx.firstChild.lastChild.lastChild.y.animVal[0].value;
+    return Math.max(event.gfx.firstChild.children[1].lastChild.y.animVal[0].value, 30) + 10;
   }
 
   function getTextHeightForLabel(event) {
-    return Math.max(Math.round(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value), 15);
+    const text = event.gfx.firstChild.firstChild;
+    return Math.max(Math.round(text.lastChild.y.animVal[0].value), 15);
   }
 
   function getTextWidthForLabel(event) {
-    let lineLengths = Array.from(event.gfx.firstChild.firstChild.children)
-      .map(child => child.textLength.baseVal.value);
+    let lineLengths = Array.from(measureTextLines(getGfxLabel(event.gfx), getStyleFromLabel(event), event.element.width + 5))
+      .map(elem => elem.width);
+
     return Math.round(Math.max(...lineLengths));
   }
 
@@ -883,4 +896,175 @@ function getEmbeddedLabelBounds(shape) {
   }
 
   return label.get('bounds');
+}
+
+// ---------- helper svg --------------
+
+function getHelperSvg() {
+  let helperSvg = document.getElementById('helper-svg');
+
+  if (!helperSvg) {
+    helperSvg = svgCreate('svg');
+
+    svgAttr(helperSvg, { id: 'helper-svg' });
+
+    assignStyle(helperSvg, {
+      visibility: 'hidden',
+      position: 'fixed',
+      width: 0,
+      height: 0,
+    });
+
+    document.body.appendChild(helperSvg);
+  }
+
+  return helperSvg;
+}
+
+// ---------- text measurement ---------
+
+function getTextBBox(text, fakeText) {
+  fakeText.textContent = text;
+
+  try {
+    const emptyLine = text === '';
+    fakeText.textContent = emptyLine ? 'dummy' : text;
+
+    const raw = fakeText.getBBox();
+
+    const box = {
+      width: raw.width + raw.x * 2,
+      height: raw.height,
+    };
+
+    if (emptyLine) box.width = 0;
+
+    return box;
+  } catch (e) {
+    console.warn('BBox failed:', e);
+    return { width: 0, height: 0 };
+  }
+}
+
+// -------- shorten logic ----------
+
+const SOFT_BREAK = '\u00AD';
+
+function semanticShorten(line, maxLength) {
+  const parts = line.split(/(\s|-|\u00AD)/g);
+  let part;
+  const shortenedParts = [];
+  let length = 0;
+
+  while ((part = parts.shift())) {
+    if (part.length + length < maxLength) {
+      shortenedParts.push(part);
+      length += part.length;
+    } else {
+      if (part === '-' || part === SOFT_BREAK) {
+        shortenedParts.pop();
+      }
+      break;
+    }
+  }
+
+  const last = shortenedParts[shortenedParts.length - 1];
+  if (last === SOFT_BREAK) shortenedParts[shortenedParts.length - 1] = '-';
+
+  return shortenedParts.join('');
+}
+
+function shortenLine(line, width, maxWidth) {
+  const length = Math.max((line.length * maxWidth) / width, 1);
+  let shortened = semanticShorten(line, length);
+
+  if (!shortened) {
+    shortened = line.slice(0, Math.max(Math.round(length - 1), 1));
+  }
+  return shortened;
+}
+
+// ---------- layout line -------------
+
+function layoutNext(lines, maxWidth, fakeText) {
+  const originalLine = lines.shift();
+  let fitLine = originalLine;
+
+  for (;;) {
+    const bbox = getTextBBox(fitLine, fakeText);
+    bbox.width = fitLine ? bbox.width : 0;
+
+    // fits or too short to split
+    if (
+      fitLine === ' ' ||
+            fitLine === '' ||
+            bbox.width < Math.round(maxWidth) ||
+            fitLine.length < 2
+    ) {
+      return fit(lines, fitLine, originalLine, bbox);
+    }
+
+    // otherwise shorten and try again
+    fitLine = shortenLine(fitLine, bbox.width, maxWidth);
+  }
+}
+
+function fit(lines, fitLine, originalLine, bbox) {
+  if (fitLine.length < originalLine.length) {
+    const remainder = originalLine.slice(fitLine.length).trim();
+    lines.unshift(remainder);
+  }
+
+  // is doof
+  return {
+    text: fitLine,
+    width: Math.round(bbox.width),
+    height: bbox.height,
+  };
+}
+
+function getStyleFromLabel(event) {
+  const styleString = event.gfx.firstChild.firstChild.attributes.style.nodeValue;
+
+  let style = Object.fromEntries(
+    styleString
+      .split(';')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(part => {
+        const [ key, value ] = part.split(':').map(s => s.trim());
+        return [ key, value ];
+      })
+  );
+  style['lineHeight'] = event.gfx.firstChild.firstChild.attributes.lineHeight.nodeValue;
+
+  return style;
+}
+
+// =====================================================
+//              PUBLIC: measureTextLines()
+// =====================================================
+
+export function measureTextLines(text, style, maxWidth, isTextAnnotation) {
+
+  // prepare helper text node
+  const helperText = svgCreate('text');
+  svgAttr(helperText, { x: 0, y: 0 });
+  svgAttr(helperText, style);
+
+  const helperSvg = getHelperSvg();
+  svgAppend(helperSvg, helperText);
+
+  const lines = text.split(/\u00AD?\r?\n/);
+  const results = [];
+
+  while (lines.length) {
+    const line = layoutNext(lines, maxWidth, helperText, isTextAnnotation);
+    results.push(line);
+  }
+  console.log(results);
+
+  svgRemove(helperText);
+
+  return results;
 }

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -63,7 +63,7 @@ export default function BpmnUpdater(
 
   var self = this;
 
-  var textPadding = 2;
+  var textPadding = 3.5;
 
 
   // connection cropping //////////////////////
@@ -192,7 +192,7 @@ export default function BpmnUpdater(
     if (event.element.type === 'label') {
 
       // handles the height difference of new rendered Text
-      event.element.height = Math.max(Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + textPadding), DEFAULT_LABEL_SIZE.height);
+      event.element.height = Math.ceil(event.gfx.firstChild.firstChild.lastChild.y.animVal[0].value + textPadding);
       updateBounds({ context: { shape: event.element } });
     }
 

--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -8,16 +8,22 @@ import { getBusinessObject, getDi, is } from '../../util/ModelUtil';
 
 import { isAny } from './util/ModelingUtil';
 
-import { getLabel, isLabel, isLabelExternal } from '../../util/LabelUtil';
-
-import { append as svgAppend, attr as svgAttr, create as svgCreate, remove as svgRemove } from 'tiny-svg';
+import {
+  getLabel,
+  getTextHeightForTextAnnotation,
+  isLabel,
+  isLabelExternal,
+  getConnectionGfx,
+  canHandleLabelResize,
+  getTextHeightForLabel,
+  getTextWidthForLabel
+} from '../../util/LabelUtil';
 
 import { isPlane } from '../../util/DrilldownUtil';
 
 import { delta } from 'diagram-js/lib/util/PositionUtil';
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
-import { assignStyle } from 'min-dom';
 
 /**
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
@@ -207,61 +213,6 @@ export default function BpmnUpdater(
     }
 
   });
-
-  function canHandleLabelResize(event) {
-    const element = event.element,
-
-          currentlabel = getLabel(element),
-
-          renderedLabel = getGfxLabel(event.gfx, currentlabel);
-
-    if (currentlabel !== renderedLabel) {
-      return true;
-    }
-    let renderedLabelHeight = getTextHeightForLabel(event),
-        renderedLabelWidth = getTextWidthForLabel(event);
-    if (hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 5)) {
-      return true;
-    }
-
-    return false;
-  }
-
-  function getConnectionGfx(event, connection) {
-    const children = event.gfx.parentElement.parentElement.children;
-    for (let child of children) {
-      const dataElementId = child.firstChild.attributes?.getNamedItem('data-element-id').value;
-      if (connection.id === dataElementId) {
-        return child;
-      }
-    }
-  }
-
-  function getTextHeightForTextAnnotation(event) {
-    return Math.max(event.gfx.firstChild.children[1].lastChild.y.animVal[0].value, 30) + 10;
-  }
-
-  function getTextHeightForLabel(event) {
-    const text = event.gfx.firstChild.firstChild;
-    return Math.max(Math.round(text.lastChild.y.animVal[0].value), 15);
-  }
-
-  function getTextWidthForLabel(event) {
-    let lineLengths = Array.from(measureTextLines(getGfxLabel(event.gfx), getStyleFromLabel(event), event.element.width + 5))
-      .map(elem => elem.width);
-
-    return Math.round(Math.max(...lineLengths));
-  }
-
-  function getGfxLabel(gfx) {
-    return Array.from(gfx.firstChild.firstChild.children)
-      .map(child => child.textContent)
-      .join('');
-  }
-
-  function hasMoreDiffThan(element, height, width, padding) {
-    return Math.abs(element.width - width) > padding || Math.abs(element.height - height) > padding;
-  }
 
   // attach / detach connection
   function updateConnection(e) {
@@ -896,174 +847,4 @@ function getEmbeddedLabelBounds(shape) {
   }
 
   return label.get('bounds');
-}
-
-// ---------- helper svg --------------
-
-function getHelperSvg() {
-  let helperSvg = document.getElementById('helper-svg');
-
-  if (!helperSvg) {
-    helperSvg = svgCreate('svg');
-
-    svgAttr(helperSvg, { id: 'helper-svg' });
-
-    assignStyle(helperSvg, {
-      visibility: 'hidden',
-      position: 'fixed',
-      width: 0,
-      height: 0,
-    });
-
-    document.body.appendChild(helperSvg);
-  }
-
-  return helperSvg;
-}
-
-// ---------- text measurement ---------
-
-function getTextBBox(text, fakeText) {
-  fakeText.textContent = text;
-
-  try {
-    const emptyLine = text === '';
-    fakeText.textContent = emptyLine ? 'dummy' : text;
-
-    const raw = fakeText.getBBox();
-
-    const box = {
-      width: raw.width + raw.x * 2,
-      height: raw.height,
-    };
-
-    if (emptyLine) box.width = 0;
-
-    return box;
-  } catch (e) {
-    console.warn('BBox failed:', e);
-    return { width: 0, height: 0 };
-  }
-}
-
-// -------- shorten logic ----------
-
-const SOFT_BREAK = '\u00AD';
-
-function semanticShorten(line, maxLength) {
-  const parts = line.split(/(\s|-|\u00AD)/g);
-  let part;
-  const shortenedParts = [];
-  let length = 0;
-
-  while ((part = parts.shift())) {
-    if (part.length + length < maxLength) {
-      shortenedParts.push(part);
-      length += part.length;
-    } else {
-      if (part === '-' || part === SOFT_BREAK) {
-        shortenedParts.pop();
-      }
-      break;
-    }
-  }
-
-  const last = shortenedParts[shortenedParts.length - 1];
-  if (last === SOFT_BREAK) shortenedParts[shortenedParts.length - 1] = '-';
-
-  return shortenedParts.join('');
-}
-
-function shortenLine(line, width, maxWidth) {
-  const length = Math.max((line.length * maxWidth) / width, 1);
-  let shortened = semanticShorten(line, length);
-
-  if (!shortened) {
-    shortened = line.slice(0, Math.max(Math.round(length - 1), 1));
-  }
-  return shortened;
-}
-
-// ---------- layout line -------------
-
-function layoutNext(lines, maxWidth, fakeText) {
-  const originalLine = lines.shift();
-  let fitLine = originalLine;
-
-  for (;;) {
-    const bbox = getTextBBox(fitLine, fakeText);
-    bbox.width = fitLine ? bbox.width : 0;
-
-    // fits or too short to split
-    if (
-      fitLine === ' ' ||
-            fitLine === '' ||
-            bbox.width < Math.round(maxWidth) ||
-            fitLine.length < 2
-    ) {
-      return fit(lines, fitLine, originalLine, bbox);
-    }
-
-    // otherwise shorten and try again
-    fitLine = shortenLine(fitLine, bbox.width, maxWidth);
-  }
-}
-
-function fit(lines, fitLine, originalLine, bbox) {
-  if (fitLine.length < originalLine.length) {
-    const remainder = originalLine.slice(fitLine.length).trim();
-    lines.unshift(remainder);
-  }
-
-  // is doof
-  return {
-    text: fitLine,
-    width: Math.round(bbox.width),
-    height: bbox.height,
-  };
-}
-
-function getStyleFromLabel(event) {
-  const styleString = event.gfx.firstChild.firstChild.attributes.style.nodeValue;
-
-  let style = Object.fromEntries(
-    styleString
-      .split(';')
-      .map(part => part.trim())
-      .filter(Boolean)
-      .map(part => {
-        const [ key, value ] = part.split(':').map(s => s.trim());
-        return [ key, value ];
-      })
-  );
-  style['lineHeight'] = event.gfx.firstChild.firstChild.attributes.lineHeight.nodeValue;
-
-  return style;
-}
-
-// =====================================================
-//              PUBLIC: measureTextLines()
-// =====================================================
-
-export function measureTextLines(text, style, maxWidth, isTextAnnotation) {
-
-  // prepare helper text node
-  const helperText = svgCreate('text');
-  svgAttr(helperText, { x: 0, y: 0 });
-  svgAttr(helperText, style);
-
-  const helperSvg = getHelperSvg();
-  svgAppend(helperSvg, helperText);
-
-  const lines = text.split(/\u00AD?\r?\n/);
-  const results = [];
-
-  while (lines.length) {
-    const line = layoutNext(lines, maxWidth, helperText, isTextAnnotation);
-    results.push(line);
-  }
-
-  svgRemove(helperText);
-
-  return results;
 }

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -222,7 +222,7 @@ export default function LabelBehavior(
         newBounds = context.newBounds,
         oldBounds = context.oldBounds;
 
-    if (shape.type !== 'label') {
+    if (shape.type !== 'label' && !hasExternalLabel(shape)) {
       return;
     }
 

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -224,7 +224,7 @@ export default function LabelBehavior(
         oldBounds = context.oldBounds;
 
     // helps to regulate bound rendering
-    if ((newBounds.y + newBounds.height === oldBounds.y + oldBounds.height ) && (newBounds.y !== oldBounds.y || newBounds.height !== oldBounds.height)) {
+    if ((newBounds.y + newBounds.height === oldBounds.y + oldBounds.height) && (newBounds.y !== oldBounds.y || newBounds.height !== oldBounds.height)) {
       event.context.shape.correctBounds = oldBounds;
     }
     if ((newBounds.x + newBounds.width === oldBounds.x + oldBounds.width) && (newBounds.x !== oldBounds.x || newBounds.width !== oldBounds.width)) {

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -223,6 +223,14 @@ export default function LabelBehavior(
         newBounds = context.newBounds,
         oldBounds = context.oldBounds;
 
+    // helps to regulate bound rendering
+    if ((newBounds.y + newBounds.height === oldBounds.y + oldBounds.height ) && (newBounds.y !== oldBounds.y || newBounds.height !== oldBounds.height)) {
+      event.context.shape.correctBounds = oldBounds;
+    }
+    if ((newBounds.x + newBounds.width === oldBounds.x + oldBounds.width) && (newBounds.x !== oldBounds.x || newBounds.width !== oldBounds.width)) {
+      event.context.shape.correctBounds = oldBounds;
+    }
+
     if (hasExternalLabel(shape)) {
 
       var label = shape.label,

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -217,18 +217,23 @@ export default function LabelBehavior(
 
   // move external label after resizing
   this.postExecute('shape.resize', function(event) {
-
     var context = event.context,
         shape = context.shape,
         newBounds = context.newBounds,
         oldBounds = context.oldBounds;
 
+    if (shape.type !== 'label') {
+      return;
+    }
+
     // helps to regulate bound rendering to stop overwriting x and y coords after resizing
     if ((newBounds.y + newBounds.height === oldBounds.y + oldBounds.height) && (newBounds.y !== oldBounds.y || newBounds.height !== oldBounds.height)) {
       event.context.shape.correctBounds = oldBounds;
+      newBounds = oldBounds;
     }
     if ((newBounds.x + newBounds.width === oldBounds.x + oldBounds.width) && (newBounds.x !== oldBounds.x || newBounds.width !== oldBounds.width)) {
       event.context.shape.correctBounds = oldBounds;
+      newBounds = oldBounds;
     }
 
     if (hasExternalLabel(shape)) {

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -223,7 +223,7 @@ export default function LabelBehavior(
         newBounds = context.newBounds,
         oldBounds = context.oldBounds;
 
-    // helps to regulate bound rendering
+    // helps to regulate bound rendering to stop overwriting x and y coords after resizing
     if ((newBounds.y + newBounds.height === oldBounds.y + oldBounds.height) && (newBounds.y !== oldBounds.y || newBounds.height !== oldBounds.height)) {
       event.context.shape.correctBounds = oldBounds;
     }

--- a/lib/features/modeling/behavior/TextAnnotationBehavior.js
+++ b/lib/features/modeling/behavior/TextAnnotationBehavior.js
@@ -34,6 +34,29 @@ export default function TextAnnotationBehavior(eventBus) {
       context.hints.autoResize = false;
     }
   }, true);
+
+  this.postExecute('shape.resize', function(event) {
+    if (event.context.shape.type === 'bpmn:TextAnnotation') {
+      var context = event.context,
+          newBounds = context.newBounds,
+          oldBounds = context.oldBounds;
+
+      if (!event.context.shape.incoming[0]) {
+        return;
+      }
+
+      // helps to regulate bound rendering to stop overwriting x and y coords after resizing
+      if (newBounds.y !== oldBounds.y && newBounds.height !== oldBounds.height) {
+        event.context.shape.oldWayPoint = event.context.shape.incoming[0].waypoints[1];
+        event.context.shape.correctBounds = oldBounds;
+      }
+      if ((newBounds.x !== oldBounds.x && newBounds.width !== oldBounds.width)) {
+        event.context.shape.oldWayPoint = event.context.shape.incoming[0].waypoints[1];
+        event.context.shape.correctBounds = oldBounds;
+      }
+    }
+  });
+
 }
 
 inherits(TextAnnotationBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/TextAnnotationBehavior.js
+++ b/lib/features/modeling/behavior/TextAnnotationBehavior.js
@@ -41,17 +41,13 @@ export default function TextAnnotationBehavior(eventBus) {
           newBounds = context.newBounds,
           oldBounds = context.oldBounds;
 
-      if (!event.context.shape.incoming[0]) {
-        return;
-      }
-
       // helps to regulate bound rendering to stop overwriting x and y coords after resizing
       if (newBounds.y !== oldBounds.y && newBounds.height !== oldBounds.height) {
-        event.context.shape.oldWayPoint = event.context.shape.incoming[0].waypoints[1];
+        event.context.shape.oldWayPoint = event.context.shape.incoming?.[0]?.waypoints?.[1];
         event.context.shape.correctBounds = oldBounds;
       }
       if ((newBounds.x !== oldBounds.x && newBounds.width !== oldBounds.width)) {
-        event.context.shape.oldWayPoint = event.context.shape.incoming[0].waypoints[1];
+        event.context.shape.oldWayPoint = event.context.shape.incoming?.[0]?.waypoints?.[1];
         event.context.shape.correctBounds = oldBounds;
       }
     }

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -18,7 +18,7 @@ import {
 } from '../modeling/util/ModelingUtil';
 
 import {
-  isLabel, isLabelExternal
+  isLabel
 } from '../../util/LabelUtil';
 
 import {
@@ -997,7 +997,7 @@ function canResize(shape, newBounds) {
     return true;
   }
 
-  if (isLabelExternal(shape)) {
+  if (isLabel(shape)) {
     return true;
   }
 
@@ -1005,7 +1005,7 @@ function canResize(shape, newBounds) {
 }
 
 /**
- * Check whether one of of the elements to be connected is a text annotation.
+ * Check whether one of the elements to be connected is a text annotation.
  *
  * @param {Element} source
  * @param {Element} target

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -18,7 +18,7 @@ import {
 } from '../modeling/util/ModelingUtil';
 
 import {
-  isLabel
+  isLabel, isLabelExternal
 } from '../../util/LabelUtil';
 
 import {
@@ -994,6 +994,10 @@ function canResize(shape, newBounds) {
   }
 
   if (isGroup(shape)) {
+    return true;
+  }
+
+  if (isLabelExternal(shape)) {
     return true;
   }
 

--- a/lib/util/LabelUtil.js
+++ b/lib/util/LabelUtil.js
@@ -8,6 +8,10 @@ import { isLabel } from 'diagram-js/lib/util/ModelUtil';
 
 export { isLabel } from 'diagram-js/lib/util/ModelUtil';
 
+import { append as svgAppend, attr as svgAttr, create as svgCreate, remove as svgRemove } from 'tiny-svg';
+
+import { assignStyle } from 'min-dom';
+
 /**
  * @typedef {import('diagram-js/lib/util/Types').Point} Point
  * @typedef {import('diagram-js/lib/util/Types').Rect} Rect
@@ -274,4 +278,256 @@ export function setLabel(element, text) {
  */
 export function isExternalLabel(element) {
   return isLabel(element) && isLabelExternal(element.labelTarget);
+}
+
+
+// ---------- helper svg --------------
+
+function getHelperSvg() {
+  let helperSvg = document.getElementById('helper-svg');
+
+  if (!helperSvg) {
+    helperSvg = svgCreate('svg');
+
+    svgAttr(helperSvg, { id: 'helper-svg' });
+
+    assignStyle(helperSvg, {
+      visibility: 'hidden',
+      position: 'fixed',
+      width: 0,
+      height: 0,
+    });
+
+    document.body.appendChild(helperSvg);
+  }
+
+  return helperSvg;
+}
+
+// ---------- text measurement ---------
+
+function getTextBBox(text, fakeText) {
+  fakeText.textContent = text;
+
+  try {
+    const emptyLine = text === '';
+    fakeText.textContent = emptyLine ? 'dummy' : text;
+
+    const raw = fakeText.getBBox();
+
+    const box = {
+      width: raw.width + raw.x * 2,
+      height: raw.height,
+    };
+
+    if (emptyLine) box.width = 0;
+
+    return box;
+  } catch (e) {
+    console.warn('BBox failed:', e);
+    return { width: 0, height: 0 };
+  }
+}
+
+// -------- shorten logic ----------
+
+const SOFT_BREAK = '\u00AD';
+
+function semanticShorten(line, maxLength) {
+  const parts = line.split(/(\s|-|\u00AD)/g);
+  let part;
+  const shortenedParts = [];
+  let length = 0;
+
+  while ((part = parts.shift())) {
+    if (part.length + length < maxLength) {
+      shortenedParts.push(part);
+      length += part.length;
+    } else {
+      if (part === '-' || part === SOFT_BREAK) {
+        shortenedParts.pop();
+      }
+      break;
+    }
+  }
+
+  const last = shortenedParts[shortenedParts.length - 1];
+  if (last === SOFT_BREAK) shortenedParts[shortenedParts.length - 1] = '-';
+
+  return shortenedParts.join('');
+}
+
+function shortenLine(line, width, maxWidth) {
+  const length = Math.max((line.length * maxWidth) / width, 1);
+  let shortened = semanticShorten(line, length);
+
+  if (!shortened) {
+    shortened = line.slice(0, Math.max(Math.round(length - 1), 1));
+  }
+  return shortened;
+}
+
+// ---------- layout line -------------
+
+function layoutNext(lines, maxWidth, fakeText) {
+  const originalLine = lines.shift();
+  let fitLine = originalLine;
+
+  for (;;) {
+    const bbox = getTextBBox(fitLine, fakeText);
+    bbox.width = fitLine ? bbox.width : 0;
+
+    // fits or too short to split
+    if (
+      fitLine === ' ' ||
+            fitLine === '' ||
+            bbox.width < Math.round(maxWidth) ||
+            fitLine.length < 2
+    ) {
+      return fit(lines, fitLine, originalLine, bbox);
+    }
+
+    // otherwise shorten and try again
+    fitLine = shortenLine(fitLine, bbox.width, maxWidth);
+  }
+}
+
+function fit(lines, fitLine, originalLine, bbox) {
+  if (fitLine.length < originalLine.length) {
+    const remainder = originalLine.slice(fitLine.length).trim();
+    lines.unshift(remainder);
+  }
+  return {
+    text: fitLine,
+    width: Math.round(bbox.width),
+    height: bbox.height,
+  };
+}
+
+
+// =====================================================
+//              PUBLIC: measureTextLines()
+// =====================================================
+
+export function measureTextLines(text, style, maxWidth, isTextAnnotation) {
+
+  // prepare helper text node
+  const helperText = svgCreate('text');
+  svgAttr(helperText, { x: 0, y: 0 });
+  svgAttr(helperText, style);
+
+  const helperSvg = getHelperSvg();
+  svgAppend(helperSvg, helperText);
+
+  const lines = text.split(/\u00AD?\r?\n/);
+  const results = [];
+
+  while (lines.length) {
+    const line = layoutNext(lines, maxWidth, helperText, isTextAnnotation);
+    results.push(line);
+  }
+
+  svgRemove(helperText);
+
+  return results;
+}
+
+
+export function changeBounds(newBounds, element) {
+  element.x = newBounds.x;
+  element.y = newBounds.y;
+  element.width = newBounds.width;
+  element.height = newBounds.height;
+}
+
+
+export function getTextAnnotationHeightFromElement(text) {
+  return Math.max(text.lastChild.y.animVal[0].value, 30) + 10;
+}
+
+export function getTextWidthForTextAnnotation(text, width) {
+
+  if ((text.textContent === '')) {
+    return 100;
+  }
+
+  let lineLengths = Array.from(measureTextLines(text.textContent, getStyleFromTextannotation(text), width + 5, true))
+    .map(elem => elem.width);
+
+  return Math.round(Math.max(...lineLengths));
+}
+
+export function canHandleLabelResize(event) {
+  const element = event.element,
+
+        currentlabel = getLabel(element),
+
+        renderedLabel = getGfxLabel(event.gfx, currentlabel);
+
+  if (currentlabel !== renderedLabel) {
+    return true;
+  }
+  let renderedLabelHeight = getTextHeightForLabel(event),
+      renderedLabelWidth = getTextWidthForLabel(event);
+  return !!hasMoreDiffThan(element, renderedLabelHeight, renderedLabelWidth, 5);
+
+}
+
+export function getConnectionGfx(event, connection) {
+  const children = event.gfx.parentElement.parentElement.children;
+  for (let child of children) {
+    const dataElementId = child.firstChild.attributes?.getNamedItem('data-element-id').value;
+    if (connection.id === dataElementId) {
+      return child;
+    }
+  }
+}
+
+export function getTextHeightForTextAnnotation(event) {
+  return Math.max(event.gfx.firstChild.children[1].lastChild.y.animVal[0].value, 30) + 10;
+}
+
+export function getTextHeightForLabel(event) {
+  const text = event.gfx.firstChild.firstChild;
+  return Math.max(Math.round(text.lastChild.y.animVal[0].value), 15);
+}
+
+export function getTextWidthForLabel(event) {
+  let lineLengths = Array.from(measureTextLines(getGfxLabel(event.gfx), getStyleFromLabel(event), event.element.width + 5))
+    .map(elem => elem.width);
+
+  return Math.round(Math.max(...lineLengths));
+}
+
+export function getGfxLabel(gfx) {
+  return Array.from(gfx.firstChild.firstChild.children)
+    .map(child => child.textContent)
+    .join('');
+}
+
+export function hasMoreDiffThan(element, height, width, padding) {
+  return Math.abs(element.width - width) > padding || Math.abs(element.height - height) > padding;
+}
+
+function parseStyleFromNode(node) {
+  const styleString = node.attributes.style.nodeValue;
+  let style = Object.fromEntries(
+    styleString.split(';')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(part => {
+        const [ key, value ] = part.split(':').map(s => s.trim());
+        return [ key, value ];
+      })
+  );
+  style['lineHeight'] = node.attributes.lineHeight.nodeValue;
+  return style;
+}
+
+export function getStyleFromLabel(event) {
+  return parseStyleFromNode(event.gfx.firstChild.firstChild);
+}
+
+function getStyleFromTextannotation(text) {
+  return parseStyleFromNode(text);
 }

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -978,7 +978,7 @@ describe('Modeler', function() {
       modeling.resizeShape(label, { x: label.x, y: label.y, width: label.width + 20, height: label.height }, 'e');
 
       const updatedLabel = elementRegistry.get(label.id);
-      expect(updatedLabel.width).to.equal(108);
+      expect(updatedLabel.width).to.closeTo(105, 3);
     });
 
     it('should adapt width of StartEvent label when text is changed and resized vertically', async function() {

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -4,29 +4,22 @@ import Modeler from 'lib/Modeler';
 import Viewer from 'lib/Viewer';
 import NavigatedViewer from 'lib/NavigatedViewer';
 
-import { isAny } from 'lib/util/ModelUtil';
+import { getDi, isAny } from 'lib/util/ModelUtil';
 
 import Clipboard from 'diagram-js/lib/features/clipboard/Clipboard';
 
 import TestContainer from 'mocha-test-container-support';
 
-import {
-  createCanvasEvent
-} from '../util/MockEvents';
+import { createCanvasEvent } from '../util/MockEvents';
 
-import {
-  setBpmnJS,
-  clearBpmnJS,
-  collectTranslations,
-  enableLogging
-} from 'test/TestHelper';
+import { bootstrapModeler, clearBpmnJS, collectTranslations, enableLogging, setBpmnJS } from 'test/TestHelper';
 
-import {
-  pick,
-  find
-} from 'min-dash';
-
-import { getDi } from 'lib/util/ModelUtil';
+import { find, pick } from 'min-dash';
+import createModule from 'diagram-js/lib/features/create';
+import resizeModule from 'diagram-js/lib/features/resize';
+import moveModule from 'diagram-js/lib/features/move';
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
 
 
 var singleStart = window.__env__ && window.__env__.SINGLE_START === 'modeler';
@@ -949,6 +942,71 @@ describe('Modeler', function() {
     });
 
   });
+
+  describe('resize text element and preserve width', function() {
+
+    var diagramXML = require('../fixtures/bpmn/simple.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        coreModule,
+        createModule,
+        modelingModule,
+        resizeModule,
+        moveModule
+      ]
+    }));
+
+    it('should adapt width of StartEvent label when text is changed and resized horizontally', async function() {
+
+      const result = await createModeler(diagramXML);
+      expect(result.error).not.to.exist;
+
+      var modeler = result.modeler;
+      var elementRegistry = modeler.get('elementRegistry');
+      var modeling = modeler.get('modeling');
+
+      var startEvent = elementRegistry.get('StartEvent_2');
+      expect(startEvent).to.exist;
+
+      var label = startEvent.label;
+      expect(label).to.exist;
+      expect(label.businessObject.name).to.equal('Start');
+
+      modeling.updateLabel(startEvent, 'This is a much longer start event text');
+
+      modeling.resizeShape(label, { x: label.x, y: label.y, width: label.width + 20, height: label.height }, 'e');
+
+      const updatedLabel = elementRegistry.get(label.id);
+      expect(updatedLabel.width).to.equal(108);
+    });
+
+    it('should adapt width of StartEvent label when text is changed and resized vertically', async function() {
+
+      const result = await createModeler(diagramXML);
+      expect(result.error).not.to.exist;
+
+      var modeler = result.modeler;
+      var elementRegistry = modeler.get('elementRegistry');
+      var modeling = modeler.get('modeling');
+
+      var startEvent = elementRegistry.get('StartEvent_2');
+      expect(startEvent).to.exist;
+
+      var label = startEvent.label;
+      expect(label).to.exist;
+      expect(label.businessObject.name).to.equal('Start');
+
+      modeling.updateLabel(startEvent, 'This is a much longer start event text');
+
+      modeling.resizeShape(label, { x: label.x, y: label.y, width: label.width, height: label.height - 20 }, 'e');
+
+      const updatedLabel = elementRegistry.get(label.id);
+      expect(updatedLabel.height).to.equal(36);
+    });
+
+  });
+
 
 });
 

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -933,6 +933,9 @@ describe('draw - bpmn renderer', function() {
             if (isCollapsedSubProcess(element)) {
               expect(svgAttr(rect, 'width')).to.equal('100');
               expect(svgAttr(rect, 'height')).to.equal('80');
+            } else if (element.type === 'bpmn:TextAnnotation') {
+              expect(svgAttr(rect, 'width')).to.equal('78');
+              expect(svgAttr(rect, 'height')).to.equal('40');
             } else {
               expect(svgAttr(rect, 'width')).to.equal('200');
               expect(svgAttr(rect, 'height')).to.equal('100');

--- a/test/spec/features/auto-place/BpmnAutoPlaceSpec.js
+++ b/test/spec/features/auto-place/BpmnAutoPlaceSpec.js
@@ -104,14 +104,14 @@ describe('features/auto-place', function() {
       it('top right of source', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'TASK_2',
-        expectedBounds: { x: 579, y: 210, width: 100, height: 30 }
+        expectedBounds: { x: 579, y: 210, width: 100, height: 40 }
       }));
 
 
       it('above existing', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'TASK_3',
-        expectedBounds: { x: 896, y: 96, width: 100, height: 30 }
+        expectedBounds: { x: 896, y: 96, width: 100, height: 40 }
       }));
 
 
@@ -120,14 +120,14 @@ describe('features/auto-place', function() {
         it('top right', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'SequenceFlow_1',
-          expectedBounds: { x: 500, y: 265, width: 100, height: 30 }
+          expectedBounds: { x: 500, y: 265, width: 100, height: 40 }
         }));
 
 
         it('above existing', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'SequenceFlow_1',
-          expectedBounds: { x: 500, y: 205, width: 100, height: 30 }
+          expectedBounds: { x: 500, y: 205, width: 100, height: 40 }
         }));
 
       });
@@ -138,14 +138,14 @@ describe('features/auto-place', function() {
         it('bottom right', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'MessageFlow_1',
-          expectedBounds: { x: 579, y: 580, width: 100, height: 30 }
+          expectedBounds: { x: 579, y: 580, width: 100, height: 40 }
         }));
 
 
         it('next to existing', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'MessageFlow_1',
-          expectedBounds: { x: 709, y: 580, width: 100, height: 30 }
+          expectedBounds: { x: 709, y: 580, width: 100, height: 40 }
         }));
 
       });
@@ -245,14 +245,14 @@ describe('features/auto-place', function() {
       it('bottom right of source', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'V_Task_2',
-        expectedBounds: { x: 550, y: 530, width: 100, height: 30 }
+        expectedBounds: { x: 550, y: 530, width: 100, height: 40 }
       }));
 
 
       it('right of existing', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'V_Task_3',
-        expectedBounds: { x: 600, y: 840, width: 100, height: 30 }
+        expectedBounds: { x: 600, y: 840, width: 100, height: 40 }
       }));
 
 
@@ -261,14 +261,14 @@ describe('features/auto-place', function() {
         it('bottom right', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'SequenceFlow_1',
-          expectedBounds: { x: 500, y: 445, width: 100, height: 30 }
+          expectedBounds: { x: 500, y: 445, width: 100, height: 40 }
         }));
 
 
         it('right of existing', autoPlace({
           element: 'bpmn:TextAnnotation',
           behind: 'SequenceFlow_1',
-          expectedBounds: { x: 630, y: 445, width: 100, height: 30 }
+          expectedBounds: { x: 630, y: 445, width: 100, height: 40 }
         }));
 
       });
@@ -537,7 +537,7 @@ describe('features/auto-place', function() {
       it('should place annotation horizontally above Nested_Start_Event', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'Nested_Start_Event',
-        expectedBounds: { x: 215, y: -1, width: 100, height: 30 }
+        expectedBounds: { x: 215, y: -1, width: 100, height: 40 }
       }));
 
 
@@ -577,7 +577,7 @@ describe('features/auto-place', function() {
       it('should place annotation horizontally above Nested_Start_Event', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'Nested_Start_Event',
-        expectedBounds: { x: 215, y: 19, width: 100, height: 30 }
+        expectedBounds: { x: 215, y: 19, width: 100, height: 40 }
       }));
 
 
@@ -617,7 +617,7 @@ describe('features/auto-place', function() {
       it('should place annotation vertically right of Nested_Start_Event', autoPlace({
         element: 'bpmn:TextAnnotation',
         behind: 'Nested_Start_Event',
-        expectedBounds: { x: 245, y: 115, width: 100, height: 30 }
+        expectedBounds: { x: 245, y: 115, width: 100, height: 40 }
       }));
 
 

--- a/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
+++ b/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
@@ -209,12 +209,12 @@ describe('features/grid-snapping', function() {
 
       // then
       expect(events.map(position('top-left'))).to.eql([
-        { x: 710, y: 30 }, // move
-        { x: 710, y: 40 }, // move
-        { x: 720, y: 60 }, // move
-        { x: 720, y: 70 }, // move
-        { x: 730, y: 80 }, // move
-        { x: 730, y: 80 } // end
+        { x: 710, y: 25 }, // move
+        { x: 710, y: 35 }, // move
+        { x: 720, y: 55 }, // move
+        { x: 720, y: 65 }, // move
+        { x: 730, y: 75 }, // move
+        { x: 730, y: 75 } // end
       ]);
 
       // expect snapped to top-left

--- a/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
+++ b/test/spec/features/grid-snapping/BpmnGridSnappingSpec.js
@@ -197,7 +197,7 @@ describe('features/grid-snapping', function() {
       ]);
 
       // when
-      move.start(canvasEvent({ x: 700, y: 20 }), textAnnotation);
+      move.start(canvasEvent({ x: 700, y: 30 }), textAnnotation);
 
       dragging.move(canvasEvent({ x: 706, y: 32 }));
       dragging.move(canvasEvent({ x: 712, y: 44 }));
@@ -219,7 +219,7 @@ describe('features/grid-snapping', function() {
 
       // expect snapped to top-left
       expect(textAnnotation.x).to.equal(730);
-      expect(textAnnotation.y).to.equal(80);
+      expect(textAnnotation.y).to.equal(70);
     }));
 
   });

--- a/test/spec/features/grid-snapping/behavior/AutoPlaceBehaviorSpec.js
+++ b/test/spec/features/grid-snapping/behavior/AutoPlaceBehaviorSpec.js
@@ -102,7 +102,7 @@ describe('features/grid-snapping - auto-place', function() {
 
       expect(getMid(shape1)).to.eql({
         x: 170, // 168 snapped to 170
-        y: 15 // 22 snapped to 15
+        y: 20 // 22 snapped to 20
       });
     }));
 
@@ -132,7 +132,7 @@ describe('features/grid-snapping - auto-place', function() {
 
       expect(getMid(shape2)).to.eql({
         x: 170, // 168 snapped to 170
-        y: -45 // -45 snapped to -45
+        y: -40 // -45 snapped to -40
       });
     }));
 

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -19,7 +19,7 @@ import {
 
 var MEDIUM_LINE_HEIGHT = 12 * 1.2;
 
-var DELTA = 3;
+var DELTA = 6;
 
 
 describe('features - label-editing', function() {

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -705,17 +705,13 @@ describe('features - label-editing', function() {
             var startEvent = elementRegistry.get('StartEvent_1');
 
             var bounds = canvas.getAbsoluteBBox(startEvent.label);
-            var mid = {
-              x: bounds.x + bounds.width / 2,
-              y: bounds.y + bounds.height / 2
-            };
 
             directEditing.activate(startEvent);
 
             expectBounds(directEditing._textbox.parent, {
-              x: mid.x - (45 * zoom),
+              x: bounds.x,
               y: bounds.y - (7 * zoom),
-              width: (90 * zoom),
+              width: bounds.width + 10 * zoom,
               height: bounds.height + (5 * zoom) + 7
             });
           }
@@ -731,17 +727,13 @@ describe('features - label-editing', function() {
             var startEvent = elementRegistry.get('StartEvent_1');
 
             var bounds = canvas.getAbsoluteBBox(startEvent.label);
-            var mid = {
-              x: bounds.x + bounds.width / 2,
-              y: bounds.y + bounds.height / 2
-            };
 
             directEditing.activate(startEvent);
 
             expectBounds(directEditing._textbox.parent, {
-              x: mid.x - (45 * zoom),
+              x: bounds.x,
               y: bounds.y - (7 * zoom),
-              width: (90 * zoom),
+              width: bounds.width + 10 * zoom,
               height: bounds.height + (5 * zoom) + (7 * zoom)
             });
           }
@@ -799,17 +791,13 @@ describe('features - label-editing', function() {
             var sequenceFlow = elementRegistry.get('SequenceFlow_1');
 
             var bounds = canvas.getAbsoluteBBox(sequenceFlow.label);
-            var mid = {
-              x: bounds.x + bounds.width / 2,
-              y: bounds.y + bounds.height / 2
-            };
 
             directEditing.activate(sequenceFlow);
 
             expectBounds(directEditing._textbox.parent, {
-              x: mid.x - (45 * zoom),
+              x: bounds.x,
               y: bounds.y - (7 * zoom),
-              width: (90 * zoom),
+              width: bounds.width + 10 * zoom,
               height: bounds.height + (5 * zoom) + 7
             });
           }
@@ -825,17 +813,13 @@ describe('features - label-editing', function() {
             var sequenceflow = elementRegistry.get('SequenceFlow_1');
 
             var bounds = canvas.getAbsoluteBBox(sequenceflow.label);
-            var mid = {
-              x: bounds.x + bounds.width / 2,
-              y: bounds.y + bounds.height / 2
-            };
 
             directEditing.activate(sequenceflow);
 
             expectBounds(directEditing._textbox.parent, {
-              x: mid.x - (45 * zoom),
+              x: bounds.x,
               y: bounds.y - (7 * zoom),
-              width: (90 * zoom),
+              width: bounds.width + 10 * zoom,
               height: bounds.height + (5 * zoom) + (7 * zoom)
             });
           }

--- a/test/spec/features/modeling/LabelLayoutingSpec.js
+++ b/test/spec/features/modeling/LabelLayoutingSpec.js
@@ -506,7 +506,7 @@ describe('modeling - label layouting', function() {
 
           // then
           expect(connection.label.y - labelPosition.y).to.be.within(-77, -73);
-          expect(connection.label.x - labelPosition.x).to.be.within(-54, -51);
+          expect(connection.label.x - labelPosition.x).to.be.within(-54, -48);
 
         }
       ));
@@ -557,7 +557,7 @@ function getLabelPosition(connection) {
   var label = connection.label;
 
   var mid = {
-    x: label.x + (label.width / 2),
+    x: label.x,
     y: label.y + (label.height / 2)
   };
 

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -187,7 +187,6 @@ describe('features/modeling - update label', function() {
     }
   ));
 
-
   it('should update group label', inject(function(modeling, elementRegistry) {
 
     // given

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -164,6 +164,29 @@ describe('features/modeling - update label', function() {
     }
   ));
 
+  it('should not change text annotation text and bounds', inject(
+    function(modeling, elementRegistry) {
+
+      // given
+      var text = 'this should be the text';
+      var element = elementRegistry.get('TextAnnotation_1');
+
+      // when
+      modeling.updateLabel(element, text);
+
+      var oldBounds = { x: element.x, y: element.y, width: element.width, height: element.height };
+      var newBounds = { x: oldBounds.x, y: oldBounds.y + 100, width: oldBounds.width, height: oldBounds.height + 100 };
+
+      modeling.resizeShape(element, newBounds);
+
+      newBounds = { x: oldBounds.x + 100, y: oldBounds.y, width: oldBounds.width + 100, height: oldBounds.height };
+
+      // then
+      expect(element.businessObject.text).to.equal(text);
+      expectBounds(element, oldBounds, 1);
+    }
+  ));
+
 
   it('should update group label', inject(function(modeling, elementRegistry) {
 

--- a/test/spec/features/modeling/UpdateLabelSpec.js
+++ b/test/spec/features/modeling/UpdateLabelSpec.js
@@ -153,14 +153,14 @@ describe('features/modeling - update label', function() {
       // given
       var element = elementRegistry.get('TextAnnotation_1');
 
-      var newBounds = { x: 100, y: 100, width: 100, height: 30 };
+      var newBounds = { x: 100, y: 100, width: 18, height: 40 };
 
       // when
       modeling.updateLabel(element, 'bar', newBounds);
 
       // then
       expect(element.businessObject.text).to.equal('bar');
-      expect(element).to.have.bounds(newBounds);
+      expectBounds(element, newBounds, 1);
     }
   ));
 
@@ -255,7 +255,7 @@ describe('features/modeling - update label', function() {
     // given
     var element = elementRegistry.get('TextAnnotation_1');
 
-    var newBounds = { x: 100, y: 100, width: 100, height: 30 };
+    var newBounds = { x: 100, y: 100, width: 100, height: 40 };
 
     // when
     modeling.updateLabel(element, null, newBounds);
@@ -297,3 +297,10 @@ describe('features/modeling - update label', function() {
   });
 
 });
+
+function expectBounds(parent, bounds, delta) {
+  expect(parent.x).to.be.closeTo(bounds.x, delta);
+  expect(parent.y).to.be.closeTo(bounds.y, delta);
+  expect(parent.width).to.be.closeTo(bounds.width, delta);
+  expect(parent.height).to.be.closeTo(bounds.height, delta);
+}

--- a/test/spec/features/modeling/append/TextAnnotationSpec.js
+++ b/test/spec/features/modeling/append/TextAnnotationSpec.js
@@ -99,6 +99,22 @@ describe('features/modeling - append text-annotation', function() {
       expect(annotationShape.width).to.eql(100);
       expect(annotationShape.height).to.eql(40);
     }));
+
+    it('and stick with right size', inject(function(elementRegistry, elementFactory, modeling) {
+
+      // given
+      var eventShape = elementRegistry.get('IntermediateCatchEvent_1');
+      var oldBounds = { x: eventShape.x, y: eventShape.y, width: eventShape.width, height: eventShape.height };
+      var newBounds = { x: oldBounds.x + 100, y: oldBounds.y, width: oldBounds.width + 100, height: oldBounds.height };
+
+      // when
+      var annotationShape = modeling.appendShape(eventShape, { type: 'bpmn:TextAnnotation' });
+      modeling.resizeShape(annotationShape, newBounds);
+
+      // then
+      expect(annotationShape.width).to.eql(100);
+      expect(annotationShape.height).to.eql(40);
+    }));
   });
 
 

--- a/test/spec/features/modeling/append/TextAnnotationSpec.js
+++ b/test/spec/features/modeling/append/TextAnnotationSpec.js
@@ -97,7 +97,7 @@ describe('features/modeling - append text-annotation', function() {
 
       // then
       expect(annotationShape.width).to.eql(100);
-      expect(annotationShape.height).to.eql(30);
+      expect(annotationShape.height).to.eql(40);
     }));
   });
 

--- a/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
@@ -667,7 +667,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
 
         // then
         expect(label.x).to.equal(labelBounds.x);
-        expect(label.y).to.be.at.most(labelBounds.y);
+        expect(label.y).to.be.at.least(labelBounds.y);
 
       }));
 
@@ -761,7 +761,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
         );
 
         // then
-        expect(label.x).to.be.at.most(labelBounds.x);
+        expect(label.x).to.be.at.least(labelBounds.x);
         expect(label.y).to.equal(labelBounds.y);
 
       }));

--- a/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/LabelBehaviorSpec.js
@@ -621,7 +621,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
 
         // then
         expect(label.x).to.equal(labelBounds.x);
-        expect(label.y).to.be.below(labelBounds.y);
+        expect(label.y).to.be.at.most(labelBounds.y);
 
       }));
 
@@ -643,7 +643,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
         );
 
         // then
-        expect(label.x).to.be.above(labelBounds.x);
+        expect(label.x).to.be.at.least(labelBounds.x);
         expect(label.y).to.equal(labelBounds.y);
 
       }));
@@ -667,7 +667,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
 
         // then
         expect(label.x).to.equal(labelBounds.x);
-        expect(label.y).to.be.above(labelBounds.y);
+        expect(label.y).to.be.at.most(labelBounds.y);
 
       }));
 
@@ -689,7 +689,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
         );
 
         // then
-        expect(label.x).to.be.below(labelBounds.x);
+        expect(label.x).to.be.at.most(labelBounds.x);
         expect(label.y).to.equal(labelBounds.y);
 
       }));
@@ -739,7 +739,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
 
         // then
         expect(label.x).to.equal(labelBounds.x);
-        expect(label.y).to.be.below(labelBounds.y);
+        expect(label.y).to.be.at.most(labelBounds.y);
 
       }));
 
@@ -761,7 +761,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
         );
 
         // then
-        expect(label.x).to.be.above(labelBounds.x);
+        expect(label.x).to.be.at.most(labelBounds.x);
         expect(label.y).to.equal(labelBounds.y);
 
       }));
@@ -785,7 +785,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
 
         // then
         expect(label.x).to.equal(labelBounds.x);
-        expect(label.y).to.be.above(labelBounds.y);
+        expect(label.y).to.be.at.least(labelBounds.y);
 
       }));
 
@@ -807,7 +807,7 @@ describe('features/modeling/behavior - LabelBehavior', function() {
         );
 
         // then
-        expect(label.x).to.be.below(labelBounds.x);
+        expect(label.x).to.be.at.most(labelBounds.x);
         expect(label.y).to.equal(labelBounds.y);
 
       }));

--- a/test/spec/features/modeling/behavior/ResizeBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/ResizeBehaviorSpec.js
@@ -487,8 +487,8 @@ describe('features/modeling - resize behavior', function() {
       dragging.end();
 
       // then
-      expect(textAnnotation.width).to.equal(50);
-      expect(textAnnotation.height).to.equal(30);
+      expect(textAnnotation.width).to.equal(100);
+      expect(textAnnotation.height).to.equal(40);
     }));
 
   });

--- a/test/spec/features/modeling/layout/LayoutAssociationSpec.js
+++ b/test/spec/features/modeling/layout/LayoutAssociationSpec.js
@@ -40,7 +40,7 @@ describe('features/modeling - layout association', function() {
 
     // then
     expect(waypoints).to.eql([
-      { original: { x: 400, y: 400 }, x: 389, y: 385 },
+      { original: { x: 400, y: 405 }, x: 385, y: 385 },
       { original: { x: 191, y: 120 }, x: 202, y: 134 }
     ]);
 
@@ -62,7 +62,7 @@ describe('features/modeling - layout association', function() {
 
     // then
     expect(waypoints).to.eql([
-      { original: { x: 420, y: 400 }, x: 408, y: 385 },
+      { original: { x: 420, y: 405 }, x: 404, y: 385 },
       { original: { x: 191, y: 120 }, x: 202, y: 134 }
     ]);
 
@@ -88,7 +88,7 @@ describe('features/modeling - layout association', function() {
 
     // then
     expect(connection).to.have.waypoints([
-      { original: { x: 420, y: 400 }, x: 417, y: 385 },
+      { original: { x: 420, y: 400 }, x: 416, y: 385 },
       { x: 400, y: 300 },
       { original: { x: 191, y: 120 }, x: 204, y: 132 }
     ]);

--- a/test/spec/features/outline/OutlineProviderSpec.js
+++ b/test/spec/features/outline/OutlineProviderSpec.js
@@ -139,7 +139,7 @@ describe('features/outline - outline provider', function() {
 
       var DELTA = 3;
 
-      it('should update label according to label dimentions', inject(function(elementRegistry, selection, modeling) {
+      it('should update label according to label dimensions', inject(function(elementRegistry, selection, modeling) {
 
         // given
         var event = elementRegistry.get('Event');
@@ -158,8 +158,8 @@ describe('features/outline - outline provider', function() {
 
         // then
         bounds = outlineShape.getBoundingClientRect();
-        expect(bounds.width).to.be.closeTo(93, DELTA);
-        expect(bounds.height).to.be.closeTo(24, DELTA);
+        expect(bounds.width).to.be.closeTo(33, DELTA);
+        expect(bounds.height).to.be.closeTo(25, DELTA);
       }));
 
     });

--- a/test/spec/features/outline/OutlineProviderSpec.js
+++ b/test/spec/features/outline/OutlineProviderSpec.js
@@ -159,7 +159,7 @@ describe('features/outline - outline provider', function() {
         // then
         bounds = outlineShape.getBoundingClientRect();
         expect(bounds.width).to.be.closeTo(93, DELTA);
-        expect(bounds.height).to.be.closeTo(37, DELTA);
+        expect(bounds.height).to.be.closeTo(24, DELTA);
       }));
 
     });


### PR DESCRIPTION
### Proposed Changes

This pull request concerns dynamic resizing of text fields. To this end, labels have been made resizable and code has been added that adjusts the height of the text to match the width.

Closes https://github.com/bpmn-io/bpmn-js/issues/1513

## Visual demo
![2025-08-26 09-48-39](https://github.com/user-attachments/assets/eb9e6cb9-fe14-407f-a0b3-b97dcbd362cf)

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
