### PR TITLE
fix(rules): disallow move when dropped outside the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: disallow `move` when dropped outside of canvas ([#2437](https://github.com/bpmn-io/bpmn-js/pull/2437), [#2210](https://github.com/bpmn-io/bpmn-js/issues/2210))
 * `CHORE`: derive label link offset from (circular) outline shape ([#2457](https://github.com/bpmn-io/bpmn-js/pull/2457))
 
 ## 18.19.0

--- a/lib/features/modeling/behavior/FixHoverBehavior.js
+++ b/lib/features/modeling/behavior/FixHoverBehavior.js
@@ -45,8 +45,9 @@ export default function FixHoverBehavior(elementRegistry, eventBus, canvas) {
     var rootElement = canvas.getRootElement();
 
     // ensure bpmn:Group and label elements are dropped
-    // always onto the root
-    if (hover !== rootElement && (shape.labelTarget || isAny(shape, [ 'bpmn:Group', 'bpmn:TextAnnotation' ]))) {
+    // always onto the root; keep a missing hover (e.g. dropped outside
+    // the canvas) untouched so it can be rejected by the rules
+    if (hover && hover !== rootElement && (shape.labelTarget || isAny(shape, [ 'bpmn:Group', 'bpmn:TextAnnotation' ]))) {
       event.hover = rootElement;
       event.hoverGfx = elementRegistry.getGraphics(event.hover);
     }

--- a/lib/features/rules/BpmnRules.js
+++ b/lib/features/rules/BpmnRules.js
@@ -937,9 +937,14 @@ function canMove(elements, target) {
     return false;
   }
 
-  // allow default move check to start move operation
-  if (!target) {
+  // allow move to start when there is no target yet (`undefined`)
+  if (target === undefined) {
     return true;
+  }
+
+  // disallow dropping outside the canvas (`null` target)
+  if (target === null) {
+    return false;
   }
 
   return elements.every(function(element) {

--- a/test/spec/features/modeling/behavior/FixHoverBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/FixHoverBehaviorSpec.js
@@ -198,6 +198,36 @@ describe('features/modeling/behavior - fix hover', function() {
         }
       ));
 
+
+      it('should not move when dropped outside the canvas', inject(
+        function(dragging, elementRegistry, move) {
+
+          // given
+          var startEvent = elementRegistry.get('StartEvent');
+
+          var label = startEvent.label;
+
+          var position = { x: label.x, y: label.y };
+
+          move.start(canvasEvent({ x: 175, y: 150 }), label, true);
+
+          // when
+          dragging.hover({ element: startEvent, gfx: elementRegistry.getGraphics(startEvent) });
+
+          dragging.move(canvasEvent({ x: 240, y: 220 }));
+
+          // dragging outside the canvas yields a `null` hover (#2210)
+          dragging.out();
+
+          dragging.move(canvasEvent({ x: 400, y: 400 }));
+
+          dragging.end();
+
+          // then
+          expect({ x: label.x, y: label.y }).to.eql(position);
+        }
+      ));
+
     });
 
   });
@@ -266,6 +296,34 @@ describe('features/modeling/behavior - fix hover', function() {
         }
       ));
 
+
+      it('should not move when dropped outside the canvas', inject(
+        function(dragging, elementRegistry, move) {
+
+          // given
+          var group = elementRegistry.get('Group');
+
+          var position = { x: group.x, y: group.y };
+
+          move.start(canvasEvent({ x: 175, y: 150 }), group, true);
+
+          // when
+          dragging.hover({ element: group, gfx: elementRegistry.getGraphics(group) });
+
+          dragging.move(canvasEvent({ x: 240, y: 220 }));
+
+          // dragging outside the canvas yields a `null` hover (#2210)
+          dragging.out();
+
+          dragging.move(canvasEvent({ x: 400, y: 400 }));
+
+          dragging.end();
+
+          // then
+          expect({ x: group.x, y: group.y }).to.eql(position);
+        }
+      ));
+
     });
 
   });
@@ -331,6 +389,34 @@ describe('features/modeling/behavior - fix hover', function() {
 
           // then
           expect(annotation.parent).to.equal(canvas.getRootElement());
+        }
+      ));
+
+
+      it('should not move when dropped outside the canvas', inject(
+        function(dragging, elementRegistry, move) {
+
+          // given
+          var annotation = elementRegistry.get('TextAnnotation_1');
+
+          var position = { x: annotation.x, y: annotation.y };
+
+          move.start(canvasEvent({ x: 175, y: 150 }), annotation, true);
+
+          // when
+          dragging.hover({ element: annotation, gfx: elementRegistry.getGraphics(annotation) });
+
+          dragging.move(canvasEvent({ x: 240, y: 220 }));
+
+          // dragging outside the canvas yields a `null` hover (#2210)
+          dragging.out();
+
+          dragging.move(canvasEvent({ x: 400, y: 400 }));
+
+          dragging.end();
+
+          // then
+          expect({ x: annotation.x, y: annotation.y }).to.eql(position);
         }
       ));
 

--- a/test/spec/features/rules/BpmnRulesSpec.js
+++ b/test/spec/features/rules/BpmnRulesSpec.js
@@ -1571,6 +1571,64 @@ describe('features/modeling/rules - BpmnRules', function() {
   });
 
 
+  describe('move outside canvas', function() {
+
+    var testXML = require('./BpmnRules.process.bpmn');
+
+    beforeEach(bootstrapModeler(testXML, { modules: testModules }));
+
+
+    it('should not allow move when dropped outside the canvas', inject(function(elementRegistry, rules) {
+
+      // given
+      var task = elementRegistry.get('Task');
+
+      // when
+      // dragging outside the canvas yields a `null` target (#2210)
+      var canMove = rules.allowed('elements.move', {
+        shapes: [ task ],
+        target: null
+      });
+
+      // then
+      expect(canMove).to.be.false;
+    }));
+
+
+    it('should not allow move of group when dropped outside the canvas', inject(function(elementRegistry, rules) {
+
+      // given
+      var group = elementRegistry.get('Group');
+
+      // when
+      // dragging outside the canvas yields a `null` target (#2210)
+      var canMove = rules.allowed('elements.move', {
+        shapes: [ group ],
+        target: null
+      });
+
+      // then
+      expect(canMove).to.be.false;
+    }));
+
+
+    it('should allow move to start without a target', inject(function(elementRegistry, rules) {
+
+      // given
+      var task = elementRegistry.get('Task');
+
+      // when
+      var canMove = rules.allowed('elements.move', {
+        shapes: [ task ]
+      });
+
+      // then
+      expect(canMove).to.be.true;
+    }));
+
+  });
+
+
   describe('event attaching', function() {
 
     var testXML = require('./BpmnRules.attaching.bpmn');


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->
Closes #2210

Dragging an element off the canvas yields a `null` move target, which `BpmnRules#canMove` treated like move-start (`!target`) and allowed — bypassing move rules (e.g. stacking pools, moving a shape out of its pool). Now only an `undefined` target starts a move; a `null` target is rejected.

Builds on the fix from #2244 by @Adam-Thometz (added co-author); adds a rules-level test that fails without the change.

**Try it:** two pools, scroll one mostly off-screen, drag the other past the
  viewport onto it → the drop is now rejected.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
