### PR TITLE
fix: null check connection `sourceRef`

### DIFF
--- a/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
+++ b/lib/features/modeling/behavior/ReplaceConnectionBehavior.js
@@ -178,7 +178,7 @@ export default function ReplaceConnectionBehavior(eventBus, modeling, bpmnRules,
     }
 
     // remove default from source on change to conditional
-    if (properties.conditionExpression && businessObject.sourceRef.default === businessObject) {
+    if (properties.conditionExpression && businessObject.sourceRef?.default === businessObject) {
       modeling.updateProperties(element.source, { default: undefined });
     }
   });


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

A conditional expression is now reused for Conditional Events, which don't have `sourceRef`, so I added a null check to make this behavior compatible with the new element type.

Required for https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1176

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
