### PR TITLE
fix(label-link): only draw links if elements are on the visible plane

### DIFF
--- a/lib/features/label-link/LabelLink.js
+++ b/lib/features/label-link/LabelLink.js
@@ -77,7 +77,7 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
 
   eventBus.on('shape.changed', function({ element }) {
 
-    if (!isAny(element, ALLOWED_ELEMENTS)) {
+    if (!isAny(element, ALLOWED_ELEMENTS) || !isElementSelected(element)) {
       return;
     }
 
@@ -178,6 +178,10 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
 
   function getElementPath(element) {
     return graphicsFactory.getShapePath(element);
+  }
+
+  function isElementSelected(element) {
+    return selection.get().includes(element);
   }
 }
 

--- a/test/spec/features/label-link/LabelLink.bpmn
+++ b/test/spec/features/label-link/LabelLink.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="Start_Event" name="Start Event">
       <bpmn:outgoing>Sequence</bpmn:outgoing>
@@ -16,54 +16,65 @@
     <bpmn:endEvent id="End_Event" name="End Event">
       <bpmn:incoming>Flow_1n4vntt</bpmn:incoming>
       <bpmn:incoming>Sequence_Curved</bpmn:incoming>
-      <bpmn:incoming>Flow_08zlypo</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_08zlypo" sourceRef="Gateway" targetRef="End_Event" />
+    <bpmn:sequenceFlow id="Flow_08zlypo" sourceRef="Gateway" targetRef="Subprocess" />
+    <bpmn:subProcess id="Subprocess">
+      <bpmn:incoming>Flow_08zlypo</bpmn:incoming>
+      <bpmn:startEvent id="Subprocess_Event" name="Sub Event" />
+    </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Event_1qfvvdd_di" bpmnElement="Start_Event">
-        <dc:Bounds x="122" y="122" width="36" height="36" />
+        <dc:Bounds x="122" y="192" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="113" y="165" width="55" height="14" />
+          <dc:Bounds x="113" y="235" width="55" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0p419jh_di" bpmnElement="Gateway" isMarkerVisible="true">
-        <dc:Bounds x="275" y="115" width="50" height="50" />
+        <dc:Bounds x="275" y="185" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="328" y="63" width="44" height="14" />
+          <dc:Bounds x="328" y="133" width="44" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0blvhsu_di" bpmnElement="End_Event">
-        <dc:Bounds x="432" y="222" width="36" height="36" />
+        <dc:Bounds x="432" y="292" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="424" y="313" width="51" height="14" />
+          <dc:Bounds x="424" y="383" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0oyfdfi_di" bpmnElement="Subprocess" isExpanded="true">
+        <dc:Bounds x="450" y="130" width="140" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pl9qv3_di" bpmnElement="Subprocess_Event">
+        <dc:Bounds x="472" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="504" y="83" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0czsvkl_di" bpmnElement="Sequence">
-        <di:waypoint x="158" y="140" />
-        <di:waypoint x="275" y="140" />
+        <di:waypoint x="158" y="210" />
+        <di:waypoint x="275" y="210" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="192" y="122" width="50" height="14" />
+          <dc:Bounds x="192" y="192" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1n4vntt_di" bpmnElement="Flow_1n4vntt">
-        <di:waypoint x="300" y="165" />
-        <di:waypoint x="300" y="240" />
-        <di:waypoint x="432" y="240" />
+        <di:waypoint x="300" y="235" />
+        <di:waypoint x="300" y="310" />
+        <di:waypoint x="432" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15ovm9c_di" bpmnElement="Sequence_Curved">
-        <di:waypoint x="300" y="165" />
-        <di:waypoint x="300" y="240" />
-        <di:waypoint x="432" y="240" />
+        <di:waypoint x="300" y="235" />
+        <di:waypoint x="300" y="310" />
+        <di:waypoint x="432" y="310" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="345" y="183" width="50" height="14" />
+          <dc:Bounds x="345" y="253" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08zlypo_di" bpmnElement="Flow_08zlypo">
-        <di:waypoint x="325" y="140" />
-        <di:waypoint x="450" y="140" />
-        <di:waypoint x="450" y="222" />
+        <di:waypoint x="325" y="210" />
+        <di:waypoint x="450" y="210" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="645" y="183" width="50" height="14" />
         </bpmndi:BPMNLabel>

--- a/test/spec/features/label-link/LabelLinkSpec.js
+++ b/test/spec/features/label-link/LabelLinkSpec.js
@@ -6,6 +6,7 @@ import {
 import coreModule from 'lib/core';
 import modelingModule from 'lib/features/modeling';
 import outlineModule from 'lib/features/outline';
+import drilldownModule from 'lib/features/drilldown';
 import labelLinkModule from 'lib/features/label-link';
 
 import { queryAll as domQueryAll } from 'min-dom';
@@ -17,7 +18,13 @@ describe('features/label-link - label link', function() {
 
   var diagramXML = require('./LabelLink.bpmn');
 
-  var testModules = [ coreModule, modelingModule, outlineModule, labelLinkModule ];
+  var testModules = [
+    coreModule,
+    modelingModule,
+    outlineModule,
+    drilldownModule,
+    labelLinkModule
+  ];
 
   beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
 
@@ -38,7 +45,7 @@ describe('features/label-link - label link', function() {
       selection.select(element);
 
       // then
-      expectLinkWithPath('M450,265L450,313');
+      expectLinkWithPath('M450,335L450,383');
     })
   );
 
@@ -53,7 +60,7 @@ describe('features/label-link - label link', function() {
       selection.select(element);
 
       // then
-      expectLinkWithPath('M328.5,240L364,197');
+      expectLinkWithPath('M328,310L364,267');
     })
   );
 
@@ -68,7 +75,7 @@ describe('features/label-link - label link', function() {
       selection.select(element);
 
       // then
-      expectLinkWithPath('M318,115L345,77');
+      expectLinkWithPath('M318,185L345,147');
     })
   );
 
@@ -103,7 +110,7 @@ describe('features/label-link - label link', function() {
       const links = queryAllLinks();
       expect(links).to.have.length(1);
 
-      expectLinkWithPath('M532,255L459,313');
+      expectLinkWithPath('M532,325L459,383');
     })
   );
 
@@ -123,7 +130,7 @@ describe('features/label-link - label link', function() {
       const links = queryAllLinks();
       expect(links).to.have.length(1);
 
-      expectLinkWithPath('M464,251L533,306');
+      expectLinkWithPath('M464,321L533,376');
     })
   );
 
