### PR TITLE
Make label bound spec more robust

### DIFF
--- a/test/spec/features/modeling/LabelBoundsSpec.js
+++ b/test/spec/features/modeling/LabelBoundsSpec.js
@@ -59,6 +59,11 @@ describe('label bounds', function() {
       });
     }
 
+    function ensureOutline(element) {
+      return getBpmnJS().invoke(function(selection) {
+        selection.select(element);
+      });
+    }
 
 
     describe('label position', function() {
@@ -125,7 +130,10 @@ describe('label bounds', function() {
           // given
           var shape = elementRegistry.get('StartEvent_1');
 
-          var outlineSpy = sinon.spy(outline, 'updateShapeOutline');
+          // ensure label has outline to update
+          ensureOutline(shape.label);
+
+          var updateOutlineSpy = sinon.spy(outline, 'updateShapeOutline');
           var rendererSpy = sinon.spy(bpmnRenderer, 'drawShape');
 
           // when
@@ -136,7 +144,7 @@ describe('label bounds', function() {
           // updated the elements bounds dimensions and position
           sinon.assert.callOrder(
             rendererSpy.withArgs(sinon.match.any, shape.label),
-            outlineSpy.withArgs(sinon.match.any, shape.label)
+            updateOutlineSpy.withArgs(sinon.match.any, shape.label)
           );
         })
 

--- a/test/spec/features/modeling/LabelBoundsSpec.js
+++ b/test/spec/features/modeling/LabelBoundsSpec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   bootstrapModeler,
+  getBpmnJS,
   inject
 } from 'test/TestHelper';
 
@@ -49,17 +50,15 @@ describe('label bounds', function() {
 
     beforeEach(bootstrapModeler(diagramXML));
 
-    var updateLabel;
 
-    beforeEach(inject(function(directEditing) {
-
-      updateLabel = function(shape, text) {
-        directEditing.activate(shape);
+    function updateLabel(element, text) {
+      return getBpmnJS().invoke(function(directEditing) {
+        directEditing.activate(element);
         directEditing._textbox.content.innerText = text;
         directEditing.complete();
-      };
+      });
+    }
 
-    }));
 
 
     describe('label position', function() {


### PR DESCRIPTION
### Proposed Changes

Don't rely on internals - ensure the element is actually focused, so outline is guaranteed there. It would otherwise break with https://github.com/bpmn-io/diagram-js/pull/1064.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
