### PR TITLE
deps: update to diagram-js@15.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: move enclosed artifacts with participants / sub-processes ([#1929](https://github.com/bpmn-io/bpmn-js/issues/1929), [#2419](https://github.com/bpmn-io/bpmn-js/issues/2419))
 * `FIX`: ignore broken `BPMNDI` when setting label colors ([#2418](https://github.com/bpmn-io/bpmn-js/pull/2418))
 * `DEPS`: update to `diagram-js@15.13.0`
+* `DEPS`: update to `min-dom@5.3.0`
 
 ## 18.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: show outline around lasso-selected elements ([#173](https://github.com/bpmn-io/bpmn-js/issues/173), [bpmn-io/diagram-js#1021](https://github.com/bpmn-io/diagram-js/pull/1021))
 * `FEAT`: improve text rendering performance ([bpmn-io/diagram-js#1026](https://github.com/bpmn-io/diagram-js/issues/1026), [bpmn-io/diagram-js#1027](https://github.com/bpmn-io/diagram-js/pull/1027))
 * `FEAT`: improve diagram import performance ([bpmn-io/diagram-js#1026](https://github.com/bpmn-io/diagram-js/issues/1026), [bpmn-io/diagram-js#1027](https://github.com/bpmn-io/diagram-js/pull/1027))
 * `FEAT`: move enclosed artifacts with participants / sub-processes ([#1929](https://github.com/bpmn-io/bpmn-js/issues/1929), [#2419](https://github.com/bpmn-io/bpmn-js/issues/2419))
 * `FIX`: ignore broken `BPMNDI` when setting label colors ([#2418](https://github.com/bpmn-io/bpmn-js/pull/2418))
-* `DEPS`: update to `diagram-js@15.12.0`
+* `DEPS`: update to `diagram-js@15.13.0`
 
 ## 18.14.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.12.0",
+        "diagram-js": "^15.13.0",
         "diagram-js-direct-editing": "^3.3.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3846,9 +3846,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.12.0.tgz",
-      "integrity": "sha512-BQmdvh4fbnvP/2r6QnEEwbpPwS80OLMTn64UQN4CKfg4u08fQd7aqMVyP1kVF2mElYfK7477sAI4kdVKKR1F+g==",
+      "version": "15.13.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.13.0.tgz",
+      "integrity": "sha512-poM84+3749g66uF0Xw0S/BlV76XsqT+esXwzYGWopHDFkFfHw+6eeXt0/wcS+nwA2SITBhl52GKIX3kW7Co/8g==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
@@ -17198,9 +17198,9 @@
       "dev": true
     },
     "diagram-js": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.12.0.tgz",
-      "integrity": "sha512-BQmdvh4fbnvP/2r6QnEEwbpPwS80OLMTn64UQN4CKfg4u08fQd7aqMVyP1kVF2mElYfK7477sAI4kdVKKR1F+g==",
+      "version": "15.13.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.13.0.tgz",
+      "integrity": "sha512-poM84+3749g66uF0Xw0S/BlV76XsqT+esXwzYGWopHDFkFfHw+6eeXt0/wcS+nwA2SITBhl52GKIX3kW7Co/8g==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0",
+        "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^5.0.0",
-    "min-dom": "^5.2.0",
+    "min-dom": "^5.3.0",
     "tiny-svg": "^4.1.4"
   },
   "remarkConfig": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.12.0",
+    "diagram-js": "^15.13.0",
     "diagram-js-direct-editing": "^3.3.0",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
### Proposed Changes

Incorporates `diagram-js@15.13.0` ([CHANGELOG](https://github.com/bpmn-io/diagram-js/blob/develop/CHANGELOG.md#15130)) to show outline around currently lasso selected elements:

<img width="1168" height="729" alt="capture 75uluL_optimized" src="https://github.com/user-attachments/assets/1292bec5-e371-4ed6-bdcd-833469d6600c" />

Closes https://github.com/bpmn-io/bpmn-js/issues/173


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
