### PR TITLE
Group events in replace menu

### DIFF
--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -15,7 +15,8 @@ import {
 import {
   forEach,
   filter,
-  isArray
+  isArray,
+  map
 } from 'min-dash';
 
 import * as replaceOptions from '../replace/ReplaceOptions';
@@ -140,7 +141,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       differentType
     );
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // expanded/collapsed pools
@@ -170,7 +171,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       }
     );
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // start events inside sub processes
@@ -181,7 +182,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       differentType
     );
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // end events
@@ -198,7 +199,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       return differentType(replaceOption);
     });
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // boundary events
@@ -219,7 +220,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       return differentType(replaceOption) || !differentType(replaceOption) && !isCancelActivityEqual;
     });
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // intermediate events
@@ -231,7 +232,7 @@ ReplaceMenuProvider.prototype.getPopupMenuEntries = function(target) {
       differentType
     );
 
-    return this._createEntries(target, filteredReplaceOptions);
+    return this._createEntries(target, withEventGroups(filteredReplaceOptions));
   }
 
   // gateways
@@ -672,6 +673,44 @@ ReplaceMenuProvider.prototype._getNonInterruptingHeaderEntries = function(elemen
 
 // helpers //////////////////////
 
+/**
+ * Assign section groups to event replace options, splitting them into
+ * interrupting, non-interrupting and typed events.
+ *
+ * @param {ReplaceOption[]} options
+ *
+ * @return {ReplaceOption[]}
+ */
+function withEventGroups(options) {
+  return map(options, function(option) {
+    var group = getEventGroup(option);
+
+    return group ? { ...option, group: group } : option;
+  });
+}
+
+/**
+ * @param {ReplaceOption} option
+ *
+ * @return {import('../replace/ReplaceOptions').ReplaceOptionGroup|undefined}
+ */
+function getEventGroup(option) {
+  var target = option.target || {};
+
+  if (target.isInterrupting === false || target.cancelActivity === false) {
+    return replaceOptions.GROUP_NON_INTERRUPTING;
+  }
+
+  if (target.isInterrupting === true || target.cancelActivity === true) {
+    return replaceOptions.GROUP_INTERRUPTING;
+  }
+
+  if (target.eventDefinitionType) {
+    return replaceOptions.GROUP_TYPED_EVENTS;
+  }
+
+  return undefined;
+}
 
 /**
  * Translate a group's name, preserving its id.

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -22,6 +22,25 @@
  */
 
 /**
+ * Groups used to structure replace options into sections (flat dividers).
+ *
+ * Names are translated when the popup menu entries are created.
+ *
+ * @type {ReplaceOptionGroup}
+ */
+export var GROUP_TYPED_EVENTS = { id: 'typed-events', name: 'Typed events' };
+
+/**
+ * @type {ReplaceOptionGroup}
+ */
+export var GROUP_INTERRUPTING = { id: 'interrupting', name: 'Interrupting' };
+
+/**
+ * @type {ReplaceOptionGroup}
+ */
+export var GROUP_NON_INTERRUPTING = { id: 'non-interrupting', name: 'Non-interrupting' };
+
+/**
  * @type {ReplaceOption[]}
  */
 export var START_EVENT = [


### PR DESCRIPTION
### Proposed Changes

On top of https://github.com/bpmn-io/bpmn-js/pull/2438, this groups events in the replace menu by interrupting state:

<img width="963" height="844" alt="capture 3lXkez_optimized" src="https://github.com/user-attachments/assets/51a358a1-e75c-40b8-94e0-85783482e437" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
