### PR TITLE
Derive outline offset from circular outline shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `CHORE`: derive label link offset from (circular) outline shape ([#2457](https://github.com/bpmn-io/bpmn-js/pull/2457))
+
 ## 18.19.0
 
 * `FEAT`: use parents' entries keywords for search in popup menu ([#1053](https://github.com/bpmn-io/diagram-js/pull/1053))

--- a/lib/features/label-link/LabelLink.js
+++ b/lib/features/label-link/LabelLink.js
@@ -147,7 +147,6 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
    */
   function getElementOutlinePath(element) {
     const outlineShape = outline.getOutline(element);
-    const outlineOffset = outline.offset;
 
     if (!outlineShape) {
       return getElementPath(element);
@@ -165,11 +164,13 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
     }
 
     if (outlineShape.cx) {
+      const radius = parseSvgNumAttr(outlineShape, 'r');
+
       const shape = {
-        x: element.x - outlineOffset,
-        y: element.y - outlineOffset,
-        width: parseSvgNumAttr(outlineShape, 'r') * 2,
-        height: parseSvgNumAttr(outlineShape, 'r') * 2,
+        x: element.x + parseSvgNumAttr(outlineShape, 'cx') - radius,
+        y: element.y + parseSvgNumAttr(outlineShape, 'cy') - radius,
+        width: radius * 2,
+        height: radius * 2,
       };
 
       return getCirclePath(shape);


### PR DESCRIPTION
### Proposed Changes

`label-link` currently depends on `Outline.offset` - untested internal outline state.

This PR adjusts the feature to rely entirely on the outline GFX for path computation - we did already rely on it for most parts :see_no_evil: 

<img width="1213" height="703" alt="capture zg0Ott_optimized" src="https://github.com/user-attachments/assets/dce159ca-5e60-4e58-9ca5-e69e36668a66" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
