### PR TITLE
Fix alignment tools working inside participant/lane

### DIFF
--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -126,6 +126,17 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
 
   var snapTargets = this.getSnapTargets(shape, target);
 
+  // If shape is an external label, add its labelTarget as a snap target
+  // This ensures alignment works inside participant/lane
+  if (shape.labelTarget) {
+    var labelTarget = shape.labelTarget;
+    if (!includes(snapTargets, labelTarget)) {
+      snapPoints.add('mid', getMid(labelTarget));
+      snapPoints.add('top-left', topLeft(labelTarget));
+      snapPoints.add('bottom-right', bottomRight(labelTarget));
+    }
+  }
+
   forEach(snapTargets, function(snapTarget) {
 
     // handle TRBL alignment


### PR DESCRIPTION
## Problem

Alignment helpers (snap lines) work correctly for external labels outside of a participant, but fail to provide alignment assistance when the element is inside a participant or lane. The label target is not recognized as a "peer" for horizontal center alignment.

## Solution

Updated the alignment logic to correctly identify label targets inside participants and lanes. The snap line calculation now consistently handles elements regardless of their modeling context.

## Validation

- External labels inside participant/lane now show alignment snap lines
- Behavior is consistent with elements outside of participant
- Horizontal center alignment works correctly

Fixes #2371