### PR TITLE
Security: Unescaped attribute/value composition in XML-like string helper

### DIFF
--- a/lib/import/Util.js
+++ b/lib/import/Util.js
@@ -3,5 +3,18 @@ export function elementToString(e) {
     return '<null>';
   }
 
-  return '<' + e.$type + (e.id ? ' id="' + e.id : '') + '" />';
+  return '<' + escapeAttr(e.$type) + (e.id ? ' id="' + escapeAttr(e.id) : '') + '" />';
+}
+
+function escapeAttr(value) {
+  return String(value).replace(/[&<>"']/g, function(match) {
+    switch (match) {
+    case '&': return '&amp;';
+    case '<': return '&lt;';
+    case '>': return '&gt;';
+    case '"': return '&quot;';
+    case '\'': return '&#39;';
+    default: return match;
+    }
+  });
 }


### PR DESCRIPTION
## Problem

`elementToString` concatenates `e.$type` and `e.id` directly into an XML-like string without escaping. If these values are attacker-controlled and later rendered in HTML logs/UI, this can enable injection (markup break-out/XSS) or log forging.

**Severity**: `low`
**File**: `lib/import/Util.js`

## Solution

Escape XML/HTML special characters for dynamic fields (`<`, `>`, `&`, `"`, `'`) before interpolation, or return a structured object and serialize safely at output boundaries.

## Changes

- `lib/import/Util.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