@@ -139,7 +146,92 @@ describe('features/label-link - label link', function() {
       selection.select([ element, label ]);
 
       // then
-      expectLinkWithPath('M450,265L450,306');
+      expectLinkWithPath('M450,335L450,376');
+    })
+  );
+
+
+  it('should show label for event in expanded subprocess', inject(
+    function(selection, elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('Subprocess_Event');
+
+      // when
+      selection.select(element);
+
+      // then
+      expectLinkWithPath('M498,169L527,97');
+    })
+  );
+
+
+  it('should show label for event in collapsed subprocess plane', inject(
+    function(selection, elementRegistry, bpmnReplace, canvas) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess');
+
+      // when
+      selection.select(subprocess);
+      bpmnReplace.replaceElement(subprocess, {
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+
+      var subprocessRoot = canvas.findRoot('Subprocess_plane');
+      canvas.setRootElement(subprocessRoot);
+
+      selection.select(elementRegistry.get('Subprocess_Event'));
+
+      // then
+      expectLinkWithPath('M206,246L235,174');
+    })
+  );
+
+
+  it('should not show label after collapsing a subprocess', inject(
+    function(selection, elementRegistry, bpmnReplace) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess');
+
+      // when
+      selection.select(subprocess);
+      bpmnReplace.replaceElement(subprocess, {
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+
+      // then
+      const links = queryAllLinks();
+      expect(links).to.have.length(0);
+    })
+  );
+
+
+  it('should not show label after expanding a subprocess', inject(
+    function(selection, elementRegistry, bpmnReplace) {
+
+      // given
+      const subprocess = elementRegistry.get('Subprocess');
+
+      // when
+      selection.select(subprocess);
+
+      bpmnReplace.replaceElement(subprocess, {
+        type: 'bpmn:SubProcess',
+        isExpanded: false
+      });
+
+      bpmnReplace.replaceElement(subprocess, {
+        type: 'bpmn:SubProcess',
+        isExpanded: true
+      });
+
+      // then
+      const links = queryAllLinks();
+      expect(links).to.have.length(0);
     })
   );
 });

--- a/test/util/svgHelpers.js
+++ b/test/util/svgHelpers.js
@@ -7,7 +7,7 @@
  */
 export function expectSvgPath(actual, expected, tolerance = 2) {
   const result = compareSvgPaths(actual, expected, tolerance);
-  expect(result).to.be.true;
+  expect(result).to.equal(true, `expected SVG path "${actual}" to approximately equal "${expected}"`);
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes

Before drawing a link, make sure the element is on the current plane.

This prevents links from staying on the root plane after a subprocess is collapsed.

**Good behavior**

![good-label-link](https://github.com/user-attachments/assets/92e91409-7492-4bfc-aee8-899eed2f3197)

**Current, bad behavior**

![bad-label-link](https://github.com/user-attachments/assets/fa921d54-b19d-4dc9-878b-4e7ecbe84456)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
