### PR TITLE
Generate declaration maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 coverage/
 lib/**/*.d.ts
+lib/**/*.d.ts.map
 .idea
 *.iml
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
-        "bio-dts": "^0.14.0",
+        "bio-dts": "^0.15.2",
         "bpmn-font": "^0.12.1",
         "camunda-bpmn-moddle": "^4.0.1",
         "chai": "^6.2.2",
@@ -925,10 +925,15 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.4.tgz",
-      "integrity": "sha512-KE/SxsDqNs3rrWwFHcRh15ZLVFrI0YoZtgAdIyIq9k5hUNmiWRXXThPomIxHuL20sLdgzbDFyvkUMna14bvtrw==",
-      "dev": true
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -3116,12 +3121,15 @@
       }
     },
     "node_modules/bio-dts": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.14.1.tgz",
-      "integrity": "sha512-JmmB6BcDptuYoMcEPkyqPV1/PmOXdSAhU0ZQkPVQXQ4hmfN4q8zp/UsFH36nQsNgMCK5z2eLMYc/Bx13mjM2qA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.15.2.tgz",
+      "integrity": "sha512-e0GduoNz3vpG0Gk4oDgB70eRtgN0BgKn1QuaChrFQzYuERAechBxzoethzGsn5Reo37rou5h3l6AtXWXiGgeog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/source-map": "^0.3.11",
         "recast": "^0.23.11",
         "tiny-glob": "^0.2.9"
       },
@@ -15304,10 +15312,14 @@
       "dev": true
     },
     "@jridgewell/source-map": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.4.tgz",
-      "integrity": "sha512-KE/SxsDqNs3rrWwFHcRh15ZLVFrI0YoZtgAdIyIq9k5hUNmiWRXXThPomIxHuL20sLdgzbDFyvkUMna14bvtrw==",
-      "dev": true
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -16698,12 +16710,14 @@
       "dev": true
     },
     "bio-dts": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.14.1.tgz",
-      "integrity": "sha512-JmmB6BcDptuYoMcEPkyqPV1/PmOXdSAhU0ZQkPVQXQ4hmfN4q8zp/UsFH36nQsNgMCK5z2eLMYc/Bx13mjM2qA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/bio-dts/-/bio-dts-0.15.2.tgz",
+      "integrity": "sha512-e0GduoNz3vpG0Gk4oDgB70eRtgN0BgKn1QuaChrFQzYuERAechBxzoethzGsn5Reo37rou5h3l6AtXWXiGgeog==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/source-map": "^0.3.11",
         "recast": "^0.23.11",
         "tiny-glob": "^0.2.9"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "distro": "node tasks/build-distro.mjs",
     "collect-translations": "cross-env COLLECT_TRANSLATIONS=1 npm test",
     "generate-types": "run-s generate-types:*",
-    "generate-types:generate": "del-cli \"lib/**/*.d.ts\" && npx bio-dts -r lib",
+    "generate-types:generate": "del-cli \"lib/**/*.d.ts\" \"lib/**/*.d.ts.map\" && npx bio-dts -r lib --declarationMap",
     "generate-types:test": "tsc --noEmit --noImplicitAny",
     "test:distro": "node tasks/test-distro.mjs",
     "postversion": "run-s distro test:distro",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
-    "bio-dts": "^0.14.0",
+    "bio-dts": "^0.15.2",
     "bpmn-font": "^0.12.1",
     "camunda-bpmn-moddle": "^4.0.1",
     "chai": "^6.2.2",


### PR DESCRIPTION
### Proposed Changes

Generates declaration maps - allowing to "jump to source" instead of generated type definitions. While editors may apply heuristics I'd rather "not guess" and ship meaningful maps with our libraries. 

<img width="1526" height="898" alt="capture ZYgL7m_optimized" src="https://github.com/user-attachments/assets/9a15c1f5-814b-4673-b717-6f88cca20561" />

Works even better when tried with https://github.com/bpmn-io/diagram-js/pull/977.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Benefits both humans and :robot: 
* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
