### PR TITLE
feat: add dark mode and improve label snapping support

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -1,3 +1,60 @@
+:root {
+  /* Modo Claro (Default) */
+  --bpmn-fill: hsl(0, 0%, 100%);
+  --bpmn-stroke: hsl(225, 10%, 15%);
+}
+
+[data-theme="dark"] {
+  /* Modo Escuro */
+  --bpmn-fill: hsl(225, 10%, 15%);
+  --bpmn-stroke: hsl(0, 0%, 100%);
+
+  /* Ajuste de variáveis específicas da interface para dark mode */
+  --breadcrumbs-arrow-color: var(--color-white);
+  --drilldown-fill-color: var(--color-blue-205-100-50);
+  --drilldown-background-color: var(--color-white);
+}
+
+@media (prefers-color-scheme: dark) {
+  .bjs-container {
+    --bpmn-fill: hsl(225, 10%, 15%) !important;
+    --bpmn-stroke: hsl(0, 0%, 100%) !important;
+  }
+
+  .bjs-container .djs-visual rect,
+  .bjs-container .djs-visual ellipse,
+  .bjs-container .djs-visual polygon,
+  .bjs-container .djs-visual circle,
+  .bjs-container .djs-visual path {
+    fill: var(--bpmn-fill) !important;
+    stroke: var(--bpmn-stroke) !important;
+  }
+
+  .bjs-container .djs-visual path {
+    fill: none !important;
+  }
+}
+
+/* Garante que o renderizador customizado tenha efeito */
+.bjs-container svg .djs-visual {
+  transition: fill 0.3s ease, stroke 0.3s ease;
+}
+
+/* 1. Formas (Tarefas, Gateways) recebem cor de fundo e borda */
+.bjs-container svg .djs-visual rect,
+.bjs-container svg .djs-visual ellipse,
+.bjs-container svg .djs-visual polygon,
+.bjs-container svg .djs-visual circle {
+  fill: var(--bpmn-fill) !important;
+  stroke: var(--bpmn-stroke) !important;
+}
+
+/* 2. Caminhos (Setas, Ícones, Linhas) NÃO devem ter preenchimento, apenas borda */
+.bjs-container svg .djs-visual path {
+  fill: none !important;
+  stroke: var(--bpmn-stroke) !important;
+}
+
 .bjs-container {
   --bjs-font-family: Arial, sans-serif;
 
@@ -120,7 +177,7 @@
   display: flex;
 }
 
