### PR TITLE
fix: render data output with filled arrow

### DIFF
--- a/lib/draw/BpmnRenderer.js
+++ b/lib/draw/BpmnRenderer.js
@@ -1501,7 +1501,7 @@ export default function BpmnRenderer(
 
       drawPath(parentGfx, arrowPathData, {
         strokeWidth: 1,
-        fill: getFillColor(element, defaultFillColor, attrs.fill),
+        fill: getStrokeColor(element, defaultStrokeColor, attrs.stroke),
         stroke: getStrokeColor(element, defaultStrokeColor, attrs.stroke)
       });
 

--- a/test/fixtures/bpmn/draw/data-objects.bpmn
+++ b/test/fixtures/bpmn/draw/data-objects.bpmn
@@ -28,7 +28,7 @@
           <signavio:signavioLabel align="left" ref="text_name" valign="top" x="18.0" y="55.0"/>
         </extensionElements>
       </dataInput>
-      <dataInput id="sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF" isCollection="true">
+      <dataInput id="DataInput_2_collection" isCollection="true">
         <extensionElements>
           <signavio:signavioMetaData metaKey="bgcolor" metaValue="#ffffff"/>
           <signavio:signavioMetaData metaKey="userstory" metaValue=""/>
@@ -41,7 +41,7 @@
           <signavio:signavioLabel align="left" ref="text_name" valign="top" x="18.0" y="55.0"/>
         </extensionElements>
       </dataOutput>
-      <dataOutput id="sid-16646BD1-38D3-499A-95A6-42A75D8D2510" isCollection="true">
+      <dataOutput id="DataOutput_2_collection" isCollection="true">
         <extensionElements>
           <signavio:signavioMetaData metaKey="bgcolor" metaValue="#ffffff"/>
           <signavio:signavioMetaData metaKey="userstory" metaValue=""/>
@@ -49,11 +49,11 @@
       </dataOutput>
       <inputSet id="sid-8c0a0c80-098c-4972-bac0-8cc303d82bfd">
         <dataInputRefs>DataInput_1</dataInputRefs>
-        <dataInputRefs>sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF</dataInputRefs>
+        <dataInputRefs>DataInput_2_collection</dataInputRefs>
       </inputSet>
       <outputSet id="sid-60cf6782-0fff-4304-882d-7d2b33336aed">
         <dataOutputRefs>DataOutput_1</dataOutputRefs>
-        <dataOutputRefs>sid-16646BD1-38D3-499A-95A6-42A75D8D2510</dataOutputRefs>
+        <dataOutputRefs>DataOutput_2_collection</dataOutputRefs>
       </outputSet>
     </ioSpecification>
     <dataObject id="sid-b71dc346-6ba3-481d-9ea6-03c3fe207b3f" name="Data Object"/>
@@ -97,7 +97,7 @@
         <targetRef>sid-b4a08214-9dd4-40ad-8f82-4620ee384231</targetRef>
       </dataInputAssociation>
       <dataInputAssociation id="DataInputAssociation_2">
-        <sourceRef>sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF</sourceRef>
+        <sourceRef>DataInput_2_collection</sourceRef>
       </dataInputAssociation>
       <dataOutputAssociation id="DataOutputAssociation_1">
         <extensionElements>
@@ -120,7 +120,7 @@
         <targetRef>DataObjectReference_1</targetRef>
       </dataOutputAssociation>
       <dataOutputAssociation id="DataOutputAssociation_5">
-        <targetRef>sid-16646BD1-38D3-499A-95A6-42A75D8D2510</targetRef>
+        <targetRef>DataOutput_2_collection</targetRef>
       </dataOutputAssociation>
     </task>
     <task id="Task_2">
@@ -217,13 +217,13 @@
       <bpmndi:BPMNShape id="DataInput_1_gui" bpmnElement="DataInput_1">
         <omgdc:Bounds height="50.0" width="36.0" x="355.0" y="84.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF_gui" bpmnElement="sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF">
+      <bpmndi:BPMNShape id="DataInput_2_collection_gui" bpmnElement="DataInput_2_collection">
         <omgdc:Bounds height="97.0" width="88.0" x="420.0" y="382.0"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="DataOutput_1_gui" bpmnElement="DataOutput_1">
         <omgdc:Bounds height="50.0" width="36.0" x="480.0" y="84.0"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="sid-16646BD1-38D3-499A-95A6-42A75D8D2510_gui" bpmnElement="sid-16646BD1-38D3-499A-95A6-42A75D8D2510">
+      <bpmndi:BPMNShape id="DataOutput_2_collection_gui" bpmnElement="DataOutput_2_collection">
         <omgdc:Bounds height="97.0" width="88.0" x="624.0" y="382.0"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="DataInputAssociation_3_gui" bpmnElement="DataInputAssociation_3">
@@ -248,12 +248,12 @@
         <omgdi:waypoint xsi:type="omgdc:Point" x="471.0" y="296.0"/>
         <omgdi:waypoint xsi:type="omgdc:Point" x="432.0" y="269.0"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_DataOutputAssociation_2" bpmnElement="DataOutputAssociation_5" sourceElement="Task_1_gui" targetElement="sid-16646BD1-38D3-499A-95A6-42A75D8D2510_gui">
+      <bpmndi:BPMNEdge id="BPMNEdge_DataOutputAssociation_2" bpmnElement="DataOutputAssociation_5" sourceElement="Task_1_gui" targetElement="DataOutput_2_collection_gui">
         <omgdi:waypoint xsi:type="omgdc:Point" x="572.0" y="296.0"/>
         <omgdi:waypoint xsi:type="omgdc:Point" x="581.0" y="361.0"/>
         <omgdi:waypoint xsi:type="omgdc:Point" x="624.0" y="395.0"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_DataInputAssociation_1" bpmnElement="DataInputAssociation_2" sourceElement="sid-ADF95ACC-DEA6-4F6F-AF91-8F5BABB299AF_gui" targetElement="Task_1_gui">
+      <bpmndi:BPMNEdge id="BPMNEdge_DataInputAssociation_1" bpmnElement="DataInputAssociation_2" sourceElement="DataInput_2_collection_gui" targetElement="Task_1_gui">
         <omgdi:waypoint xsi:type="omgdc:Point" x="508.0" y="397.0"/>
         <omgdi:waypoint xsi:type="omgdc:Point" x="557.0" y="360.0"/>
         <omgdi:waypoint xsi:type="omgdc:Point" x="563.0" y="296.0"/>

--- a/test/spec/draw/BpmnRendererSpec.js
+++ b/test/spec/draw/BpmnRendererSpec.js
@@ -121,11 +121,48 @@ describe('draw - bpmn renderer', function() {
   });
 
 
-  it('should render data objects', function() {
+  it('should render data objects with correct markers', function() {
     var xml = require('../../fixtures/bpmn/draw/data-objects.bpmn');
     return bootstrapViewer(xml).call(this).then(function(result) {
 
       checkErrors(result.error, result.warnings);
+
+      inject(function(elementRegistry) {
+        [
+          [ 'DataInput_1' , 'rgb(34, 36, 42)' , 'none' ],
+          [ 'DataOutput_1' , 'rgb(34, 36, 42)', 'rgb(34, 36, 42)' ],
+        ].forEach(([ id, stroke, fill ]) => {
+          var dataObjectGfx = elementRegistry.getGraphics(id);
+          var allPaths = domQueryAll('.djs-visual path', dataObjectGfx);
+
+          expect(allPaths).to.have.lengthOf(2);
+
+          var marker = allPaths[1];
+          stroke && expect(marker.style.stroke, `expected stroke of ${id} to be ${stroke}`).to.eql(stroke);
+          fill && expect(marker.style.fill, `expected fill of ${id} to be ${fill}`).to.eql(fill);
+        });
+      })();
+    });
+  });
+
+
+  it('should render data objects with collection markers', function() {
+    var xml = require('../../fixtures/bpmn/draw/data-objects.bpmn');
+    return bootstrapViewer(xml).call(this).then(function(result) {
+
+      checkErrors(result.error, result.warnings);
+
+      inject(function(elementRegistry) {
+        [
+          'DataInput_2_collection',
+          'DataOutput_2_collection'
+        ].forEach(id => {
+          var dataObjectGfx = elementRegistry.getGraphics(id);
+          var allPaths = domQueryAll('.djs-visual path', dataObjectGfx);
+
+          expect(allPaths).to.have.lengthOf(3);
+        });
+      })();
     });
   });
 


### PR DESCRIPTION
### Proposed Changes

I just discovered that we don't display the data outputs correctly. This PR fixes it.

Before:

<img width="132" height="96" alt="image" src="https://github.com/user-attachments/assets/499b0cf3-eb50-4c97-ae87-5fc82dac8dfc" />

After:

<img width="170" height="122" alt="image" src="https://github.com/user-attachments/assets/0ecca2d4-4f74-4e14-8774-70475f311f45" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
