### PR TITLE
fix(snapping): allow label snapping inside participants and lanes

### DIFF
--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -3,6 +3,7 @@ import inherits from 'inherits-browser';
 import CreateMoveSnapping from 'diagram-js/lib/features/snapping/CreateMoveSnapping';
 
 import {
+  getChildren,
   isSnapped,
   setSnapped,
   topLeft,
@@ -181,12 +182,31 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
  * @return {Shape[]}
  */
 BpmnCreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
-  return CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
+  var snapTargets = CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
     .filter(function(snapTarget) {
 
       // do not snap to lanes
       return !is(snapTarget, 'bpmn:Lane');
     });
+
+  // When a label is inside a participant/lane, FixHoverBehavior re-routes the
+  // hover target to the root element. In that case, getChildren(root) only
+  // returns participants — not the shapes inside them. We therefore also
+  // collect snap targets from the label's actual parent so that alignment
+  // helpers (snap lines) work correctly inside participants and lanes.
+  if (shape.labelTarget && shape.parent && shape.parent !== target) {
+    var parentChildren = getChildren(shape.parent).filter(function(child) {
+      return !child.hidden && !is(child, 'bpmn:Lane');
+    });
+
+    forEach(parentChildren, function(child) {
+      if (snapTargets.indexOf(child) === -1) {
+        snapTargets = snapTargets.concat([ child ]);
+      }
+    });
+  }
+
+  return snapTargets;
 };
 
 // helpers //////////


### PR DESCRIPTION
Fixes #2371

Root Cause: > FixHoverBehavior.js:49 forces the hover target to the root element whenever a label is being moved. In a collaboration diagram, the root is the collaboration element whose direct children are only participants — not the gateway/event shapes inside them. So getSnapTargets returned an empty set for labels inside participants, making alignment snap lines invisible.

Fix: > In BpmnCreateMoveSnapping.js, the getSnapTargets method now detects when the moving shape is a label whose actual parent differs from the forced root target (shape.labelTarget && shape.parent !== target). In that case, it additionally collects siblings from the label's real parent container (the lane/participant), merging them into the snap target list. This gives the snapping system access to the label's siblings (other labels, the labelTarget gateway/event, etc.), restoring the alignment helpers inside participants and lanes.