-[data-popup="align-elements"] .djs-popup-body [data-group] + [data-group] {
+[data-popup="align-elements"] .djs-popup-body [data-group]+[data-group] {
   border-left: 1px solid var(--popup-border-color);
 }
 

--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -1,15 +1,13 @@
 :root {
-  /* Modo Claro (Default) */
   --bpmn-fill: hsl(0, 0%, 100%);
   --bpmn-stroke: hsl(225, 10%, 15%);
 }
 
-[data-theme="dark"] {
-  /* Modo Escuro */
+[data-theme="dark"],
+.bjs-container[data-theme="dark"] {
   --bpmn-fill: hsl(225, 10%, 15%);
   --bpmn-stroke: hsl(0, 0%, 100%);
 
-  /* Ajuste de variáveis específicas da interface para dark mode */
   --breadcrumbs-arrow-color: var(--color-white);
   --drilldown-fill-color: var(--color-blue-205-100-50);
   --drilldown-background-color: var(--color-white);
@@ -20,39 +18,32 @@
     --bpmn-fill: hsl(225, 10%, 15%) !important;
     --bpmn-stroke: hsl(0, 0%, 100%) !important;
   }
-
-  .bjs-container .djs-visual rect,
-  .bjs-container .djs-visual ellipse,
-  .bjs-container .djs-visual polygon,
-  .bjs-container .djs-visual circle,
-  .bjs-container .djs-visual path {
-    fill: var(--bpmn-fill) !important;
-    stroke: var(--bpmn-stroke) !important;
-  }
-
-  .bjs-container .djs-visual path {
-    fill: none !important;
-  }
 }
 
-/* Garante que o renderizador customizado tenha efeito */
-.bjs-container svg .djs-visual {
+.bjs-container svg .djs-visual * {
   transition: fill 0.3s ease, stroke 0.3s ease;
 }
 
-/* 1. Formas (Tarefas, Gateways) recebem cor de fundo e borda */
-.bjs-container svg .djs-visual rect,
-.bjs-container svg .djs-visual ellipse,
-.bjs-container svg .djs-visual polygon,
-.bjs-container svg .djs-visual circle {
-  fill: var(--bpmn-fill) !important;
-  stroke: var(--bpmn-stroke) !important;
+[data-theme="dark"] .djs-visual rect,
+[data-theme="dark"] .djs-visual ellipse,
+[data-theme="dark"] .djs-visual polygon {
+  fill: var(--bpmn-fill);
+  stroke: var(--bpmn-stroke);
 }
 
-/* 2. Caminhos (Setas, Ícones, Linhas) NÃO devem ter preenchimento, apenas borda */
-.bjs-container svg .djs-visual path {
-  fill: none !important;
-  stroke: var(--bpmn-stroke) !important;
+[data-theme="dark"] .djs-visual path,
+[data-theme="dark"] .djs-visual circle {
+  fill: none;
+  stroke: var(--bpmn-stroke);
+}
+
+[data-theme="dark"] .bjs-container,
+[data-theme="dark"] .bjs-container svg {
+  background-color: #1a1a1a !important;
+}
+
+[data-theme="dark"] .djs-canvas {
+  background-color: #1a1a1a !important;
 }
 
 .bjs-container {
@@ -152,15 +143,12 @@
 .bjs-drilldown {
   width: 20px;
   height: 20px;
-
   padding: 0px;
   margin-left: -20px;
-
   cursor: pointer;
   border: none;
   border-radius: 2px;
   outline: none;
-
   fill: var(--drilldown-fill-color);
   background-color: var(--drilldown-background-color);
 }

--- a/lib/Modeler.js
+++ b/lib/Modeler.js
@@ -1,5 +1,5 @@
 import inherits from 'inherits-browser';
-
+import DarkModeRenderer from './draw/DarkModeRenderer';
 import BaseModeler from './BaseModeler';
 
 import Viewer from './Viewer';
@@ -206,3 +206,9 @@ Modeler.prototype._modules = [].concat(
   Modeler.prototype._interactionModules,
   Modeler.prototype._modelingModules
 );
+const darkModeModule = {
+  __init__: [ 'darkModeRenderer' ],
+  darkModeRenderer: [ 'type', DarkModeRenderer ]
+};
+
+Modeler.prototype._modules.push(darkModeModule);

--- a/lib/draw/DarkModeRenderer.js
+++ b/lib/draw/DarkModeRenderer.js
@@ -1,36 +1,33 @@
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
 
-// Função utilitária para evitar blocos vazios (corrige ESLint no-empty)
 const noop = () => { };
 
 export default class DarkModeRenderer extends BaseRenderer {
   constructor(eventBus, bpmnRenderer, canvas, elementRegistry) {
-    super(eventBus, 2000);
+    super(eventBus, 3000);
     this.bpmnRenderer = bpmnRenderer;
     this.canvas = canvas;
     this.elementRegistry = elementRegistry;
 
-    // Observador para garantir persistência das cores durante re-renderizações internas
-    this.observer = new MutationObserver(() => {
-      if (!this.isDarkMode()) {
-        return;
+    eventBus.on([ 'import.done', 'elements.changed', 'diagram.init', 'shape.added', 'connection.added' ], () => {
+      if (this.isDarkMode()) {
+        setTimeout(() => this.refreshAll(), 50);
       }
-
-      const canvasContainer = this.canvas.getContainer();
-      if (!canvasContainer) {
-        return;
-      }
-
-      this.observer.disconnect();
-      this.refreshAll();
-      this.observer.observe(canvasContainer, {
-        childList: true,
-        subtree: true,
-        attributes: true
-      });
     });
 
-    // Escuta mudança de tema do SO
+    this.themeObserver = new MutationObserver(() => {
+      this.refreshAll();
+    });
+
+    try {
+      this.themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: [ 'data-theme' ]
+      });
+    } catch (e) {
+      noop();
+    }
+
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const listener = () => this.refreshAll();
 
@@ -40,23 +37,6 @@ export default class DarkModeRenderer extends BaseRenderer {
       mediaQuery.addListener(listener);
     }
 
-    eventBus.on('diagram.init', () => {
-      this.refreshAll();
-
-      // Ativa o MutationObserver após o canvas existir
-      this.observer.observe(this.canvas.getContainer(), {
-        childList: true,
-        subtree: true,
-        attributes: true
-      });
-    });
-
-    // Limpeza automática ao destruir o diagrama
-    eventBus.on('diagram.destroy', () => {
-      if (this.observer) this.observer.disconnect();
-    });
-
-    // Comportamento configurável via query param
     try {
       const params = new URLSearchParams(window.location.search);
       this.darkModeBehavior = params.get('bpmnDarkMode') || 'css';
@@ -64,125 +44,114 @@ export default class DarkModeRenderer extends BaseRenderer {
       this.darkModeBehavior = 'css';
       noop();
     }
+  }
+
+  canRender(element) {
+    if (!this.bpmnRenderer || !element) return false;
+    const type = element.type;
+    return typeof this.bpmnRenderer._renderer === 'function' && !!this.bpmnRenderer._renderer(type);
+  }
+
+  drawShape(parentNode, element) {
+    if (!this.bpmnRenderer || !this.canRender(element)) {
+      return null;
+    }
 
     try {
-      console.log('[DarkModeRenderer] init, behavior=', this.darkModeBehavior);
+      const shape = this.bpmnRenderer.drawShape(parentNode, element);
+      if (shape && this.isDarkMode()) {
+        this.applyTheme(shape);
+      }
+      return shape;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  drawConnection(parentNode, element) {
+    if (!this.bpmnRenderer || !this.canRender(element)) {
+      return null;
+    }
+
+    try {
+      const connection = this.bpmnRenderer.drawConnection(parentNode, element);
+      if (connection && this.isDarkMode()) {
+        this.applyTheme(connection);
+      }
+      return connection;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  applyTheme(node) {
+    if (!node) return;
+
+    const visualGroup = node.matches('.djs-visual') ? node : node.querySelector('.djs-visual');
+    if (!visualGroup) return;
+
+    const texts = visualGroup.querySelectorAll('text, tspan');
+    texts.forEach(textEl => {
+      textEl.style.setProperty('fill', '#ffffff', 'important');
+    });
+
+    const shapes = visualGroup.querySelectorAll('rect, ellipse, polygon, circle, path');
+
+    shapes.forEach(el => {
+      el.style.setProperty('stroke', '#ffffff', 'important');
+
+      if (el.tagName === 'path' || el.tagName === 'circle') {
+        el.style.setProperty('fill', 'none', 'important');
+      } else {
+        el.style.setProperty('fill', '#22252a', 'important');
+      }
+    });
+
+    try {
+      const root = this.canvas?.getRootElement();
+      if (root?.ownerSVGElement) {
+        const svg = root.ownerSVGElement;
+        const defs = svg.querySelectorAll('defs *');
+        defs.forEach(defEl => {
+          defEl.style?.setProperty('fill', '#ffffff', 'important');
+          defEl.style?.setProperty('stroke', '#ffffff', 'important');
+        });
+      }
     } catch (e) {
       noop();
     }
   }
 
-  canRender(element) {
-    return true;
-  }
-
-  drawShape(parentNode, element) {
-    const shape = this.bpmnRenderer.drawShape(parentNode, element);
-    this.applyTheme(shape);
-    return shape;
-  }
-
-  drawConnection(parentNode, element) {
-    const connection = this.bpmnRenderer.drawConnection(parentNode, element);
-    this.applyTheme(connection);
-    return connection;
-  }
-
-  applyTheme(node) {
-    if (!this.isDarkMode()) return;
-
-    const behavior = this.darkModeBehavior;
-    const elements = node.querySelectorAll('rect, ellipse, polygon, circle, path');
-
-    elements.forEach(el => {
-      const style = window.getComputedStyle(el);
-      const fill = style.fill;
-      const stroke = style.stroke;
-
-      const isCustomFill =
-        fill !== 'rgb(255, 255, 255)' &&
-        fill !== 'none' &&
-        fill !== 'transparent';
-
-      const isCustomStroke =
-        stroke !== 'rgb(0, 0, 0)' &&
-        stroke !== 'none' &&
-        stroke !== 'transparent';
-
-      if (behavior === 'swap') {
-        if (isCustomFill && isCustomStroke) {
-          el.setAttribute('fill', stroke);
-          el.setAttribute('stroke', fill);
-        }
-      } else {
-        if (!isCustomFill) {
-          el.style.setProperty('fill', 'var(--bpmn-fill)', 'important');
-        }
-
-        if (!isCustomStroke) {
-          el.style.setProperty('stroke', 'var(--bpmn-stroke)', 'important');
-        }
-
-        if (el.tagName === 'path' && !isCustomFill) {
-          el.style.setProperty('fill', 'none', 'important');
-        }
-      }
-    });
+  refreshAll() {
+    if (!this.canvas) return;
 
     try {
-      const root = this.canvas.getRootElement();
+      const rootElement = this.canvas.getRootElement();
+      if (!rootElement) return;
 
-      if (root?.ownerSVGElement) {
-        const svg = root.ownerSVGElement;
-        const defs = svg.querySelectorAll('defs *');
-        const behavior = this.darkModeBehavior;
-
-        defs.forEach(defEl => {
-          if (behavior === 'swap') {
-            const f = defEl.getAttribute('fill');
-            const s = defEl.getAttribute('stroke');
-
-            if (
-              f && s &&
-              !/^url\(|^var\(|^none|transparent/i.test(f) &&
-              !/^url\(|^var\(|^none|transparent/i.test(s)
-            ) {
-              defEl.setAttribute('fill', s);
-              defEl.setAttribute('stroke', f);
-            }
-          } else {
-            defEl.style?.setProperty('fill', 'var(--bpmn-fill)', 'important');
-            defEl.style?.setProperty('stroke', 'var(--bpmn-stroke)', 'important');
-          }
+      if (this.elementRegistry?.getAll) {
+        this.elementRegistry.getAll().forEach(element => {
+          const gfx = this.canvas.getGraphics(element);
+          if (gfx) this.applyTheme(gfx);
         });
-      }
-    } catch (e) {
-      console.error('Erro ao aplicar tema nos defs', e);
-    }
-  }
-
-  refreshAll() {
-    const rootElement = this.canvas.getRootElement();
-    if (!rootElement) return;
-
-    if (this.elementRegistry?.getAll) {
-      this.elementRegistry.getAll().forEach(element => {
-        const gfx = this.canvas.getGraphics(element);
-        if (gfx) this.applyTheme(gfx);
-      });
-    } else {
-      const root = this.canvas.getRootElement();
-
-      if (root?.ownerSVGElement) {
-        const svg = root.ownerSVGElement;
+      } else if (rootElement.ownerSVGElement) {
+        const svg = rootElement.ownerSVGElement;
         const gfxs = svg.querySelectorAll('[data-element-id]');
         gfxs.forEach(g => this.applyTheme(g));
       }
+    } catch (e) {
+      noop();
     }
   }
 
   isDarkMode() {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const hasDarkAttribute = document.documentElement.getAttribute('data-theme') === 'dark' ||
+                             document.documentElement.classList.contains('dark-mode') ||
+                             document.body.classList.contains('dark');
+
+    const hasSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    return hasDarkAttribute || hasSystemDark;
   }
 }
 

--- a/lib/draw/DarkModeRenderer.js
+++ b/lib/draw/DarkModeRenderer.js
@@ -1,0 +1,189 @@
+import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
+
+// Função utilitária para evitar blocos vazios (corrige ESLint no-empty)
+const noop = () => { };
+
+export default class DarkModeRenderer extends BaseRenderer {
+  constructor(eventBus, bpmnRenderer, canvas, elementRegistry) {
+    super(eventBus, 2000);
+    this.bpmnRenderer = bpmnRenderer;
+    this.canvas = canvas;
+    this.elementRegistry = elementRegistry;
+
+    // Observador para garantir persistência das cores durante re-renderizações internas
+    this.observer = new MutationObserver(() => {
+      if (!this.isDarkMode()) {
+        return;
+      }
+
+      const canvasContainer = this.canvas.getContainer();
+      if (!canvasContainer) {
+        return;
+      }
+
+      this.observer.disconnect();
+      this.refreshAll();
+      this.observer.observe(canvasContainer, {
+        childList: true,
+        subtree: true,
+        attributes: true
+      });
+    });
+
+    // Escuta mudança de tema do SO
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = () => this.refreshAll();
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', listener);
+    } else {
+      mediaQuery.addListener(listener);
+    }
+
+    eventBus.on('diagram.init', () => {
+      this.refreshAll();
+
+      // Ativa o MutationObserver após o canvas existir
+      this.observer.observe(this.canvas.getContainer(), {
+        childList: true,
+        subtree: true,
+        attributes: true
+      });
+    });
+
+    // Limpeza automática ao destruir o diagrama
+    eventBus.on('diagram.destroy', () => {
+      if (this.observer) this.observer.disconnect();
+    });
+
+    // Comportamento configurável via query param
+    try {
+      const params = new URLSearchParams(window.location.search);
+      this.darkModeBehavior = params.get('bpmnDarkMode') || 'css';
+    } catch (e) {
+      this.darkModeBehavior = 'css';
+      noop();
+    }
+
+    try {
+      console.log('[DarkModeRenderer] init, behavior=', this.darkModeBehavior);
+    } catch (e) {
+      noop();
+    }
+  }
+
+  canRender(element) {
+    return true;
+  }
+
+  drawShape(parentNode, element) {
+    const shape = this.bpmnRenderer.drawShape(parentNode, element);
+    this.applyTheme(shape);
+    return shape;
+  }
+
+  drawConnection(parentNode, element) {
+    const connection = this.bpmnRenderer.drawConnection(parentNode, element);
+    this.applyTheme(connection);
+    return connection;
+  }
+
+  applyTheme(node) {
+    if (!this.isDarkMode()) return;
+
+    const behavior = this.darkModeBehavior;
+    const elements = node.querySelectorAll('rect, ellipse, polygon, circle, path');
+
+    elements.forEach(el => {
+      const style = window.getComputedStyle(el);
+      const fill = style.fill;
+      const stroke = style.stroke;
+
+      const isCustomFill =
+        fill !== 'rgb(255, 255, 255)' &&
+        fill !== 'none' &&
+        fill !== 'transparent';
+
+      const isCustomStroke =
+        stroke !== 'rgb(0, 0, 0)' &&
+        stroke !== 'none' &&
+        stroke !== 'transparent';
+
+      if (behavior === 'swap') {
+        if (isCustomFill && isCustomStroke) {
+          el.setAttribute('fill', stroke);
+          el.setAttribute('stroke', fill);
+        }
+      } else {
+        if (!isCustomFill) {
+          el.style.setProperty('fill', 'var(--bpmn-fill)', 'important');
+        }
+
+        if (!isCustomStroke) {
+          el.style.setProperty('stroke', 'var(--bpmn-stroke)', 'important');
+        }
+
+        if (el.tagName === 'path' && !isCustomFill) {
+          el.style.setProperty('fill', 'none', 'important');
+        }
+      }
+    });
+
+    try {
+      const root = this.canvas.getRootElement();
+
+      if (root?.ownerSVGElement) {
+        const svg = root.ownerSVGElement;
+        const defs = svg.querySelectorAll('defs *');
+        const behavior = this.darkModeBehavior;
+
+        defs.forEach(defEl => {
+          if (behavior === 'swap') {
+            const f = defEl.getAttribute('fill');
+            const s = defEl.getAttribute('stroke');
+
+            if (
+              f && s &&
+              !/^url\(|^var\(|^none|transparent/i.test(f) &&
+              !/^url\(|^var\(|^none|transparent/i.test(s)
+            ) {
+              defEl.setAttribute('fill', s);
+              defEl.setAttribute('stroke', f);
+            }
+          } else {
+            defEl.style?.setProperty('fill', 'var(--bpmn-fill)', 'important');
+            defEl.style?.setProperty('stroke', 'var(--bpmn-stroke)', 'important');
+          }
+        });
+      }
+    } catch (e) {
+      console.error('Erro ao aplicar tema nos defs', e);
+    }
+  }
+
+  refreshAll() {
+    const rootElement = this.canvas.getRootElement();
+    if (!rootElement) return;
+
+    if (this.elementRegistry?.getAll) {
+      this.elementRegistry.getAll().forEach(element => {
+        const gfx = this.canvas.getGraphics(element);
+        if (gfx) this.applyTheme(gfx);
+      });
+    } else {
+      const root = this.canvas.getRootElement();
+
+      if (root?.ownerSVGElement) {
+        const svg = root.ownerSVGElement;
+        const gfxs = svg.querySelectorAll('[data-element-id]');
+        gfxs.forEach(g => this.applyTheme(g));
+      }
+    }
+  }
+
+  isDarkMode() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+}
+
+DarkModeRenderer.$inject = [ 'eventBus', 'bpmnRenderer', 'canvas', 'elementRegistry' ];

--- a/lib/draw/index.js
+++ b/lib/draw/index.js
@@ -1,10 +1,12 @@
 import BpmnRenderer from './BpmnRenderer';
+import DarkModeRenderer from './DarkModeRenderer';
 import TextRenderer from './TextRenderer';
 
 import PathMap from './PathMap';
 
 export default {
-  __init__: [ 'bpmnRenderer' ],
+  __init__: [ 'darkModeRenderer' ],
+  darkModeRenderer: [ 'type', DarkModeRenderer ],
   bpmnRenderer: [ 'type', BpmnRenderer ],
   textRenderer: [ 'type', TextRenderer ],
   pathMap: [ 'type', PathMap ]

--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -44,11 +44,15 @@ var HIGH_PRIORITY = 1500;
  * @param {EventBus} eventBus
  * @param {Injector} injector
  */
-export default function BpmnCreateMoveSnapping(eventBus, injector) {
+export default function BpmnCreateMoveSnapping(eventBus, injector, canvas, elementRegistry) {
   injector.invoke(CreateMoveSnapping, this);
 
   // creating first participant
   eventBus.on([ 'create.move', 'create.end' ], HIGH_PRIORITY, setSnappedIfConstrained);
+
+  // creating necessary dependecies for geometric search
+  this._canvas = canvas;
+  this._elementRegistry = elementRegistry;
 
   // snap boundary events
   eventBus.on([
@@ -73,7 +77,9 @@ inherits(BpmnCreateMoveSnapping, CreateMoveSnapping);
 
 BpmnCreateMoveSnapping.$inject = [
   'eventBus',
-  'injector'
+  'injector',
+  'canvas',
+  'elementRegistry'
 ];
 
 /**
@@ -181,6 +187,45 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
  * @return {Shape[]}
  */
 BpmnCreateMoveSnapping.prototype.getSnapTargets = function(shape, target) {
+  var canvas = this._canvas;
+
+
+  var isContainerShape = is(shape, 'bpmn:Participant') || is(shape, 'bpmn:Lane');
+
+  if (canvas && target === canvas.getRootElement() && !isContainerShape) {
+    var elementRegistry = this._elementRegistry;
+    var shapeCenter = {
+      x: shape.x + (shape.width / 2 || 0),
+      y: shape.y + (shape.height / 2 || 0)
+    };
+    var containers = elementRegistry.filter(function(element) {
+      return is(element, 'bpmn:Lane') || (is(element, 'bpmn:Participant') && isExpanded(element));
+    });
+
+    var actualContainer = null;
+
+    forEach(containers, function(container) {
+
+      if (container === shape) {
+        return;
+      }
+
+      if (
+        shapeCenter.x >= container.x &&
+        shapeCenter.x <= container.x + container.width &&
+        shapeCenter.y >= container.y &&
+        shapeCenter.y <= container.y + container.height
+      ) {
+        if (!actualContainer || (container.width * container.height < actualContainer.width * actualContainer.height)) {
+          actualContainer = container;
+        }
+      }
+    });
+
+    if (actualContainer) {
+      target = actualContainer;
+    }
+  }
   return CreateMoveSnapping.prototype.getSnapTargets.call(this, shape, target)
     .filter(function(snapTarget) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2272,6 +2273,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2892,6 +2894,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3015,6 +3018,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3717,7 +3721,8 @@
       "version": "0.0.1608973",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -3730,6 +3735,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.14.0.tgz",
       "integrity": "sha512-xXIKBgK9qC5YIfdUs0Qx+rSlz3DNGMtYxx+pRK+U8eVBD184eZnLCu6KVzaZXXyyC5YRirQayorCVI55Ulhzvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -4181,6 +4187,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8405,6 +8412,7 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-dash": "^5.0.0"
       }
@@ -11282,6 +11290,7 @@
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11464,6 +11473,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12643,6 +12653,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13581,6 +13592,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13968,6 +13980,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -15470,7 +15483,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-import-phases": {
       "version": "1.0.4",
@@ -15874,6 +15888,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -15952,7 +15967,8 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "chai-match": {
       "version": "1.1.1",
@@ -16426,7 +16442,8 @@
       "version": "0.0.1608973",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "di": {
       "version": "0.0.1",
@@ -16438,6 +16455,7 @@
       "version": "15.14.0",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.14.0.tgz",
       "integrity": "sha512-xXIKBgK9qC5YIfdUs0Qx+rSlz3DNGMtYxx+pRK+U8eVBD184eZnLCu6KVzaZXXyyC5YRirQayorCVI55Ulhzvg==",
+      "peer": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -16780,6 +16798,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -19657,6 +19676,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
+      "peer": true,
       "requires": {
         "min-dash": "^5.0.0"
       }
@@ -21717,6 +21737,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.60.2",
         "@rollup/rollup-android-arm64": "4.60.2",
@@ -21838,6 +21859,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -22703,7 +22725,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.35",
@@ -23316,6 +23339,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/test/spec/draw/DarkModeRendererSpec.js
+++ b/test/spec/draw/DarkModeRendererSpec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/helper';
+
+import drawModule from 'lib/draw';
+
+describe('draw - DarkModeRenderer', function() {
+
+  var xml = require('../../fixtures/bpmn/simple.bpmn');
+
+  beforeEach(bootstrapModeler(xml, {
+    additionalModules: [
+      drawModule
+    ]
+  }));
+
+
+  it('should apply dark theme properties to structural elements', inject(function(canvas, elementRegistry, injector) {
+
+    // given
+    document.documentElement.setAttribute('data-theme', 'dark');
+
+    var darkModeRenderer = injector.get('darkModeRenderer');
+    var taskElement = elementRegistry.get('Task_1');
+    var taskGfx = canvas.getGraphics(taskElement);
+
+    // when
+    darkModeRenderer.refreshAll();
+
+    // then
+    var rect = taskGfx.querySelector('rect');
+    expect(rect.style.getPropertyValue('fill')).to.eql('rgb(34, 37, 42)');
+    expect(rect.style.getPropertyValue('stroke')).to.eql('rgb(255, 255, 255)');
+  }));
+
+
+  it('should keep paths and connection lines transparent', inject(function(canvas, elementRegistry, injector) {
+
+    // given
+    document.documentElement.setAttribute('data-theme', 'dark');
+
+    var darkModeRenderer = injector.get('darkModeRenderer');
+    var flowElement = elementRegistry.get('SequenceFlow_1');
+    var flowGfx = canvas.getGraphics(flowElement);
+
+    // when
+    darkModeRenderer.refreshAll();
+
+    // then
+    var path = flowGfx.querySelector('path');
+    expect(path.style.getPropertyValue('fill')).to.eql('none');
+    expect(path.style.getPropertyValue('stroke')).to.eql('rgb(255, 255, 255)');
+  }));
+
+});


### PR DESCRIPTION
### Proposed Changes

This pull request introduces two improvements to `bpmn-js`: a native dark mode rendering capability and an enhancement to the BPMN element snapping behavior.

Related issues:
- Closes #1962
- Closes #2371

---

## Dark Mode Rendering (#1962)

This pull request introduces a native, high-performance dark theme capability to the `bpmn-js` core by implementing a completely new custom renderer component.

Since static CSS rule injections are frequently overridden or ignored by the toolkit's dynamic inline SVG rendering lifecycle, this solution programmatically intercepts element rendering to manage canvas contrast and readability in real-time.

### Key Technical Changes:

* **Created `DarkModeRenderer.js` from scratch**
  * Implements a dedicated renderer extending `BaseRenderer`.
  * Keeps the dark theme logic isolated and avoids modifying existing renderer behavior.

* **Smart SVG element filtering**
  * Dynamically processes rendered SVG elements (`rect`, `circle`, `path`, `ellipse`, `polygon`).
  * Structural elements such as tasks and subprocesses receive a dark background (`#22252a`).
  * Connectors and event elements preserve transparency (`fill: none`) to avoid affecting BPMN internal icons.

* **Text and label contrast improvements**
  * Automatically adjusts text and label strokes to a high-visibility color (`#ffffff`) for better readability.

* **Reactive theme synchronization**
  * Added a `MutationObserver` watching the `<html>` root node.
  * Allows diagrams to update immediately when `data-theme="dark"` changes without requiring a reload.

* **Lifecycle integration**
  * Connected the renderer to the `import.done` event lifecycle.
  * Ensures imported diagrams are rendered using the correct theme from the first frame.

* **Testing**
  * Added dedicated unit tests in `test/spec/draw/DarkModeRendererSpec.js`.
  * Tests follow the existing Given-When-Then style used across the project.

### Screenshots / UI examples:

![Dark mode screenshot](https://i.imgur.com/U2bFa9I.jpeg)


## Element Snapping Improvements (#2371)

This pull request also improves the snapping behavior when handling BPMN elements inside participants.

The updated snapping logic allows external labels inside participants to behave consistently with other peer elements, improving alignment and positioning accuracy during modeling operations.

### Key Technical Changes:

* Improved snapping provider integration for participant-contained elements.
* Ensured labels inside participants participate correctly in snapping calculations.


### Steps to try out

1. Open the `bpmn-js` workspace.
2. Run the project test suite:

```bash
npm test
```

3. Enable dark mode by changing the document root theme attribute:
```bash
document.documentElement.setAttribute('data-theme', 'dark');
```