### PR TITLE
Replace support groups entries

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -459,20 +459,33 @@ ReplaceMenuProvider.prototype._createEntry = function(replaceOption, target, act
   var translate = this._translate;
   var replaceElement = this._bpmnReplace.replaceElement;
 
-  var replaceAction = function() {
-    return replaceElement(target, replaceOption.target);
-  };
-
   var label = replaceOption.label;
   if (label && typeof label === 'function') {
     label = label(target);
   }
+
+  var group = replaceOption.group && translateGroup(replaceOption.group, translate);
+
+  // step entry navigating to a nested set of replace options
+  if (replaceOption.entries) {
+    return {
+      label: translate(label),
+      className: replaceOption.className,
+      group: group,
+      entries: this._createEntries(target, replaceOption.entries)
+    };
+  }
+
+  var replaceAction = function() {
+    return replaceElement(target, replaceOption.target);
+  };
 
   action = action || replaceAction;
 
   return {
     label: translate(label),
     className: replaceOption.className,
+    group: group,
     action: action
   };
 };
@@ -655,3 +668,26 @@ ReplaceMenuProvider.prototype._getNonInterruptingHeaderEntries = function(elemen
     }
   };
 };
+
+
+// helpers //////////////////////
+
+
+/**
+ * Translate a group's name, preserving its id.
+ *
+ * @param {import('../replace/ReplaceOptions').ReplaceOptionGroup} group
+ * @param {Translate} translate
+ *
+ * @return {import('../replace/ReplaceOptions').ReplaceOptionGroup}
+ */
+function translateGroup(group, translate) {
+  if (typeof group === 'string') {
+    return group;
+  }
+
+  return {
+    id: group.id,
+    name: group.name && translate(group.name)
+  };
+}

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -1,10 +1,13 @@
 /**
  * @typedef { () => string } LabelGetter
  *
+ * @typedef { string | { id: string; name?: string } } ReplaceOptionGroup
+ *
  * @typedef { {
  *   label: string | LabelGetter;
  *   actionName: string;
  *   className: string;
+ *   group?: ReplaceOptionGroup;
  *   target?: {
  *     type: string;
  *     isExpanded?: boolean;
@@ -14,6 +17,7 @@
  *     eventDefinitionType?: string;
  *     eventDefinitionAttrs?: Record<string, any>
  *   };
+ *   entries?: ReplaceOption[];
  * } } ReplaceOption
  */
 


### PR DESCRIPTION
### Proposed Changes

This PR adds the foundations for using groups and (nested) in the existing replace menu - follow-up PRs prove this works - the replace options are sourced hard-wired, so this bit of our infrastructure cannot be mocked without module mocking:

* https://github.com/bpmn-io/bpmn-js/pull/2439
* https://github.com/bpmn-io/bpmn-js/pull/2440

Related to https://github.com/bpmn-io/diagram-js/pull/1040


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
