### PR TITLE
fix(snapping): snap labels to peers inside participant/lane

### DIFF
--- a/lib/features/snapping/BpmnCreateMoveSnapping.js
+++ b/lib/features/snapping/BpmnCreateMoveSnapping.js
@@ -171,6 +171,17 @@ BpmnCreateMoveSnapping.prototype.addSnapTargetPoints = function(snapPoints, shap
     snapPoints = this.addSnapTargetPoints(snapPoints, shape, target.parent);
   }
 
+  // labels are always hovered onto the root element (see FixHoverBehavior),
+  // so their peers (siblings of the labelTarget) are not picked up as snap
+  // targets; add the labelTarget's actual container explicitly
+  if (shape.labelTarget) {
+    var labelParent = shape.labelTarget.parent;
+
+    if (labelParent && labelParent !== target) {
+      snapPoints = this.addSnapTargetPoints(snapPoints, shape, labelParent);
+    }
+  }
+
   return snapPoints;
 };
 

--- a/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping-process.bpmn
+++ b/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping-process.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start" />
+    <bpmn:exclusiveGateway id="Gateway_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="200" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="190" y="160" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="400" y="125" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
+++ b/test/spec/features/snapping/BpmnCreateMoveSnapping.label-snapping.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_1">
+      <bpmn:lane id="Lane_1">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_2" />
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1" name="Start" />
+    <bpmn:exclusiveGateway id="Gateway_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_1_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="600" height="240" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1_di" bpmnElement="Lane_1" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="570" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_2_di" bpmnElement="Lane_2" isHorizontal="true">
+        <dc:Bounds x="190" y="200" width="570" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="200" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="190" y="160" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="400" y="125" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
+++ b/test/spec/features/snapping/BpmnCreateMoveSnappingSpec.js
@@ -715,6 +715,100 @@ describe('features/snapping - BpmnCreateMoveSnapping', function() {
 
   });
 
+
+  describe('label snapping', function() {
+
+    function moveLabel(label, hover, toPosition) {
+      getBpmnJS().invoke(function(dragging, move, canvas) {
+        move.start(canvasEvent(mid(label)), label);
+
+        dragging.hover({
+          element: hover,
+          gfx: canvas.getGraphics(hover)
+        });
+
+        dragging.move(canvasEvent({ x: 0, y: 0 }));
+
+        dragging.move(canvasEvent(toPosition));
+
+        dragging.end();
+      });
+    }
+
+
+    describe('inside participant', function() {
+
+      var diagramXML = require('./BpmnCreateMoveSnapping.label-snapping.bpmn');
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        modules: testModules
+      }));
+
+
+      it('should snap label to peer shape inside participant', inject(
+        function(elementRegistry) {
+
+          // given
+          var label = elementRegistry.get('StartEvent_1').label,
+              gateway = elementRegistry.get('Gateway_1'),
+              participant = elementRegistry.get('Participant_1');
+
+          var labelMid = mid(label);
+
+          // when
+          // move label close to the gateway's horizontal center (peer)
+          moveLabel(label, participant, {
+            x: mid(gateway).x - 5,
+            y: labelMid.y
+          });
+
+          // then
+          expect(mid(label)).to.eql({
+            x: mid(gateway).x, // snapped to peer shape inside participant
+            y: labelMid.y
+          });
+        }
+      ));
+
+    });
+
+
+    describe('inside process (no participant)', function() {
+
+      var diagramXML = require('./BpmnCreateMoveSnapping.label-snapping-process.bpmn');
+
+      beforeEach(bootstrapModeler(diagramXML, {
+        modules: testModules
+      }));
+
+
+      it('should snap label to peer shape (same behavior independent of context)', inject(
+        function(elementRegistry, canvas) {
+
+          // given
+          var label = elementRegistry.get('StartEvent_1').label,
+              gateway = elementRegistry.get('Gateway_1'),
+              root = canvas.getRootElement();
+
+          var labelMid = mid(label);
+
+          // when
+          moveLabel(label, root, {
+            x: mid(gateway).x - 5,
+            y: labelMid.y
+          });
+
+          // then
+          expect(mid(label)).to.eql({
+            x: mid(gateway).x, // snapped to peer shape
+            y: labelMid.y
+          });
+        }
+      ));
+
+    });
+
+  });
 });
 
 // helpers //////////


### PR DESCRIPTION
### Proposed Changes

Closes #2371

#### Problem

External labels are always hovered onto the root element (see `FixHoverBehavior`),
so snap targets were computed from the root's children only. Inside a collaboration
the actual peers (events, gateways, ...) are children of the participant, not the
root — so no alignment assistance was given when moving a label inside a
participant/lane. Outside of a participant it worked because the label owner's
parent already *is* the root.

#### Solution

In `BpmnCreateMoveSnapping#addSnapTargetPoints`, when moving a label, also add the
label owner's actual container (`shape.labelTarget.parent`) as a snap target source,
reusing the existing recursion already used for sequence-flow parents. This restores
consistent behavior independent of the modeling context and also covers labels inside
expanded sub-processes.

### Steps to try out

1. Open `demo.bpmn.io` (or this build).
2. Create a pool with lanes and two labeled elements (e.g. start event + gateway).
3. Drag one external label — snap lines now align with the peer element inside the
   participant, identical to the behavior outside of a participant.

### Tests

Added `describe('label snapping')` in `BpmnCreateMoveSnappingSpec`:

- `should snap label to peer shape inside participant`
- `should snap label to peer shape (same behavior independent of context)` (regression in a plain process)

The participant test fails without the fix and passes with it; the full suite is green.

### Notes

This addresses the same issue as #2376 with a smaller, more general change (no extra
helper, also covers expanded sub-processes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
