### PR TITLE
Add keep selection visible on canvas resize feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: keep selection visible on canvas resize ([bpmn-io/diagram-js#1038](https://github.com/bpmn-io/diagram-js/pull/1038), [#2435](https://github.com/bpmn-io/bpmn-js/pull/2435))
 * `FIX`: do not copy message flows without participants ([#1902](https://github.com/bpmn-io/bpmn-js/issues/1902), [#2475](https://github.com/bpmn-io/bpmn-js/pull/2475))
 
 ## 18.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 18.28.0
+
 * `FEAT`: keep selection visible on canvas resize ([bpmn-io/diagram-js#1038](https://github.com/bpmn-io/diagram-js/pull/1038), [#2435](https://github.com/bpmn-io/bpmn-js/pull/2435))
 
 ## 18.27.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: keep selection visible on canvas resize ([bpmn-io/diagram-js#1038](https://github.com/bpmn-io/diagram-js/pull/1038), [#2435](https://github.com/bpmn-io/bpmn-js/pull/2435))
+
 ## 18.27.1
 
 * `FIX`: do not move group label away from the group ([#2495](https://github.com/bpmn-io/bpmn-js/pull/2495))

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -5,6 +5,7 @@ import BaseModeler from './BaseModeler';
 import Viewer from './Viewer';
 import NavigatedViewer from './NavigatedViewer';
 
+import KeepSelectionVisibleModule from 'diagram-js/lib/features/keep-selection-visible';
 import KeyboardMoveModule from 'diagram-js/lib/navigation/keyboard-move';
 import MoveCanvasModule from 'diagram-js/lib/navigation/movecanvas';
 import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
@@ -157,6 +158,7 @@ Modeler.prototype.createDiagram = function createDiagram() {
 Modeler.prototype._interactionModules = [
 
   // non-modeling components
+  KeepSelectionVisibleModule,
   KeyboardMoveModule,
   MoveCanvasModule,
   ZoomScrollModule

--- a/lib/NavigatedViewer.js
+++ b/lib/NavigatedViewer.js
@@ -2,6 +2,7 @@ import inherits from 'inherits-browser';
 
 import Viewer from './Viewer';
 
+import KeepSelectionVisibleModule from 'diagram-js/lib/features/keep-selection-visible';
 import KeyboardMoveModule from 'diagram-js/lib/navigation/keyboard-move';
 import MoveCanvasModule from 'diagram-js/lib/navigation/movecanvas';
 import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
@@ -27,6 +28,7 @@ inherits(NavigatedViewer, Viewer);
 
 
 NavigatedViewer.prototype._navigationModules = [
+  KeepSelectionVisibleModule,
   KeyboardMoveModule,
   MoveCanvasModule,
   ZoomScrollModule

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -258,11 +258,34 @@ export function createViewer(container, viewerInstance, xml, diagramId) {
 
   setBpmnJS(viewer);
 
+  observeContainerResize(viewer);
+
   return viewer.importXML(xml, diagramId).then(function(result) {
     return { warnings: result.warnings, viewer: viewer };
   }).catch(function(err) {
     return { error: err, viewer: viewer, warnings: err.warnings };
   });
+}
+
+/**
+ * Notify the instance of container size changes in single-start mode.
+ *
+ * Canvas#resized must be called by the embedding application when the
+ * container size changes; observe the container to simulate that.
+ *
+ * @param {object} instance viewer or modeler instance
+ */
+export function observeContainerResize(instance) {
+
+  if (!(window.__env__ && window.__env__.SINGLE_START)) {
+    return;
+  }
+
+  var canvas = instance.get('canvas');
+
+  new ResizeObserver(function() {
+    canvas.resized();
+  }).observe(canvas.getContainer());
 }
 
 function logConfigured(type, force) {

--- a/test/helper/index.js
+++ b/test/helper/index.js
@@ -258,11 +258,32 @@ export function createViewer(container, viewerInstance, xml, diagramId) {
 
   setBpmnJS(viewer);
 
+  observeContainerResize(viewer);
+
   return viewer.importXML(xml, diagramId).then(function(result) {
     return { warnings: result.warnings, viewer: viewer };
   }).catch(function(err) {
     return { error: err, viewer: viewer, warnings: err.warnings };
   });
+}
+
+/**
+ * Call Canvas#resized on container resize, as an embedding
+ * application would. Single start only.
+ *
+ * @param {object} instance viewer or modeler instance
+ */
+export function observeContainerResize(instance) {
+
+  if (!(window.__env__ && window.__env__.SINGLE_START)) {
+    return;
+  }
+
+  var canvas = instance.get('canvas');
+
+  new ResizeObserver(function() {
+    canvas.resized();
+  }).observe(canvas.getContainer());
 }
 
 function logConfigured(type, force) {

--- a/test/spec/ModelerSpec.js
+++ b/test/spec/ModelerSpec.js
@@ -13,7 +13,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import { createCanvasEvent } from '../util/MockEvents';
 
-import { clearBpmnJS, collectTranslations, enableLogging, setBpmnJS } from 'test/TestHelper';
+import { clearBpmnJS, collectTranslations, enableLogging, observeContainerResize, setBpmnJS } from 'test/TestHelper';
 
 import { find, pick } from 'min-dash';
 
@@ -42,6 +42,8 @@ describe('Modeler', function() {
     setBpmnJS(modeler);
 
     enableLogging(modeler, singleStart);
+
+    observeContainerResize(modeler);
 
     return modeler.importXML(xml).then(function(result) {
       return { error: null, warnings: result.warnings, modeler: modeler };

--- a/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
+++ b/test/spec/features/keep-selection-visible/KeepSelectionVisibleSpec.js
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+import keepSelectionVisibleModule from 'diagram-js/lib/features/keep-selection-visible';
+
+import { getBBox } from 'diagram-js/lib/util/Elements';
+import { asTRBL } from 'diagram-js/lib/layout/LayoutUtil';
+
+
+describe('features/keep-selection-visible', function() {
+
+  var diagramXML = require('./keep-selection-visible.bpmn');
+
+  var testModules = [
+    coreModule,
+    modelingModule,
+    keepSelectionVisibleModule
+  ];
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules,
+    canvas: {
+      width: 800,
+      height: 600
+    }
+  }));
+
+
+  it('should scroll right when canvas shrinks and selection is near right edge', inject(
+    function(canvas, elementRegistry, keepSelectionVisible, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_Right');
+      selection.select(task);
+
+      keepSelectionVisible._flush();
+
+      // when
+      canvas.getContainer().style.width = '600px';
+      canvas.resized();
+
+      // then
+      expectSelectionInView(canvas, selection);
+    }
+  ));
+
+
+  it('should scroll down when canvas shrinks and selection is near bottom edge', inject(
+    function(canvas, elementRegistry, keepSelectionVisible, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_Bottom');
+      selection.select(task);
+
+      keepSelectionVisible._flush();
+
+      // when
+      canvas.getContainer().style.height = '400px';
+      canvas.resized();
+
+      // then
+      expectSelectionInView(canvas, selection);
+    }
+  ));
+
+
+  it('should NOT scroll when selection is still visible after resize', inject(
+    function(canvas, elementRegistry, keepSelectionVisible, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_TopLeft');
+      selection.select(task);
+
+      keepSelectionVisible._flush();
+
+      var viewboxBefore = canvas.viewbox();
+
+      // when
+      canvas.getContainer().style.width = '600px';
+      canvas.resized();
+
+      // then
+      var viewboxAfter = canvas.viewbox();
+      expect(viewboxAfter.x).to.equal(viewboxBefore.x);
+      expect(viewboxAfter.y).to.equal(viewboxBefore.y);
+    }
+  ));
+
+
+  it('should NOT scroll when selection was not visible before resize', inject(
+    function(canvas, elementRegistry, keepSelectionVisible, selection) {
+
+      // given
+      var task = elementRegistry.get('Task_Right');
+      selection.select(task);
+
+      canvas.scroll({ dx: -2000, dy: 0 });
+
+      keepSelectionVisible._flush();
+
+      var viewboxBefore = canvas.viewbox();
+
+      // when
+      canvas.getContainer().style.width = '600px';
+      canvas.resized();
+
+      // then
+      var viewboxAfter = canvas.viewbox();
+      expect(viewboxAfter.x).to.equal(viewboxBefore.x);
+      expect(viewboxAfter.y).to.equal(viewboxBefore.y);
+    }
+  ));
+
+});
+
+
+function expectSelectionInView(canvas, selection) {
+  var SCROLL_PADDING = 10;
+  var viewbox = canvas.viewbox();
+  var viewboxTrbl = asTRBL(viewbox);
+  var selectionBBox = getBBox(selection.get());
+  var selectionTrbl = asTRBL(selectionBBox);
+
+  expect(selectionTrbl.left).to.be.at.least(viewboxTrbl.left + SCROLL_PADDING);
+  expect(selectionTrbl.right).to.be.at.most(viewboxTrbl.right - SCROLL_PADDING);
+  expect(selectionTrbl.top).to.be.at.least(viewboxTrbl.top + SCROLL_PADDING);
+  expect(selectionTrbl.bottom).to.be.at.most(viewboxTrbl.bottom - SCROLL_PADDING);
+}

--- a/test/spec/features/keep-selection-visible/keep-selection-visible.bpmn
+++ b/test/spec/features/keep-selection-visible/keep-selection-visible.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Task_TopLeft" name="Top Left" />
+    <bpmn:task id="Task_Right" name="Right" />
+    <bpmn:task id="Task_Bottom" name="Bottom" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_TopLeft_di" bpmnElement="Task_TopLeft">
+        <dc:Bounds x="10" y="10" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Right_di" bpmnElement="Task_Right">
+        <dc:Bounds x="700" y="10" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Bottom_di" bpmnElement="Task_Bottom">
+        <dc:Bounds x="10" y="500" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Related to camunda/camunda-modeler#5957

### Proposed Changes

This pull request incorporates the ["keep selection visible on canvas resize" feature](https://github.com/bpmn-io/diagram-js/pull/1038) from `diagram-js`.

Without this opt-in feature, resizing the canvas may leave the selection out of view even if there is enough space in the canvas. With it enabled, resizing the canvas keeps the selection in view with minimum movement. If the selection was already out of view before resizing, this is a no-op.

Try it out with:

```
npx @bpmn-io/sr bpmn-io/bpmn-js#issue-5957-keep-selection-visible-on-resize
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
