### PR TITLE
test(replace-preview): verify visuals equal

### DIFF
--- a/test/spec/features/replace-preview/BpmnReplacePreviewSpec.js
+++ b/test/spec/features/replace-preview/BpmnReplacePreviewSpec.js
@@ -18,6 +18,10 @@ import {
 } from 'min-dash';
 
 import {
+  query as domQuery
+} from 'min-dom';
+
+import {
   attr as svgAttr,
   clone as svgClone,
   innerSVG
@@ -169,7 +173,7 @@ describe('features/replace-preview', function() {
         eventDefinitionType: 'bpmn:MessageEventDefinition'
       });
 
-      expect(innerSVG(context.dragGroup.childNodes[0])).to.equal(innerSVG(startEventGfx));
+      expectVisuals(context.dragGroup.childNodes[0], startEventGfx);
     })
   );
 
@@ -186,7 +190,7 @@ describe('features/replace-preview', function() {
       // check if the visual replacement is a blank interrupting start event
       var startEventGfx = getGfx({ type: 'bpmn:StartEvent' });
 
-      expect(innerSVG(context.dragGroup.childNodes[1])).to.equal(innerSVG(startEventGfx));
+      expectVisuals(context.dragGroup.childNodes[1], startEventGfx);
     })
   );
 
@@ -210,7 +214,7 @@ describe('features/replace-preview', function() {
         eventDefinitionType: 'bpmn:MessageEventDefinition'
       });
 
-      expect(innerSVG(context.dragGroup.childNodes[0])).to.equal(innerSVG(startEventGfx));
+      expectVisuals(context.dragGroup.childNodes[0], startEventGfx);
     })
   );
 
@@ -230,7 +234,7 @@ describe('features/replace-preview', function() {
       // check if the visual representation remains a non interrupting message start event
       var startEventGfx = getGfx({ type: 'bpmn:StartEvent' });
 
-      expect(innerSVG(context.dragGroup.childNodes[1])).to.equal(innerSVG(startEventGfx));
+      expectVisuals(context.dragGroup.childNodes[1], startEventGfx);
     })
   );
 
@@ -253,9 +257,9 @@ describe('features/replace-preview', function() {
       // check if the visual replacements are blank interrupting start events
       var startEventGfx = getGfx({ type: 'bpmn:StartEvent' });
 
-      expect(innerSVG(context.dragGroup.childNodes[1])).to.equal(innerSVG(startEventGfx));
-      expect(innerSVG(context.dragGroup.childNodes[3])).to.equal(innerSVG(startEventGfx));
-      expect(innerSVG(context.dragGroup.childNodes[4])).to.equal(innerSVG(startEventGfx));
+      expectVisuals(context.dragGroup.childNodes[1], startEventGfx);
+      expectVisuals(context.dragGroup.childNodes[3], startEventGfx);
+      expectVisuals(context.dragGroup.childNodes[4], startEventGfx);
     })
   );
 
@@ -290,9 +294,9 @@ describe('features/replace-preview', function() {
       var context = dragging.context().data.context;
 
       // then
-      expect(innerSVG(context.dragGroup.childNodes[0])).to.equal(innerSVG(messageStartEventGfx));
-      expect(innerSVG(context.dragGroup.childNodes[1])).to.equal(innerSVG(startEventGfx));
-      expect(innerSVG(context.dragGroup.childNodes[2])).to.equal(innerSVG(timerStartEventGfx));
+      expectVisuals(context.dragGroup.childNodes[0], messageStartEventGfx);
+      expectVisuals(context.dragGroup.childNodes[1], startEventGfx);
+      expectVisuals(context.dragGroup.childNodes[2], timerStartEventGfx);
     })
   );
 
@@ -341,4 +345,32 @@ function skipCI(userAgent) {
   }
 
   return true;
+}
+
+
+/**
+ * Returns the inner markup of an element's visual, ignoring accompanying
+ * graphics such as the interaction hit box or the (lazily created,
+ * selection-only) outline that are not part of the rendered visual.
+ *
+ * @param {SVGElement} gfx
+ *
+ * @return {string}
+ */
+function getVisualInnerSVG(gfx) {
+  return innerSVG(domQuery('.djs-visual', gfx));
+}
+
+/**
+ * Expect that the two elements are visually "equal".
+ *
+ * @param {SVGElement} element
+ * @param {SVGElement} expectedElement
+ */
+function expectVisuals(element, expectedElement) {
+  expect(
+    getVisualInnerSVG(element)
+  ).to.eql(
+    getVisualInnerSVG(expectedElement)
+  );
 }


### PR DESCRIPTION
### Proposed Changes

Test previously asserted full element instead of just the visuals. This change makes the test more robust - do not assert non-visuals (and assuming internals of whoever plugs in).

Background: Lazy outline rendering (https://github.com/bpmn-io/diagram-js/pull/1064) would otherwise break the tests - unnecessarily.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
