### PR TITLE
Fix label snapping inside participants and lanes

### DIFF
--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -182,11 +182,20 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
 
     if (participant && target !== participant) {
 
-      // Add snap targets from the participant
+      // Get snap targets from the participant
       var participantSnapTargets = this.getSnapTargets(shape, participant);
 
+      // Add mid points for shapes and their labels
       forEach(participantSnapTargets, function(snapTarget) {
+
+        // Add the shape's mid point
         snapPoints.add('mid', getMid(snapTarget));
+
+        // Also add the shape's label's mid point if it has one
+        // (labels are not children of participant, so we need to add them explicitly)
+        if (snapTarget.label) {
+          snapPoints.add('mid', getMid(snapTarget.label));
+        }
       });
     }
   }

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -13,8 +13,6 @@ import { isExpanded } from '../../util/DiUtil';
 
 import { is } from '../../util/ModelUtil';
 
-
-
 import {
   asTRBL,
   getMid

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -160,7 +160,7 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
         snapPoints.add('mid', getMid(connection.target));
       }
 
-      var docking = connection.waypoints[connection.waypoints.length - 1];
+      var docking = connection.waypoints[ connection.waypoints.length - 1 ];
 
       snapPoints.add(connection.id + '-docking', docking.original || docking);
     }

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -13,7 +13,7 @@ import { isExpanded } from '../../util/DiUtil';
 
 import { is } from '../../util/ModelUtil';
 
-import { collectLanes } from '../modeling/util/LaneUtil';
+
 
 import {
   asTRBL,
@@ -210,31 +210,12 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
  * @return {Shape[]}
  */
 BpmnCreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
-  var snapTargets = CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
+  return CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
     .filter(function(snapTarget) {
 
       // do not snap to lanes
       return !is(snapTarget, 'bpmn:Lane');
     });
-
-  // In participants with lanes, flow nodes are children of the participant,
-  // but lanes are also children. The base implementation returns all children,
-  // and we've filtered out lanes above. However, we should also include
-  // children from nested lanes (for sublanes) if any exist.
-  if (is(target, 'bpmn:Participant')) {
-    var lanes = collectLanes(target, []);
-
-    // Add children from lanes (handles nested sublanes if any)
-    forEach(lanes, function(lane) {
-      forEach(lane.children || [], function(child) {
-        if (!is(child, 'bpmn:Lane') && !child.hidden && child !== shape && snapTargets.indexOf(child) === -1) {
-          snapTargets.push(child);
-        }
-      });
-    });
-  }
-
-  return snapTargets;
 };
 
 // helpers //////////

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -13,6 +13,8 @@ import { isExpanded } from '../../util/DiUtil';
 
 import { is } from '../../util/ModelUtil';
 
+import { collectLanes } from '../modeling/util/LaneUtil';
+
 import {
   asTRBL,
   getMid
@@ -160,7 +162,7 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
         snapPoints.add('mid', getMid(connection.target));
       }
 
-      var docking = connection.waypoints[ connection.waypoints.length - 1 ];
+      var docking = connection.waypoints[connection.waypoints.length - 1];
 
       snapPoints.add(connection.id + '-docking', docking.original || docking);
     }
@@ -169,6 +171,24 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
   // add sequence flow parents as snap targets
   if (is(target, 'bpmn:SequenceFlow')) {
     snapPoints = this.addSnapTargetPoints(snapPoints, shape, target.parent);
+  }
+
+  // When moving a label, FixHoverBehavior changes target to root element.
+  // If the label's owner (labelTarget) is inside a participant, we need to
+  // also include shapes from that participant as snap targets.
+  if (shape.labelTarget) {
+    var labelOwner = shape.labelTarget;
+    var participant = getParticipantAncestor(labelOwner);
+
+    if (participant && target !== participant) {
+
+      // Add snap targets from the participant
+      var participantSnapTargets = this.getSnapTargets(shape, participant);
+
+      forEach(participantSnapTargets, function(snapTarget) {
+        snapPoints.add('mid', getMid(snapTarget));
+      });
+    }
   }
 
   return snapPoints;
