### PR TITLE
fix: explicitly set `isInterrupting` for events in the replace menu

### DIFF
--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -1008,7 +1008,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-message',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:MessageEventDefinition'
+        eventDefinitionType: 'bpmn:MessageEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1046,7 +1047,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-timer',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:TimerEventDefinition'
+        eventDefinitionType: 'bpmn:TimerEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1066,7 +1068,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-condition',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:ConditionalEventDefinition'
+        eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1086,7 +1089,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-signal',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:SignalEventDefinition'
+        eventDefinitionType: 'bpmn:SignalEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1124,7 +1128,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-error',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:ErrorEventDefinition'
+        eventDefinitionType: 'bpmn:ErrorEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1144,7 +1149,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-escalation',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:EscalationEventDefinition'
+        eventDefinitionType: 'bpmn:EscalationEventDefinition',
+        isInterrupting: true
       }
     },
     {
@@ -1173,7 +1179,8 @@ export var TYPED_EVENT = {
       className: 'bpmn-icon-start-event-compensation',
       target: {
         type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:CompensateEventDefinition'
+        eventDefinitionType: 'bpmn:CompensateEventDefinition',
+        isInterrupting: true
       }
     },
     {

--- a/test/fixtures/bpmn/draw/activity-markers-simple.bpmn
+++ b/test/fixtures/bpmn/draw/activity-markers-simple.bpmn
@@ -20,7 +20,11 @@
     <bpmn2:subProcess id="SubProcess" />
     <bpmn2:transaction id="Transaction" />
     <bpmn2:adHocSubProcess id="AdHocSubProcess" />
-    <bpmn2:subProcess id="EventSubProcess" triggeredByEvent="true" />
+    <bpmn2:subProcess id="EventSubProcess" triggeredByEvent="true">
+      <bpmn2:startEvent id="MessageStartEvent">
+        <bpmn2:messageEventDefinition id="MessageEventDefinition_0xmds0m" />
+      </bpmn2:startEvent>
+    </bpmn2:subProcess>
     <bpmn2:adHocSubProcess id="AdHocSubProcessExpanded" />
     <bpmn2:subProcess id="SubProcessCollapsed" />
     <bpmn2:task id="TaskCompensation" name="Task" isForCompensation="true"/>
@@ -39,9 +43,6 @@
       <bpmndi:BPMNShape id="_BPMNShape_Task_8" bpmnElement="Task">
         <dc:Bounds x="588" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0378hpz" bpmnElement="TaskCompensation">
-        <dc:Bounds x="1000" y="100" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_di" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="161" y="224" width="350" height="200" />
       </bpmndi:BPMNShape>
@@ -54,11 +55,17 @@
       <bpmndi:BPMNShape id="SubProcess_0oip8c9_di" bpmnElement="EventSubProcess" isExpanded="true">
         <dc:Bounds x="161" y="474" width="350" height="200" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0iocal3_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="202" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lpc84d_di" bpmnElement="AdHocSubProcessExpanded" isExpanded="true">
         <dc:Bounds x="556" y="474" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0qrv1en_di" bpmnElement="SubProcessCollapsed">
         <dc:Bounds x="860" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0378hpz" bpmnElement="TaskCompensation">
+        <dc:Bounds x="1000" y="100" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -1056,6 +1056,28 @@ describe('features/popup-menu - replace menu provider', function() {
       })
     );
 
+
+    it('should replace interrupting event <-> non-interrupting event',
+      inject(function(elementRegistry) {
+
+        // given
+        const event = elementRegistry.get('MessageStartEvent');
+
+        // when
+        openPopup(event);
+        const nonInterruptingEvent = triggerAction('replace-with-non-interrupting-message-start');
+
+        // then
+        expect(nonInterruptingEvent.businessObject.isInterrupting, 'isInterrupting').to.be.false;
+
+        // when
+        openPopup(nonInterruptingEvent);
+        const interruptingEvent = triggerAction('replace-with-message-start');
+
+        // then
+        expect(interruptingEvent.businessObject.isInterrupting, 'isInterrupting').to.be.true;
+      })
+    );
   });
 
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/bpmn-js/issues/2313 
Related to https://github.com/camunda/camunda-modeler/issues/5395

### Proposed Changes

Explicitly set `isInterrupting` to `true` for the interrupting events in the replace menu. This allows a non-interrupting event to be replaced with its interrupting counterpart.

### Try it

`npm start` and mess around with events.

![evnts-fix](https://github.com/user-attachments/assets/3abb527a-42d2-4e81-a21b-aab75a2232ef)


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
