### PR TITLE
Improve direct editing for events / start outside of sub-process

### DIFF
--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -148,13 +148,28 @@ export default function LabelEditingProvider(
 
 
   function activateDirectEdit(element, force) {
-    if (force ||
-        isAny(element, [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:TextAnnotation', 'bpmn:Participant' ])) {
-
+    if (force || isLabeledElement(element)) {
       directEditing.activate(element);
     }
   }
 
+}
+
+function isLabeledElement(element) {
+
+  if (isAny(element, [
+    'bpmn:Activity',
+    'bpmn:TextAnnotation',
+    'bpmn:Participant',
+    'bpmn:Event',
+    'bpmn:DataObjectReference',
+    'bpmn:DataStoreReference',
+    'bpmn:Group'
+  ])) {
+    return true;
+  }
+
+  return false;
 }
 
 LabelEditingProvider.$inject = [

--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -7,8 +7,7 @@ import {
 } from '../../util/LabelUtil';
 
 import {
-  is,
-  getBusinessObject
+  is
 } from '../../util/ModelUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
@@ -150,8 +149,7 @@ export default function LabelEditingProvider(
 
   function activateDirectEdit(element, force) {
     if (force ||
-        isAny(element, [ 'bpmn:Activity', 'bpmn:TextAnnotation', 'bpmn:Participant' ]) ||
-        (is(element, 'bpmn:Event') && !isPlainStartOrEndEvent(element))) {
+        isAny(element, [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:TextAnnotation', 'bpmn:Participant' ])) {
 
       directEditing.activate(element);
     }
@@ -518,11 +516,4 @@ function isExpandedPool(element) {
 
 function isEmptyText(label) {
   return !label || !label.trim();
-}
-
-function isPlainStartOrEndEvent(element) {
-  var businessObject = getBusinessObject(element);
-
-  return isAny(element, [ 'bpmn:StartEvent', 'bpmn:EndEvent' ]) &&
-    !(businessObject.eventDefinitions && businessObject.eventDefinitions.length);
 }

--- a/test/spec/features/label-editing/LabelEditing.bpmn
+++ b/test/spec/features/label-editing/LabelEditing.bpmn
@@ -1,47 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.0">
   <bpmn:collaboration id="Collaboration_1o0amh9">
     <bpmn:participant id="Participant_1" name="FOO BAR" processRef="Process_1" />
     <bpmn:participant id="Participant_2" />
     <bpmn:participant id="Participant_3" name="VER" processRef="Process_3" />
     <bpmn:participant id="Participant_4" name="CAL" />
     <bpmn:messageFlow id="MessageFlow_1" name="FOO" sourceRef="Task_1fo1fvh" targetRef="Participant_2" />
-    <bpmn:textAnnotation id="TextAnnotation_1">    <bpmn:text>FOO</bpmn:text>
-</bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>FOO</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
+    <bpmn:group id="Group_2" />
   </bpmn:collaboration>
   <bpmn:process id="Process_1" isExecutable="false">
-    <bpmn:laneSet>
-      <bpmn:lane id="Lane_2">
-        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>SubProcess_1</bpmn:flowNodeRef>
-      </bpmn:lane>
-      <bpmn:lane id="Lane_1" name="FOO BAR">
-        <bpmn:flowNodeRef>StartEvent_08jn2xd</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Task_1</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Task_1fo1fvh</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>ExclusiveGateway_1</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>SubProcess_2</bpmn:flowNodeRef>
-      </bpmn:lane>
-    </bpmn:laneSet>
     <bpmn:ioSpecification>
-      <bpmn:dataInput name="Input" isCollection="false" id="DataInput"/>
-      <bpmn:dataOutput name="Output" isCollection="false" id="DataOutput"/>
+      <bpmn:dataInput id="DataInput" name="Input" />
+      <bpmn:dataOutput id="DataOutput" name="Output" />
       <bpmn:inputSet id="_9f9aea93-30cd-4899-bbe1-e62165c3dbc9">
         <bpmn:dataInputRefs>DataInput</bpmn:dataInputRefs>
       </bpmn:inputSet>
       <bpmn:outputSet id="_8154d47e-5733-41c1-8125-29ff926b3cd2">
         <bpmn:dataOutputRefs>DataOutput</bpmn:dataOutputRefs>
       </bpmn:outputSet>
-      </bpmn:ioSpecification>
+    </bpmn:ioSpecification>
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_2">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>SubProcess_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1" name="FOO BAR">
+        <bpmn:flowNodeRef>SubProcess_2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>StartEvent_08jn2xd</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_1fo1fvh</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
     <bpmn:startEvent id="StartEvent_1" name="FOO">
       <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="StartEvent_1" targetRef="SubProcess_1" />
-    <bpmn:subProcess id="SubProcess_1" name="FOO">
-      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_14kuv1e</bpmn:outgoing>
-    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="SequenceFlow_14kuv1e" sourceRef="SubProcess_1" targetRef="Task_1" />
+    <bpmn:subProcess id="SubProcess_2" />
     <bpmn:startEvent id="StartEvent_08jn2xd" name="FOO&#10;BAR">
       <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
     </bpmn:startEvent>
@@ -51,28 +52,28 @@
       <bpmn:outgoing>SequenceFlow_13rjp44</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0kmqqm9</bpmn:outgoing>
     </bpmn:task>
-    <bpmn:sequenceFlow id="SequenceFlow_1" name="FOO" sourceRef="StartEvent_08jn2xd" targetRef="Task_1" />
-    <bpmn:sequenceFlow id="SequenceFlow_14kuv1e" sourceRef="SubProcess_1" targetRef="Task_1" />
     <bpmn:task id="Task_1fo1fvh" name="FOO&#10;BAR">
       <bpmn:incoming>SequenceFlow_13rjp44</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1h7vuvi</bpmn:outgoing>
     </bpmn:task>
-    <bpmn:sequenceFlow id="SequenceFlow_13rjp44" sourceRef="Task_1" targetRef="Task_1fo1fvh" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1" name="FOO">
       <bpmn:incoming>SequenceFlow_1h7vuvi</bpmn:incoming>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1h7vuvi" sourceRef="Task_1fo1fvh" targetRef="ExclusiveGateway_1" />
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>SequenceFlow_0kmqqm9</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0kmqqm9" sourceRef="Task_1" targetRef="EndEvent_1" />
     <bpmn:dataObjectReference id="DataObjectReference_1" dataObjectRef="DataObject_1rq8hb8" />
     <bpmn:dataObject id="DataObject_1rq8hb8" />
     <bpmn:dataStoreReference id="DataStoreReference_1" />
-    <bpmn:subProcess id="SubProcess_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1" name="FOO" sourceRef="StartEvent_08jn2xd" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_13rjp44" sourceRef="Task_1" targetRef="Task_1fo1fvh" />
+    <bpmn:sequenceFlow id="SequenceFlow_0kmqqm9" sourceRef="Task_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1h7vuvi" sourceRef="Task_1fo1fvh" targetRef="ExclusiveGateway_1" />
+    <bpmn:subProcess id="SubProcess_1" name="FOO">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_14kuv1e</bpmn:outgoing>
+    </bpmn:subProcess>
     <bpmn:association id="Association_0ckvfj2" sourceRef="SubProcess_1" targetRef="TextAnnotation_1" />
-    <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
-    <bpmn:group id="Group_2" />
   </bpmn:process>
   <bpmn:category id="Category_1">
     <bpmn:categoryValue id="CategoryValue_1" value="FOO" />
@@ -85,20 +86,14 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1o0amh9">
-      <bpmndi:BPMNShape id="Participant_15tkgjw_di" bpmnElement="Participant_1">
-        <dc:Bounds x="160" y="122" width="600" height="477" />
+      <bpmndi:BPMNShape id="Participant_15tkgjw_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="122" width="600" height="517" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1qi2aws_di" bpmnElement="Lane_1" isHorizontal="true">
+        <dc:Bounds x="190" y="372" width="570" height="267" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_00fz5ca_di" bpmnElement="Lane_2">
         <dc:Bounds x="190" y="122" width="570" height="250" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1qi2aws_di" bpmnElement="Lane_1">
-        <dc:Bounds x="190" y="372" width="570" height="227" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_194zznr_di" bpmnElement="SubProcess_1" isExpanded="true">
-        <dc:Bounds x="311" y="147" width="350" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_194zznr_di" bpmnElement="SubProcess_1" isExpanded="true">
-        <dc:Bounds x="311" y="147" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_0909sti_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="223" y="229" width="36" height="36" />
@@ -106,121 +101,44 @@
           <dc:Bounds x="228" y="265" width="25" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_140ewlr_di" bpmnElement="SequenceFlow_2">
-        <di:waypoint xsi:type="dc:Point" x="259" y="247" />
-        <di:waypoint xsi:type="dc:Point" x="311" y="247" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="285" y="232" width="0" height="0" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_0vwfagl_di" bpmnElement="TextAnnotation_1">
-        <dc:Bounds x="814" y="122" width="100" height="30" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0ckvfj2_di" bpmnElement="Association_0ckvfj2">
-        <di:waypoint xsi:type="dc:Point" x="661" y="196" />
-        <di:waypoint xsi:type="dc:Point" x="814" y="152" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_08jn2xd_di" bpmnElement="StartEvent_08jn2xd">
-        <dc:Bounds x="223" y="416" width="36" height="36" />
+        <dc:Bounds x="257" y="416" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="228" y="452" width="25" height="24" />
+          <dc:Bounds x="263" y="452" width="24" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1i068gk_di" bpmnElement="Task_1">
-        <dc:Bounds x="436" y="394" width="100" height="80" />
+        <dc:Bounds x="470" y="394" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_088kva8_di" bpmnElement="SequenceFlow_1">
-        <di:waypoint xsi:type="dc:Point" x="259" y="434" />
-        <di:waypoint xsi:type="dc:Point" x="436" y="434" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="335" y="409" width="25" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_14kuv1e_di" bpmnElement="SequenceFlow_14kuv1e">
-        <di:waypoint xsi:type="dc:Point" x="486" y="347" />
-        <di:waypoint xsi:type="dc:Point" x="486" y="394" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="501" y="360.5" width="0" height="0" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Task_1fo1fvh_di" bpmnElement="Task_1fo1fvh">
-        <dc:Bounds x="436" y="500" width="100" height="80" />
+        <dc:Bounds x="470" y="500" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_13rjp44_di" bpmnElement="SequenceFlow_13rjp44">
-        <di:waypoint xsi:type="dc:Point" x="486" y="474" />
-        <di:waypoint xsi:type="dc:Point" x="486" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="501" y="477" width="0" height="0" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1dulwbf_di" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
-        <dc:Bounds x="578" y="515" width="50" height="50" />
+        <dc:Bounds x="612" y="515" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="590" y="565" width="25" height="12" />
+          <dc:Bounds x="625" y="565" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1h7vuvi_di" bpmnElement="SequenceFlow_1h7vuvi">
-        <di:waypoint xsi:type="dc:Point" x="536" y="540" />
-        <di:waypoint xsi:type="dc:Point" x="578" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="557" y="515" width="0" height="0" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_0c4s9zs_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="585" y="416" width="36" height="36" />
+        <dc:Bounds x="619" y="416" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="603" y="452" width="0" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0kmqqm9_di" bpmnElement="SequenceFlow_0kmqqm9">
-        <di:waypoint xsi:type="dc:Point" x="536" y="434" />
-        <di:waypoint xsi:type="dc:Point" x="585" y="434" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="561" y="409" width="0" height="0" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="DataObjectReference_024w45b_di" bpmnElement="DataObjectReference_1">
-        <dc:Bounds x="223" y="515" width="36" height="50" />
+        <dc:Bounds x="257" y="515" width="36" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="241" y="565" width="0" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataStoreReference_0b4jv9b_di" bpmnElement="DataStoreReference_1">
-        <dc:Bounds x="315.54926829268294" y="515" width="50" height="50" />
+        <dc:Bounds x="350" y="515" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="341" y="565" width="0" height="0" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="MessageFlow_0pmpiw7_di" bpmnElement="MessageFlow_1">
-        <di:waypoint xsi:type="dc:Point" x="486" y="580" />
-        <di:waypoint xsi:type="dc:Point" x="486" y="646" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="488" y="603" width="25" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Participant_0kzj58d_di" bpmnElement="Participant_2">
-        <dc:Bounds x="161" y="646" width="600" height="250" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Participant_09pdsq3_di" bpmnElement="Participant_3" isHorizontal="false">
-        <dc:Bounds x="900" y="122" width="250" height="600" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1ja5e3n_di" bpmnElement="Vertical_Lane_2" isHorizontal="false">
-        <dc:Bounds x="1025" y="152" width="125" height="570" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_0u3fowr_di" bpmnElement="Vertical_Lane_1" isHorizontal="false">
-        <dc:Bounds x="900" y="152" width="125" height="570" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Participant_03y1uz8_di" bpmnElement="Participant_4" isHorizontal="false">
-        <dc:Bounds x="1178" y="122" width="60" height="600" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="DataOutput_di" bpmnElement="DataOutput">
-        <dc:Bounds x="265" y="150" width="34" height="40" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="265" y="195" width="30" height="12" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="SubProcess_194zznr_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="330" y="147" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataInput_di" bpmnElement="DataInput">
         <dc:Bounds x="220" y="150" width="34" height="40" />
@@ -228,15 +146,95 @@
           <dc:Bounds x="220" y="200" width="30" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
-        <dc:Bounds x="195" y="390" width="225" height="190" />
+      <bpmndi:BPMNShape id="DataOutput_di" bpmnElement="DataOutput">
+        <dc:Bounds x="265" y="150" width="34" height="40" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="296" y="397" width="24" height="14" />
+          <dc:Bounds x="265" y="195" width="30" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_140ewlr_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="259" y="247" />
+        <di:waypoint x="330" y="247" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="285" y="232" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_14kuv1e_di" bpmnElement="SequenceFlow_14kuv1e">
+        <di:waypoint x="520" y="347" />
+        <di:waypoint x="520" y="394" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="501" y="360.5" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_088kva8_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="293" y="434" />
+        <di:waypoint x="470" y="434" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="370" y="409" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_13rjp44_di" bpmnElement="SequenceFlow_13rjp44">
+        <di:waypoint x="520" y="474" />
+        <di:waypoint x="520" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="501" y="477" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0kmqqm9_di" bpmnElement="SequenceFlow_0kmqqm9">
+        <di:waypoint x="570" y="434" />
+        <di:waypoint x="619" y="434" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="561" y="409" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1h7vuvi_di" bpmnElement="SequenceFlow_1h7vuvi">
+        <di:waypoint x="570" y="540" />
+        <di:waypoint x="612" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="557" y="515" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0ckvfj2_di" bpmnElement="Association_0ckvfj2">
+        <di:waypoint x="680" y="193" />
+        <di:waypoint x="817" y="152" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_09pdsq3_di" bpmnElement="Participant_3" isHorizontal="false">
+        <dc:Bounds x="900" y="122" width="250" height="390" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0u3fowr_di" bpmnElement="Vertical_Lane_1" isHorizontal="false">
+        <dc:Bounds x="900" y="152" width="125" height="360" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1ja5e3n_di" bpmnElement="Vertical_Lane_2" isHorizontal="false">
+        <dc:Bounds x="1025" y="152" width="125" height="360" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_03y1uz8_di" bpmnElement="Participant_4" isHorizontal="false">
+        <dc:Bounds x="1178" y="122" width="60" height="390" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0kzj58d_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="390" y="716" width="300" height="64" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0vwfagl_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="814" y="122" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1_di" bpmnElement="Group_1">
+        <dc:Bounds x="229" y="390" width="225" height="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="330" y="397" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_2_di" bpmnElement="Group_2">
-        <dc:Bounds x="555" y="390" width="85" height="200" />
+        <dc:Bounds x="589" y="390" width="85" height="200" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_0pmpiw7_di" bpmnElement="MessageFlow_1">
+        <di:waypoint x="520" y="580" />
+        <di:waypoint x="520" y="716" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="528" y="663" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_17fa1v0">

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -578,7 +578,7 @@ describe('features - label-editing', function() {
        * @param {any} [createContext]
        * @param {string|import('diagram-js/lib/model').Element} [parentElementOrId]
        */
-      function createElement(elementOrType, createContext = {}, parentElementOrId = 'SubProcess_1') {
+      function createElement(elementOrType, createContext = {}, parentElementOrId = 'Participant_1') {
 
         var parent = typeof parentElementOrId === 'string'
           ? elementRegistry.get(parentElementOrId)
@@ -636,7 +636,7 @@ describe('features - label-editing', function() {
         });
 
 
-        it('on StartEvent creation', function() {
+        it('on StartEvent creation outside of sub-process', function() {
 
           // when
           createElement('bpmn:StartEvent');
@@ -646,10 +646,30 @@ describe('features - label-editing', function() {
         });
 
 
-        it('on EndEvent creation', function() {
+        it('on EndEvent creation outside of sub-process', function() {
 
           // when
           createElement('bpmn:EndEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on StartEvent creation inside of sub-process', function() {
+
+          // when
+          createElement('bpmn:StartEvent', {}, 'SubProcess_1');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on EndEvent creation inside of sub-process', function() {
+
+          // when
+          createElement('bpmn:EndEvent', {}, 'SubProcess_1');
 
           // then
           expect(directEditing.isActive()).to.be.true;
@@ -675,6 +695,7 @@ describe('features - label-editing', function() {
           expect(directEditing.isActive()).to.be.true;
         });
 
+
         it('on SubProcess creation', function() {
 
           // when
@@ -683,6 +704,7 @@ describe('features - label-editing', function() {
           // then
           expect(directEditing.isActive()).to.be.true;
         });
+
 
         it('on AdHocSubProcess creation', function() {
 
@@ -693,7 +715,38 @@ describe('features - label-editing', function() {
           expect(directEditing.isActive()).to.be.true;
         });
 
+
+        it('on DataObjectReference creation', function() {
+
+          // when
+          createElement('bpmn:DataObjectReference');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on DataStoreReference creation', function() {
+
+          // when
+          createElement('bpmn:DataStoreReference');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on Group creation', function() {
+
+          // when
+          createElement('bpmn:Group');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
       });
+
 
       describe('should NOT activate', function() {
 
@@ -758,7 +811,6 @@ describe('features - label-editing', function() {
           // then
           expect(directEditing.isActive()).to.be.false;
         });
-
 
       });
 

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -573,17 +573,35 @@ describe('features - label-editing', function() {
 
     describe('on element creation', function() {
 
-      function createElement(type, context) {
-        var shape = elementFactory.create('shape', { type: type }),
-            parent = elementRegistry.get('SubProcess_1'),
-            parentGfx = elementRegistry.getGraphics(parent);
+      /**
+       * @param {string|import('diagram-js/lib/model').Element} typeOrElement
+       * @param {any} [createContext]
+       * @param {string|import('diagram-js/lib/model').Element} [parentElementOrId]
+       */
+      function createElement(elementOrType, createContext = {}, parentElementOrId = 'SubProcess_1') {
 
-        create.start(canvasEvent({ x: 0, y: 0 }), [ shape ], context);
+        var parent = typeof parentElementOrId === 'string'
+          ? elementRegistry.get(parentElementOrId)
+          : parentElementOrId;
+
+        // assume
+        expect(parent, `<element#${parentElementOrId}>`).to.exist;
+
+        var shape = typeof elementOrType === 'string'
+          ? elementFactory.create('shape', { type: elementOrType })
+          : elementOrType;
+
+        var parentGfx = elementRegistry.getGraphics(parent);
+
+        create.start(canvasEvent({ x: 0, y: 0 }), [ shape ], createContext);
         dragging.hover({
           element: parent,
           gfx: parentGfx
         });
-        dragging.move(canvasEvent({ x: 400, y: 250 }));
+        dragging.move(canvasEvent({
+          x: (parent.x || 0) + 20 + shape.width / 2,
+          y: (parent.y || 0) + 20 + shape.width / 2
+        }));
         dragging.end();
       }
 
@@ -592,19 +610,7 @@ describe('features - label-editing', function() {
       }
 
       function createParticipant() {
-
-        var collaboration = elementRegistry.get('Collaboration_1o0amh9'),
-            collaborationGfx = elementRegistry.getGraphics(collaboration);
-
-        var participant = elementFactory.createParticipantShape();
-
-        // when
-        create.start(canvasEvent({ x: 400, y: 300 }), participant);
-
-        dragging.hover({ element: collaboration, gfx: collaborationGfx });
-        dragging.move(canvasEvent({ x: 400, y: 300 }));
-
-        dragging.end();
+        return createElement(elementFactory.createParticipantShape(), {}, 'Collaboration_1o0amh9');
       }
 
 

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -630,6 +630,26 @@ describe('features - label-editing', function() {
         });
 
 
+        it('on StartEvent creation', function() {
+
+          // when
+          createElement('bpmn:StartEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on EndEvent creation', function() {
+
+          // when
+          createElement('bpmn:EndEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
         it('on IntermediateThrowEvent creation', function() {
 
           // when
@@ -681,26 +701,6 @@ describe('features - label-editing', function() {
           // then
           expect(directEditing.isActive()).to.be.false;
 
-        });
-
-
-        it('on plain StartEvent creation', function() {
-
-          // when
-          createElement('bpmn:StartEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.false;
-        });
-
-
-        it('on plain EndEvent creation', function() {
-
-          // when
-          createElement('bpmn:EndEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.false;
         });
 
 


### PR DESCRIPTION
### Proposed Changes

This consistently enables direct editing for all elements but gateways (https://github.com/bpmn-io/bpmn-js/issues/748). 
<img width="1250" height="902" alt="capture UbS3an_optimized" src="https://github.com/user-attachments/assets/e6feff98-23a2-40d7-ac32-890d06f03154" />

> [!NOTE]
> Draft, because of the UX impact ("one more click") and validation pending.

### What's inside

* Simplify tests
* Fix direct editing not activating for start events outside of sub-processes


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