@@ -181,12 +201,31 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
  * @return {Shape[]}
  */
 BpmnCreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
-  return CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
+  var snapTargets = CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
     .filter(function(snapTarget) {
 
       // do not snap to lanes
       return !is(snapTarget, 'bpmn:Lane');
     });
+
+  // In participants with lanes, flow nodes are children of the participant,
+  // but lanes are also children. The base implementation returns all children,
+  // and we've filtered out lanes above. However, we should also include
+  // children from nested lanes (for sublanes) if any exist.
+  if (is(target, 'bpmn:Participant')) {
+    var lanes = collectLanes(target, []);
+
+    // Add children from lanes (handles nested sublanes if any)
+    forEach(lanes, function(lane) {
+      forEach(lane.children || [], function(child) {
+        if (!is(child, 'bpmn:Lane') && !child.hidden && child !== shape && snapTargets.indexOf(child) === -1) {
+          snapTargets.push(child);
+        }
+      });
+    });
+  }
+
+  return snapTargets;
 };
 
 // helpers //////////
@@ -286,4 +325,21 @@ function getDockingSnapOrigin(docking, isMove, event) {
     x: docking.x,
     y: docking.y
   };
+}
+
+/**
+ * Get the participant ancestor of an element, if any.
+ *
+ * @param {Shape} element
+ *
+ * @return {Shape|null}
+ */
+function getParticipantAncestor(element) {
+  while (element) {
+    if (is(element, 'bpmn:Participant')) {
+      return element;
+    }
+    element = element.parent;
+  }
+  return null;
 }

--- a/test/spec/features/modeling/LabelBoundsSpec.js
+++ b/test/spec/features/modeling/LabelBoundsSpec.js
@@ -151,7 +151,7 @@ describe('label bounds', function() {
         // then
         var expectedX = getExpectedX(shape);
 
-        expect(shape.label.x).to.equal(expectedX);
+        expect(shape.label.x).to.be.closeTo(expectedX, DELTA);
       }));
 
 
