### PR TITLE
Set color ignore missing di

### DIFF
--- a/lib/features/modeling/cmd/SetColorHandler.js
+++ b/lib/features/modeling/cmd/SetColorHandler.js
@@ -7,6 +7,7 @@ import {
 
 import {
   getDi,
+  is,
   isAny
 } from '../../../util/ModelUtil';
 
@@ -87,6 +88,10 @@ SetColorHandler.prototype.postExecute = function(context) {
     ensureLegacySupport(assignedDi);
 
     if (isLabel(element)) {
+
+      if (!elementDi || !is(elementDi.label, 'bpmndi:BPMNLabel')) {
+        return;
+      }
 
       // set label colors as bpmndi:BPMNLabel#color
       self._commandStack.execute('element.updateModdleProperties', {

--- a/lib/features/modeling/cmd/SetColorHandler.js
+++ b/lib/features/modeling/cmd/SetColorHandler.js
@@ -72,12 +72,14 @@ SetColorHandler.prototype.postExecute = function(context) {
 
   if ('fill' in colors) {
     assign(di, {
-      'background-color': this._normalizeColor(colors.fill) });
+      'background-color': this._normalizeColor(colors.fill)
+    });
   }
 
   if ('stroke' in colors) {
     assign(di, {
-      'border-color': this._normalizeColor(colors.stroke) });
+      'border-color': this._normalizeColor(colors.stroke)
+    });
   }
 
   forEach(elements, function(element) {

--- a/test/spec/features/modeling/SetColor.missingLabelDi.bpmn
+++ b/test/spec/features/modeling/SetColor.missingLabelDi.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="simple" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_1" isExecutable="false">
+    <bpmn2:startEvent id="StartEvent_1" name="Foo" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_03k0cr0_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/test/spec/features/modeling/SetColorSpec.js
+++ b/test/spec/features/modeling/SetColorSpec.js
@@ -347,6 +347,43 @@ describe('features/modeling - set color', function() {
   });
 
 
+  describe('execute with incomplete DI', function() {
+
+    var incompleteDiXML = require('./SetColor.missingLabelDi.bpmn');
+
+    beforeEach(bootstrapModeler(incompleteDiXML, {
+      modules: [
+        coreModule,
+        modelingModule
+      ]
+    }));
+
+
+    it('should ignore color updates on external labels without BPMNLabel DI', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var startEventShape = elementRegistry.get('StartEvent_1'),
+            startEventLabel = startEventShape.label,
+            labelTargetShape = startEventLabel.labelTarget,
+            targetDi = getDi(labelTargetShape);
+
+        expect(targetDi.label).not.to.exist;
+
+        // when
+        expect(function() {
+          modeling.setColor(startEventLabel, { stroke: 'YELLOW', fill: 'FUCHSIA' });
+        }).not.to.throw();
+
+        // then
+        expect(targetDi.get('border-color')).not.to.exist;
+        expect(targetDi.get('background-color')).not.to.exist;
+        expect(targetDi.label).not.to.exist;
+      }
+    ));
+  });
+
+
   describe('undo', function() {
 
     it('setting fill color', inject(


### PR DESCRIPTION
### Proposed Changes

Minimal version of https://github.com/bpmn-io/bpmn-js/pull/2413.

Ignore elements with missing `bpmndi:BPMNLabel` when setting color.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
