### PR TITLE
Revert "feat: disable direct editing for plain start/end events"

### DIFF
--- a/lib/features/label-editing/LabelEditingProvider.js
+++ b/lib/features/label-editing/LabelEditingProvider.js
@@ -7,8 +7,7 @@ import {
 } from '../../util/LabelUtil';
 
 import {
-  is,
-  getBusinessObject
+  is
 } from '../../util/ModelUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
@@ -150,8 +149,7 @@ export default function LabelEditingProvider(
 
   function activateDirectEdit(element, force) {
     if (force ||
-        isAny(element, [ 'bpmn:Activity', 'bpmn:TextAnnotation', 'bpmn:Participant' ]) ||
-        (is(element, 'bpmn:Event') && !isPlainStartOrEndEvent(element))) {
+        isAny(element, [ 'bpmn:Activity', 'bpmn:Event', 'bpmn:TextAnnotation', 'bpmn:Participant' ])) {
 
       directEditing.activate(element);
     }
@@ -518,11 +516,4 @@ function isExpandedPool(element) {
 
 function isEmptyText(label) {
   return !label || !label.trim();
-}
-
-function isPlainStartOrEndEvent(element) {
-  var businessObject = getBusinessObject(element);
-
-  return isAny(element, [ 'bpmn:StartEvent', 'bpmn:EndEvent' ]) &&
-    !(businessObject.eventDefinitions && businessObject.eventDefinitions.length);
 }

--- a/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -630,6 +630,26 @@ describe('features - label-editing', function() {
         });
 
 
+        it('on StartEvent creation', function() {
+
+          // when
+          createElement('bpmn:StartEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
+        it('on EndEvent creation', function() {
+
+          // when
+          createElement('bpmn:EndEvent');
+
+          // then
+          expect(directEditing.isActive()).to.be.true;
+        });
+
+
         it('on IntermediateThrowEvent creation', function() {
 
           // when
@@ -681,26 +701,6 @@ describe('features - label-editing', function() {
           // then
           expect(directEditing.isActive()).to.be.false;
 
-        });
-
-
-        it('on plain StartEvent creation', function() {
-
-          // when
-          createElement('bpmn:StartEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.false;
-        });
-
-
-        it('on plain EndEvent creation', function() {
-
-          // when
-          createElement('bpmn:EndEvent');
-
-          // then
-          expect(directEditing.isActive()).to.be.false;
         });
 
 


### PR DESCRIPTION
### Proposed Changes

This reverts commit 70285b7b942e13ac2e8fa41a8be4210a6adf286c.

The changes around events are [not mirroring sufficiently the reality of our customers](https://camunda.slack.com/archives/C057H178R9T/p1776419562630869) - most start events [must have labels](https://docs.camunda.io/docs/components/best-practices/modeling/naming-bpmn-elements/#naming-events), including start events inside of sub-processes. We want to follow-up with a rework, potentially via https://github.com/bpmn-io/bpmn-js/pull/2416.

Reopens #748 


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