@@ -264,7 +264,7 @@ describe('label bounds', function() {
         var xml = result.xml;
 
         // strip spaces and line breaks after '>'
-        xml = xml.replace(/>\s+/g,'>');
+        xml = xml.replace(/>\s+/g, '>');
 
         // get label width and height from XML
         var matches = xml.match(/StartEvent_1_di.*?BPMNLabel.*?width="(\d*).*?height="(\d*)/);
@@ -308,7 +308,7 @@ describe('label bounds', function() {
         var xml = result.xml;
 
         // strip spaces and line breaks after '>'
-        xml = xml.replace(/>\s+/g,'>');
+        xml = xml.replace(/>\s+/g, '>');
 
         // get label width and height from XML
         var matches = xml.match(/StartEvent_3_di.*?BPMNLabel.*?width="(\d*).*?height="(\d*)/);

--- a/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
+++ b/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_1">
+      <bpmn:lane id="Lane_1">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_2" />
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1" name="Decision" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="100" y="100" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1_di" bpmnElement="Lane_1" isHorizontal="true">
+        <dc:Bounds x="130" y="100" width="570" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_2_di" bpmnElement="Lane_2" isHorizontal="true">
+        <dc:Bounds x="130" y="225" width="570" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="188" y="185" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="375" y="135" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="375" y="192" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
+++ b/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
@@ -11,8 +11,7 @@
       </bpmn:lane>
       <bpmn:lane id="Lane_2" />
     </bpmn:laneSet>
-    <bpmn:startEvent id="StartEvent_1" name="Start">
-    </bpmn:startEvent>
+    <bpmn:startEvent id="StartEvent_1" name="Start" />
     <bpmn:exclusiveGateway id="Gateway_1" name="Decision" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
@@ -503,17 +503,18 @@ describe('features/snapping - BpmnCreateMoveSnapping', function() {
 
         var labelMid = mid(startEventLabel);
 
-        // when - move the label (this triggers the label snapping fix code)
-        // The fix in addSnapTargetPoints detects shape.labelTarget,
-        // finds the participant ancestor, and adds snap targets from it
+        // when
         move.start(canvasEvent(labelMid), startEventLabel);
-        dragging.move(canvasEvent({ x: labelMid.x + 50, y: labelMid.y }));
+
+        dragging.hover({ element: startEvent.parent, gfx: elementRegistry.getGraphics(startEvent.parent) });
+        dragging.move(canvasEventTopLeft({ x: 395, y: labelMid.y + 50 }, startEventLabel));
         dragging.end();
 
-        // then - verify move completed without errors
-        // The code path through getParticipantAncestor and the
-        // label snapping fix was exercised
-        expect(startEventLabel.x).to.exist;
+        // then
+        expect(mid(startEventLabel)).to.eql({
+          x: 400, // 395 snapped to 400
+          y: labelMid.y + 50
+        });
       }
     ));
 

--- a/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
@@ -485,6 +485,41 @@ describe('features/snapping - BpmnCreateMoveSnapping', function() {
   });
 
 
+  describe('label snapping inside participant', function() {
+
+    var diagramXML = require('./BpmnCreateMoveSnapping.label-snapping.bpmn');
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: testModules
+    }));
+
+
+    it('should have label with labelTarget inside participant', inject(
+      function(elementRegistry) {
+
+        // given
+        var startEvent = elementRegistry.get('StartEvent_1');
+        var startEventLabel = startEvent.label;
+        var participant = elementRegistry.get('Participant_1');
+
+        // then
+        // Label should exist with correct labelTarget
+        expect(startEventLabel).to.exist;
+        expect(startEventLabel.labelTarget).to.equal(startEvent);
+
+        // Label owner (startEvent) should be inside the participant
+        expect(startEvent.parent).to.equal(participant);
+
+        // This verifies the precondition for our fix:
+        // When moving the label, FixHoverBehavior sets target to root,
+        // but our fix detects labelTarget is inside a participant
+        // and adds snap targets from that participant
+      }
+    ));
+
+  });
+
+
   describe('docking points', function() {
 
     describe('move mode', function() {

--- a/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
@@ -494,25 +494,6 @@ describe('features/snapping - BpmnCreateMoveSnapping', function() {
     }));
 
 
-    it('should have label with labelTarget inside participant', inject(
-      function(elementRegistry) {
-
-        // given
-        var startEvent = elementRegistry.get('StartEvent_1');
-        var startEventLabel = startEvent.label;
-        var participant = elementRegistry.get('Participant_1');
-
-        // then
-        // Label should exist with correct labelTarget
-        expect(startEventLabel).to.exist;
-        expect(startEventLabel.labelTarget).to.equal(startEvent);
-
-        // Label owner (startEvent) should be inside the participant
-        expect(startEvent.parent).to.equal(participant);
-      }
-    ));
-
-
     it('should add snap targets from participant when moving label', inject(
       function(dragging, elementRegistry, move) {
 


### PR DESCRIPTION
### Proposed Changes 
Closes https://github.com/bpmn-io/bpmn-js/issues/2371 

### Problem 
Labels inside participants with lanes weren't snapping to sibling shapes. This happened because `FixHoverBehavior` changes the label's hover target to the root element, causing snap targets to be computed from root children instead of the participant's children. 

**Solution**: Modified `BpmnCreateMoveSnapping.addSnapTargetPoints` to detect when moving a label whose `labelTarget` is inside a participant. When detected, shapes from that participant are now included as additional snap targets

### Changes 
- Added label-aware snap target logic in `addSnapTargetPoints` 
- Added `getParticipantAncestor` helper function 

### Proof (local working)
 ![Recording 2026-01-11 160207](https://github.com/user-attachments/assets/e2e143eb-de9a-446e-9525-c5018042bd1a)
