### PR TITLE
feat: activate direct editing for new activities and events

### DIFF
--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -149,8 +149,7 @@ export default function LabelEditingProvider(
 
   function activateDirectEdit(element, force) {
     if (force ||
-        isAny(element, [ 'bpmn:Task', 'bpmn:TextAnnotation', 'bpmn:Participant' ]) ||
-        isCollapsedSubProcess(element)) {
+        isAny(element, [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:TextAnnotation', 'bpmn:Participant' ])) {
 
       directEditing.activate(element);
     }

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -7,7 +7,8 @@ import {
 } from '../../util/LabelUtil';
 
 import {
-  is
+  is,
+  getBusinessObject
 } from '../../util/ModelUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
@@ -149,7 +150,8 @@ export default function LabelEditingProvider(
 
   function activateDirectEdit(element, force) {
     if (force ||
-        isAny(element, [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:TextAnnotation', 'bpmn:Participant' ])) {
+        isAny(element, [ 'bpmn:Activity', 'bpmn:TextAnnotation', 'bpmn:Participant' ]) ||
+        (is(element, 'bpmn:Event') && !isPlainStartOrEndEvent(element))) {
 
       directEditing.activate(element);
     }
@@ -516,4 +518,11 @@ function isExpandedPool(element) {
 
 function isEmptyText(label) {
   return !label || !label.trim();
+}
+
+function isPlainStartOrEndEvent(element) {
+  var businessObject = getBusinessObject(element);
+
+  return isAny(element, [ 'bpmn:StartEvent', 'bpmn:EndEvent' ]) &&
+    !(businessObject.eventDefinitions && businessObject.eventDefinitions.length);
 }

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -573,8 +573,8 @@ describe('features - label-editing', function() {
 
     describe('on element creation', function() {
 
-      function createTaskElement(context) {
-        var shape = elementFactory.create('shape', { type: 'bpmn:Task' }),
+      function createElement(type, context) {
+        var shape = elementFactory.create('shape', { type: type }),
             parent = elementRegistry.get('SubProcess_1'),
             parentGfx = elementRegistry.getGraphics(parent);
 
@@ -585,6 +585,10 @@ describe('features - label-editing', function() {
         });
         dragging.move(canvasEvent({ x: 400, y: 250 }));
         dragging.end();
+      }
+
+      function createTaskElement(context) {
+        createElement('bpmn:Task', context);
       }
 
       function createParticipant() {
@@ -623,6 +627,117 @@ describe('features - label-editing', function() {
 
           // then
           expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on StartEvent creation', function() {
+
+          // when
+          createElement('bpmn:StartEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on EndEvent creation', function() {
+
+          // when
+          createElement('bpmn:EndEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on IntermediateThrowEvent creation', function() {
+
+          // when
+          createElement('bpmn:IntermediateThrowEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on CallActivity creation', function() {
+
+          // when
+          createElement('bpmn:CallActivity');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+        it('on subProcess creation', function() {
+
+          // when
+          createElement('bpmn:SubProcess');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+        it('on adHocSubProcess creation', function() {
+
+          // when
+          createElement('bpmn:AdHocSubProcess');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+      });
+
+      describe('should NOT activate', function() {
+
+        it('on ExclusiveGateway creation', function() {
+
+          // when
+          createElement('bpmn:ExclusiveGateway');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+        });
+
+
+        it('on ParallelGateway creation', function() {
+
+          // when
+          createElement('bpmn:ParallelGateway');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+        });
+
+
+        it('on InclusiveGateway creation', function() {
+
+          // when
+          createElement('bpmn:InclusiveGateway');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+        });
+
+
+        it('on ComplexGateway creation', function() {
+
+          // when
+          createElement('bpmn:ComplexGateway');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+        });
+
+
+        it('on EventBasedGateway creation', function() {
+
+          // when
+          createElement('bpmn:EventBasedGateway');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
         });
 
       });

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -669,7 +669,7 @@ describe('features - label-editing', function() {
           expect(directEditing.isActive()).to.be.true;
         });
 
-        it('on subProcess creation', function() {
+        it('on SubProcess creation', function() {
 
           // when
           createElement('bpmn:SubProcess');
@@ -678,7 +678,7 @@ describe('features - label-editing', function() {
           expect(directEditing.isActive()).to.be.true;
         });
 
-        it('on adHocSubProcess creation', function() {
+        it('on AdHocSubProcess creation', function() {
 
           // when
           createElement('bpmn:AdHocSubProcess');

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -630,26 +630,6 @@ describe('features - label-editing', function() {
         });
 
 
-        it('on StartEvent creation', function() {
-
-          // when
-          createElement('bpmn:StartEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.true;
-        });
-
-
-        it('on EndEvent creation', function() {
-
-          // when
-          createElement('bpmn:EndEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.true;
-        });
-
-
         it('on IntermediateThrowEvent creation', function() {
 
           // when
@@ -701,6 +681,26 @@ describe('features - label-editing', function() {
           // then
           expect(directEditing.isActive()).to.be.false;
 
+        });
+
+
+        it('on plain StartEvent creation', function() {
+
+          // when
+          createElement('bpmn:StartEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+        });
+
+
+        it('on plain EndEvent creation', function() {
+
+          // when
+          createElement('bpmn:EndEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
         });
 
 

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -691,6 +691,19 @@ describe('features - label-editing', function() {
 
       describe('should NOT activate', function() {
 
+        it('with behavior hint', function() {
+
+          // when
+          createTaskElement({
+            hints: { createElementsBehavior: false }
+          });
+
+          // then
+          expect(directEditing.isActive()).to.be.false;
+
+        });
+
+
         it('on ExclusiveGateway creation', function() {
 
           // when
@@ -740,21 +753,8 @@ describe('features - label-editing', function() {
           expect(directEditing.isActive()).to.be.false;
         });
 
-      });
-
-
-      it('should NOT activate with behavior hint', function() {
-
-        // when
-        createTaskElement({
-          hints: { createElementsBehavior: false }
-        });
-
-        // then
-        expect(directEditing.isActive()).to.be.false;
 
       });
-
 
     });
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

closes #748 

Immediately open the name editor after creating any new activity (not just tasks) or any new event.

I excluded plain start and end events because:
- These typically do not have labels associated with them
- Plain start events in subprocesses (based on team feedback) almost never have labels. I believe we should treat plain start events consistently.


https://github.com/user-attachments/assets/d02d4d2e-2ec8-4908-808a-01343e0961f7


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
