### PR TITLE
Prevent keyboard movement of boundary events without their host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: activate wheel zoom/scoll on `mouseover` ([#1008](https://github.com/bpmn-io/diagram-js/pull/1008))
+* `FEAT`: prevent keyboard movement for boundary events without host ([#2386](https://github.com/bpmn-io/bpmn-js/pull/2386))
 * `DEPS`: update to `diagram-js@15.9.0`
 
 ## 18.11.0

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -161,7 +161,19 @@ BpmnRules.prototype.init = function() {
 
     var target = context.target,
         shapes = context.shapes,
-        position = context.position;
+        position = context.position,
+        hints = context.hints;
+
+    // prevent keyboard movement of boundary events without host
+    if (hints?.keyboardMove) {
+      const hasAttachedEventWithoutHost = shapes.some(function(shape) {
+        return isBoundaryEvent(shape) && !shapes.includes(shape.host);
+      });
+
+      if (hasAttachedEventWithoutHost) {
+        return false;
+      }
+    }
 
     return canAttach(shapes, target, null, position) ||
            canReplace(shapes, target, position) ||

--- a/test/spec/features/keyboard-move-selection/KeyboardMoveSelectionSpec.js
+++ b/test/spec/features/keyboard-move-selection/KeyboardMoveSelectionSpec.js
@@ -75,4 +75,53 @@ describe('features/keyboard-move-selection', function() {
     expect(getMid(lane)).to.eql(mid);
   }));
 
+
+  it('should NOT move boundary event without host', inject(
+    function(elementRegistry, keyboardMoveSelection, selection, rules) {
+
+      // given
+      var boundaryEvent = elementRegistry.get('BoundaryEvent_on_Task');
+
+      selection.select(boundaryEvent);
+
+      var mid = getMid(boundaryEvent);
+      var hostBeforeMove = boundaryEvent.host;
+
+      // when
+      keyboardMoveSelection.moveSelection('right');
+      keyboardMoveSelection.moveSelection('right');
+      keyboardMoveSelection.moveSelection('right');
+
+      // then
+
+      // position should not change
+      expect(getMid(boundaryEvent)).to.eql(mid);
+
+      // shouldn't be deattached from host
+      expect(boundaryEvent.host).to.equal(hostBeforeMove);
+    }
+  ));
+
+
+  it('should move boundary event with host', inject(
+    function(elementRegistry, keyboardMoveSelection, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_1');
+      var boundaryEvent = elementRegistry.get('BoundaryEvent_on_Task');
+
+      selection.select([ task, boundaryEvent ]);
+
+      var taskMid = getMid(task);
+      var boundaryMid = getMid(boundaryEvent);
+
+      // when
+      keyboardMoveSelection.moveSelection('right');
+
+      // then
+      expect(getMid(task)).not.to.eql(taskMid);
+      expect(getMid(boundaryEvent)).not.to.eql(boundaryMid);
+    }
+  ));
+
 });

--- a/test/spec/features/keyboard-move-selection/keyboard-move-selection.bpmn
+++ b/test/spec/features/keyboard-move-selection/keyboard-move-selection.bpmn
@@ -11,6 +11,7 @@
       <bpmn:lane id="Lane_2" />
     </bpmn:laneSet>
     <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_on_Task" attachedToRef="Task_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
@@ -25,6 +26,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1y7dv59_di" bpmnElement="Task_1">
         <dc:Bounds x="50" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0f3xtwc_di" bpmnElement="BoundaryEvent_on_Task">
+        <dc:Bounds x="82" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1517,6 +1517,55 @@ describe('features/modeling/rules - BpmnRules', function() {
         });
       }
     ));
+  });
+
+
+  describe('event keyboard move', function() {
+
+    var testXML = require('./BpmnRules.boundaryEvent.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+
+    it('should NOT allow keyboard move of boundary event without host',
+      inject(function(elementRegistry, rules) {
+
+        // given
+        var boundaryEvent = elementRegistry.get('BoundaryEvent_on_Task');
+
+        // when
+        var canMove = rules.allowed('elements.move', {
+          shapes: [ boundaryEvent ],
+          hints: {
+            keyboardMove: true
+          }
+        });
+
+        // then
+        expect(canMove).to.be.false;
+      })
+    );
+
+
+    it('should allow keyboard move of boundary event with host',
+      inject(function(elementRegistry, rules) {
+
+        // given
+        var task = elementRegistry.get('Task');
+        var boundaryEvent = elementRegistry.get('BoundaryEvent_on_Task');
+
+        // when
+        var canMove = rules.allowed('elements.move', {
+          shapes: [ task, boundaryEvent ],
+          hints: {
+            keyboardMove: true
+          }
+        });
+
+        // then
+        expect(canMove).to.be.true;
+      })
+    );
 
   });
 


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/bpmn-io/bpmn-js/issues/1803
Closes https://github.com/bpmn-io/bpmn-js/issues/1876

Disable keyboard movement of boundary events without their host (cf. https://github.com/bpmn-io/bpmn-js/issues/1803#issuecomment-3846254260)

https://github.com/user-attachments/assets/5032e55f-bd48-41dc-8998-b342a694334a

**Try it:** 
`npx @bpmn-io/sr bpmn-io/bpmn-js#1803-disable-boundaryEvent-keyboard-move -l bpmn-io/diagram-js#keyboard-move-add-flag`

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
