### PR TITLE
Add huge-diagram performance benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: disallow `move` when dropped outside of canvas ([#2437](https://github.com/bpmn-io/bpmn-js/pull/2437), [#2210](https://github.com/bpmn-io/bpmn-js/issues/2210))
 * `CHORE`: derive label link offset from (circular) outline shape ([#2457](https://github.com/bpmn-io/bpmn-js/pull/2457))
+* `DEPS`: update to `diagram-js@15.18.1`
 
 ## 18.19.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.18.0",
+        "diagram-js": "^15.18.1",
         "diagram-js-direct-editing": "^3.4.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -4219,9 +4219,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.18.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.18.0.tgz",
-      "integrity": "sha512-aOVeXrjQc1ki0jlrSuwXDoye5nKO6uAtXCtmgQopUvF/aC9aJwoaBOsNvQ2Na9GmMc6X2b3xAefhRChvGgcbgQ==",
+      "version": "15.18.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.18.1.tgz",
+      "integrity": "sha512-tQZEB2PcB5GaD+5EFc9/LnsNqoGEf5QUjluS4mb5rr/ayWva92l7EUCHq9YxpJu65r+D10Zg2NU6axN8begplg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.18.0",
+    "diagram-js": "^15.18.1",
     "diagram-js-direct-editing": "^3.4.0",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start:navigated-viewer": "cross-env SINGLE_START=navigated-viewer npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
     "test": "karma start test/config/karma.unit.js",
+    "benchmark": "karma start test/config/karma.benchmark.js",
     "distro": "node tasks/build-distro.mjs",
     "collect-translations": "cross-env COLLECT_TRANSLATIONS=1 npm test",
     "generate-types": "run-s generate-types:*",

--- a/test/benchmark/generate-diagram.js
+++ b/test/benchmark/generate-diagram.js
@@ -1,0 +1,203 @@
+/**
+ * Generate a large, realistic BPMN process for benchmarking.
+ *
+ * The process models a long end-to-end flow, decomposed into a number of
+ * expanded sub-processes ("phases"). Each phase contains a grid of tasks
+ * wired into a linear chain via sequence flows, framed by a start and end
+ * event. The phases themselves are chained on the top level.
+ *
+ * This yields realistic nesting (plane -> sub-process -> task), a high edge
+ * density and thousands of elements - exactly the shape that stresses the
+ * diagram-js code paths optimized in bpmn-io/diagram-js#1064:
+ *
+ *  - import / rendering (GraphicsFactory ordering, deferred outline)
+ *  - copy (createTree, getParents, hasRelations)
+ *  - move preview (edge resolution, dragger layout)
+ *
+ * @param {Object} [options]
+ * @param {number} [options.tasksPerPhase=100]
+ * @param {number} [options.phases=20]
+ * @param {number} [options.columns=10] tasks per row inside a phase
+ *
+ * @return {{ xml: string, stats: Object }}
+ */
+export function generateDiagram(options = {}) {
+
+  const tasksPerPhase = options.tasksPerPhase || 100;
+  const phases = options.phases || 20;
+  const columns = options.columns || 10;
+
+  const TASK_W = 100;
+  const TASK_H = 80;
+  const COL_GAP = 60;
+  const ROW_GAP = 40;
+  const EVENT_SIZE = 36;
+
+  const cellW = TASK_W + COL_GAP;
+  const cellH = TASK_H + ROW_GAP;
+
+  const rowsPerPhase = Math.ceil(tasksPerPhase / columns);
+
+  // inner padding of a sub-process frame
+  const PAD_LEFT = 120; // room for phase start event
+  const PAD_RIGHT = 120; // room for phase end event
+  const PAD_TOP = 60;
+  const PAD_BOTTOM = 60;
+
+  const phaseW = PAD_LEFT + columns * cellW + PAD_RIGHT;
+  const phaseH = PAD_TOP + rowsPerPhase * cellH + PAD_BOTTOM;
+
+  const PHASE_GAP = 120;
+
+  const process = [];
+  const shapesDi = [];
+  const edgesDi = [];
+
+  let flowSeq = 0;
+  let shapeCount = 0;
+  let connectionCount = 0;
+
+  function shape(di) {
+    shapesDi.push(di);
+    shapeCount++;
+  }
+
+  function edge(id, source, target, waypoints) {
+    process.push(
+      `<bpmn:sequenceFlow id="${id}" sourceRef="${source}" targetRef="${target}" />`
+    );
+    const wp = waypoints
+      .map((p) => `<di:waypoint x="${p.x}" y="${p.y}" />`)
+      .join('');
+    edgesDi.push(
+      `<bpmndi:BPMNEdge id="${id}_di" bpmnElement="${id}">${wp}</bpmndi:BPMNEdge>`
+    );
+    connectionCount++;
+  }
+
+  const phaseIds = [];
+
+  for (let p = 0; p < phases; p++) {
+
+    const phaseX = 100 + p * (phaseW + PHASE_GAP);
+    const phaseY = 100;
+
+    const spId = `Phase_${p}`;
+    phaseIds.push(spId);
+
+    // collect children markup for this sub-process
+    const children = [];
+
+    const startId = `${spId}_start`;
+    const endId = `${spId}_end`;
+
+    const startX = phaseX + 40;
+    const startY = phaseY + phaseH / 2 - EVENT_SIZE / 2;
+
+    const endX = phaseX + phaseW - 40 - EVENT_SIZE;
+    const endY = startY;
+
+    children.push(`<bpmn:startEvent id="${startId}" />`);
+    shape(
+      `<bpmndi:BPMNShape id="${startId}_di" bpmnElement="${startId}"><dc:Bounds x="${startX}" y="${startY}" width="${EVENT_SIZE}" height="${EVENT_SIZE}" /></bpmndi:BPMNShape>`
+    );
+
+    const taskPos = [];
+
+    for (let t = 0; t < tasksPerPhase; t++) {
+      const id = `${spId}_task_${t}`;
+      const col = t % columns;
+      const row = Math.floor(t / columns);
+
+      const x = phaseX + PAD_LEFT + col * cellW;
+      const y = phaseY + PAD_TOP + row * cellH;
+
+      taskPos.push({ id, x, y });
+
+      children.push(
+        `<bpmn:task id="${id}" name="Task ${p}.${t}" />`
+      );
+      shape(
+        `<bpmndi:BPMNShape id="${id}_di" bpmnElement="${id}"><dc:Bounds x="${x}" y="${y}" width="${TASK_W}" height="${TASK_H}" /></bpmndi:BPMNShape>`
+      );
+    }
+
+    // wire: start -> task0 -> task1 -> ... -> end
+    // (flows live in the sub-process, so push them into children)
+    function innerEdge(id, source, target, waypoints) {
+      children.push(
+        `<bpmn:sequenceFlow id="${id}" sourceRef="${source}" targetRef="${target}" />`
+      );
+      const wp = waypoints
+        .map((p) => `<di:waypoint x="${p.x}" y="${p.y}" />`)
+        .join('');
+      edgesDi.push(
+        `<bpmndi:BPMNEdge id="${id}_di" bpmnElement="${id}">${wp}</bpmndi:BPMNEdge>`
+      );
+      connectionCount++;
+    }
+
+    let prevId = startId;
+    let prevOut = { x: startX + EVENT_SIZE, y: startY + EVENT_SIZE / 2 };
+
+    for (let t = 0; t < tasksPerPhase; t++) {
+      const task = taskPos[t];
+      const inPt = { x: task.x, y: task.y + TASK_H / 2 };
+      innerEdge(`flow_${flowSeq++}`, prevId, task.id, [ prevOut, inPt ]);
+      prevId = task.id;
+      prevOut = { x: task.x + TASK_W, y: task.y + TASK_H / 2 };
+    }
+
+    children.push(`<bpmn:endEvent id="${endId}" />`);
+    shape(
+      `<bpmndi:BPMNShape id="${endId}_di" bpmnElement="${endId}"><dc:Bounds x="${endX}" y="${endY}" width="${EVENT_SIZE}" height="${EVENT_SIZE}" /></bpmndi:BPMNShape>`
+    );
+    innerEdge(`flow_${flowSeq++}`, prevId, endId, [
+      prevOut,
+      { x: endX, y: endY + EVENT_SIZE / 2 }
+    ]);
+
+    // the expanded sub-process itself
+    process.push(
+      `<bpmn:subProcess id="${spId}" name="Phase ${p}">${children.join('')}</bpmn:subProcess>`
+    );
+    shape(
+      `<bpmndi:BPMNShape id="${spId}_di" bpmnElement="${spId}" isExpanded="true"><dc:Bounds x="${phaseX}" y="${phaseY}" width="${phaseW}" height="${phaseH}" /></bpmndi:BPMNShape>`
+    );
+  }
+
+  // chain the phases on the top level
+  for (let p = 0; p < phases - 1; p++) {
+    const sourceX = 100 + p * (phaseW + PHASE_GAP) + phaseW;
+    const targetX = 100 + (p + 1) * (phaseW + PHASE_GAP);
+    const midY = 100 + phaseH / 2;
+    edge(`top_flow_${p}`, phaseIds[p], phaseIds[p + 1], [
+      { x: sourceX, y: midY },
+      { x: targetX, y: midY }
+    ]);
+  }
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_huge" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_huge" isExecutable="false">
+    ${process.join('\n    ')}
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_huge">
+      ${shapesDi.join('\n      ')}
+      ${edgesDi.join('\n      ')}
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+  return {
+    xml,
+    stats: {
+      phases,
+      tasksPerPhase,
+      shapes: shapeCount,
+      connections: connectionCount,
+      total: shapeCount + connectionCount
+    }
+  };
+}

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -16,6 +16,7 @@ insertCSS('bpmn-font', bpmnFontCSS);
 
 
 const SIZES = [
+  { label: 'XS', phases: 2, tasksPerPhase: 10 }, // ~50 elements
   { label: 'S', phases: 10, tasksPerPhase: 50 }, // ~1k elements
   { label: 'M', phases: 20, tasksPerPhase: 100 }, // ~4k elements
   { label: 'L', phases: 20, tasksPerPhase: 200 } // ~8k elements

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -97,6 +97,33 @@ describe('benchmark/huge-diagram', function() {
       });
 
 
+      it('space tool preview', function() {
+        const spaceTool = modeler.get('spaceTool');
+        const dragging = modeler.get('dragging');
+        const canvas = modeler.get('canvas');
+
+        const root = canvas.getRootElement();
+
+        dragging.setOptions({ manual: true });
+
+        const ms = time(() => {
+          spaceTool.activateMakeSpace(canvasEvent(modeler, { x: 200, y: 200 }));
+
+          dragging.hover({
+            element: root,
+            gfx: canvas.getGraphics(root)
+          });
+
+          // triggers space tool init (selfAndAllChildren + adjustment calculation)
+          dragging.move(canvasEvent(modeler, { x: 260, y: 200 }));
+        });
+
+        dragging.cancel();
+
+        record('space preview', size, stats, ms);
+      });
+
+
       after(function() {
         modeler && modeler.destroy();
         container && container.remove();

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -67,6 +67,52 @@ describe('benchmark/huge-diagram', function() {
       });
 
 
+      it('select all', function() {
+        const selection = modeler.get('selection');
+
+        // given no selection
+        selection.select(null);
+
+        // when selecting all elements
+        const ms = time(() => selection.select(elements));
+
+        record('select all', size, stats, ms);
+      });
+
+
+      it('reselect all', function() {
+        const selection = modeler.get('selection');
+
+        // given the full selection is active
+        selection.select(elements);
+
+        // when re-applying the same selection the `selection.changed`
+        // diff dominates -- the pre-Set implementation scanned the
+        // old/new selection linearly (O(n^2)) in both Selection and
+        // SelectionVisuals, with no actual marker changes to do
+        const ms = time(() => selection.select(elements.slice()));
+
+        record('reselect all', size, stats, ms);
+      });
+
+
+      it('isSelected', function() {
+        const selection = modeler.get('selection');
+
+        // given the full selection is active
+        selection.select(elements);
+
+        // when probing membership for every element
+        const ms = time(() => {
+          for (let i = 0; i < elements.length; i++) {
+            selection.isSelected(elements[i]);
+          }
+        });
+
+        record('isSelected', size, stats, ms);
+      });
+
+
       it('move preview', function() {
         const move = modeler.get('move');
         const dragging = modeler.get('dragging');

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -170,6 +170,24 @@ describe('benchmark/huge-diagram', function() {
       });
 
 
+      it('move commit', function() {
+        const modeling = modeler.get('modeling');
+
+        const shapes = elements.filter(e => !e.waypoints);
+
+        // when committing a move of the whole diagram
+        //
+        // AttachSupport's `postExecuted('elements.move')` filters the moved
+        // shapes for attachers moved without their host. This exercises the
+        // guarded membership check (`isAttacher(shape) && !includes(...)`) --
+        // included so we can detect trade-offs (e.g. an unconditional `Set`
+        // allocation regressing the common, attacher-free case) early.
+        const ms = time(() => modeling.moveElements(shapes, { x: 20, y: 20 }));
+
+        record('move commit', size, stats, ms);
+      });
+
+
       after(function() {
         modeler && modeler.destroy();
         container && container.remove();

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -188,6 +188,29 @@ describe('benchmark/huge-diagram', function() {
       });
 
 
+      it('paste', function() {
+        const copyPaste = modeler.get('copyPaste');
+        const canvas = modeler.get('canvas');
+
+        const root = canvas.getRootElement();
+
+        copyPaste.copy(elements);
+
+        // when pasting the whole diagram
+        //
+        // CreateElementsHandler resolves `getParents(elements)` and then, for
+        // every created element, probes membership to decide whether to
+        // auto-resize -- O(n * parents), quadratic when many top-level
+        // elements are pasted.
+        const ms = time(() => copyPaste.paste({
+          element: root,
+          point: { x: 3000, y: 3000 }
+        }));
+
+        record('paste', size, stats, ms);
+      });
+
+
       after(function() {
         modeler && modeler.destroy();
         container && container.remove();

--- a/test/benchmark/huge-diagram.js
+++ b/test/benchmark/huge-diagram.js
@@ -1,0 +1,176 @@
+import Modeler from '../../lib/Modeler';
+
+import { getParents } from 'diagram-js/lib/util/Elements';
+
+import { generateDiagram } from './generate-diagram';
+
+import diagramCSS from 'diagram-js/assets/diagram-js.css';
+import bpmnCSS from '../../assets/bpmn-js.css';
+import bpmnFontCSS from 'bpmn-font/dist/css/bpmn-embedded.css';
+
+
+// styles are needed so elements are laid out and rendered realistically
+insertCSS('diagram-js', diagramCSS);
+insertCSS('bpmn-js', bpmnCSS);
+insertCSS('bpmn-font', bpmnFontCSS);
+
+
+const SIZES = [
+  { label: 'S', phases: 10, tasksPerPhase: 50 }, // ~1k elements
+  { label: 'M', phases: 20, tasksPerPhase: 100 }, // ~4k elements
+  { label: 'L', phases: 20, tasksPerPhase: 200 } // ~8k elements
+];
+
+const results = [];
+
+
+describe('benchmark/huge-diagram', function() {
+
+  // huge diagrams -> be generous
+  this.timeout(600000);
+
+  SIZES.forEach(function(size) {
+
+    describe('size ' + size.label, function() {
+
+      const { xml, stats } = generateDiagram(size);
+
+      let modeler, elements, container;
+
+      before(async function() {
+        container = createContainer();
+        modeler = new Modeler({ container });
+
+        const ms = await time(() => modeler.importXML(xml));
+
+        elements = modeler.get('elementRegistry').getAll().filter(e => e.parent);
+
+        record('import', size, stats, ms);
+      });
+
+
+      it('getParents', function() {
+        const ms = time(() => getParents(elements));
+
+        record('getParents', size, stats, ms);
+      });
+
+
+      it('copy', function() {
+        const copyPaste = modeler.get('copyPaste');
+
+        modeler.get('selection').select(elements);
+
+        const ms = time(() => copyPaste.copy(elements));
+
+        record('copy', size, stats, ms);
+      });
+
+
+      it('move preview', function() {
+        const move = modeler.get('move');
+        const dragging = modeler.get('dragging');
+        const elementRegistry = modeler.get('elementRegistry');
+
+        const shapes = elements.filter(e => !e.waypoints);
+        const shape = elementRegistry.get('Phase_0');
+
+        modeler.get('selection').select(shapes);
+
+        dragging.setOptions({ manual: true });
+
+        const ms = time(() => {
+          move.start(canvasEvent(modeler, { x: 200, y: 200 }), shape);
+
+          dragging.hover({
+            element: shape.parent,
+            gfx: elementRegistry.getGraphics(shape.parent)
+          });
+
+          // triggers preview setup (dragger creation + edge resolution)
+          dragging.move(canvasEvent(modeler, { x: 260, y: 260 }));
+        });
+
+        dragging.cancel();
+
+        record('move preview', size, stats, ms);
+      });
+
+
+      after(function() {
+        modeler && modeler.destroy();
+        container && container.remove();
+      });
+
+    });
+
+  });
+
+
+  after(printResults);
+
+});
+
+
+// helpers ///////////////////////////////////////////////
+
+function time(fn) {
+  const start = performance.now();
+  const result = fn();
+
+  if (result && typeof result.then === 'function') {
+    return result.then(() => performance.now() - start);
+  }
+
+  return performance.now() - start;
+}
+
+function record(op, size, stats, ms) {
+  results.push({ op, size: size.label, elements: stats.total, ms });
+}
+
+function createContainer() {
+  const container = document.createElement('div');
+
+  container.style.cssText = 'position:absolute;left:-10000px;width:1000px;height:700px';
+  document.body.appendChild(container);
+
+  return container;
+}
+
+function canvasEvent(modeler, position) {
+  const canvas = modeler.get('canvas');
+  const rect = canvas._container.getBoundingClientRect();
+
+  return modeler.get('eventBus').createEvent({
+    target: canvas._svg,
+    x: position.x + rect.left,
+    y: position.y + rect.top,
+    clientX: position.x + rect.left,
+    clientY: position.y + rect.top,
+    button: 0
+  });
+}
+
+function insertCSS(name, css) {
+  const style = document.createElement('style');
+
+  style.setAttribute('data-css', name);
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+function printResults() {
+  const rows = results.map(r =>
+    r.op.padEnd(14) +
+    r.size.padEnd(3) +
+    String(r.elements).padStart(6) + ' elements' +
+    r.ms.toFixed(1).padStart(10) + 'ms'
+  );
+
+  console.log(
+    '\n\n===== huge-diagram benchmark =====\n' +
+    rows.join('\n') +
+    '\n==================================\n'
+  );
+}

--- a/test/config/karma.benchmark.js
+++ b/test/config/karma.benchmark.js
@@ -1,0 +1,73 @@
+var path = require('path');
+
+var basePath = '../..';
+
+var absoluteBasePath = path.resolve(path.join(__dirname, basePath));
+
+var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(',');
+
+var suite = 'test/benchmark/huge-diagram.js';
+
+
+module.exports = function(karma) {
+  karma.set({
+
+    basePath,
+
+    frameworks: [
+      'mocha',
+      'webpack'
+    ],
+
+    files: [
+      suite
+    ],
+
+    preprocessors: {
+      [ suite ]: [ 'webpack' ]
+    },
+
+    reporters: [ 'tldr' ],
+
+    browsers,
+
+    // benchmark operations block the browser's main thread for
+    // seconds at a time (large synchronous copy / move preview), so
+    // give karma generous tolerances before it considers the browser
+    // unresponsive
+    browserNoActivityTimeout: 600000,
+    browserDisconnectTimeout: 600000,
+    pingTimeout: 600000,
+
+    singleRun: true,
+    autoWatch: false,
+
+    webpack: {
+      mode: 'development',
+      module: {
+        rules: [
+          {
+            test: /test[\\/]benchmark[\\/]/,
+            sideEffects: true
+          },
+          {
+            test: /\.css$/,
+            type: 'asset/source'
+          }
+        ]
+      },
+      resolve: {
+        mainFields: [
+          'dev:module',
+          'module',
+          'main'
+        ],
+        modules: [
+          'node_modules',
+          absoluteBasePath
+        ]
+      },
+      devtool: 'eval-source-map'
+    }
+  });
+};

--- a/test/config/karma.unit.js
+++ b/test/config/karma.unit.js
@@ -58,7 +58,7 @@ module.exports = function(karma) {
       ]
     },
 
-    envPreProcessor: [
+    envPreprocessor: [
       'CI'
     ],
 


### PR DESCRIPTION

This adds a standalone benchmark that exercises the diagram-js code paths optimized in [bpmn-io/diagram-js#1064](https://github.com/bpmn-io/diagram-js/pull/1064) and related fixes - against realistic, large BPMN diagrams — so we can validate and quantify the impact of those changes from the bpmn-js side.

## What's included

* **`test/benchmark/generate-diagram.js`** — generates a realistic huge process: expanded sub-process "phases" chained on the top level, each holding a grid of tasks wired into a sequence-flow chain (realistic nesting `plane → sub-process → task`, high edge density).
* **`test/benchmark/huge-diagram.js`** — measures user-facing operations across diagram sizes (~49 / 1k / 4k / 8k elements): **import**, **getParents**, **copy**, **select all**, **reselect all**, **isSelected**, **move preview**, **space preview**, **move commit**, **paste**.
* **`test/config/karma.benchmark.js`** — dedicated karma config; run via `npm run benchmark`.
* **`chore(test)`** — fixed a latent `envPreProcessor` → `envPreprocessor` typo so the `CI` variable is actually published to `window.__env__`.

## Run it

```sh
npm run benchmark
```

## Results

Headless Chromium, single run per configuration (absolute numbers are noisy, ratios are the signal).
**before** = diagram-js `v15.18.1` (`8eeca306`) · **after** = combined perf branch (bpmn-io/diagram-js#1064 + related fixes, all changes stacked).

Speedup by operation and diagram size:

| operation      | XS (49) | S (1 049) | M (4 099) | L (8 099) |
| -------------- | ------: | --------: | --------: | --------: |
| import         |  ~1×    |   1.1×    |   1.1×    |   1.0×    |
| getParents     |  ~1×    |   140×    |   313×    | **863×**  |
| copy           |  ~1×    |   2.0×    |   4.3×    | **7.4×**  |
| select all     |  ~1×    |   2.3×    |   2.7×    | **3.2×**  |
| reselect all   |  ~1×    |   8.6×    |    23×    | **55×**   |
| move preview   |  ~1×    |   2.0×    |   2.9×    | **4.3×**  |
| space preview  |  ~1×    |   2.7×    |   5.2×    | **9.4×**  |
| move commit    |  ~1×    |   1.1×    |   1.3×    |   1.5×    |
| paste          |  ~1×    |   1.1×    |   1.1×    |   1.1×    |

Selected absolute numbers on the large diagram (L, 8 099 elements):

| operation      | before (ms) | after (ms) |
| -------------- | ----------: | ---------: |
| getParents     |      1517.0 |        1.7 |
| copy           |      6709.5 |      900.7 |
| space preview  |     19212.7 |     2052.3 |
| move preview   |      7194.0 |     1654.3 |

### Reading the numbers

* **Speedups grow with diagram size** — the signature of removing quadratic behaviour. `getParents` was O(n²), now O(n) (**1.5 s → 1.7 ms** at L); `copy` **6.7 s → 0.9 s** (7.4×); `space preview` **19.2 s → 2.1 s** (9.4×); `move preview` **7.2 s → 1.7 s** (4.3×).
* **Set-based selection** removes the O(n²) blow-up in `select all` (3.2×) and `reselect all` (55× at L).
* **Small diagrams are unaffected — and there is no regression.** At XS (49 elements) every operation runs in under ~40 ms both before and after (e.g. `space preview` 19.7 → 11.6 ms, `import` 42.4 → 27.1 ms, `paste` 23.1 → 23.8 ms); the differences are within single-run noise. The `Set` construction the optimizations introduce adds no measurable overhead at small scale — the wins only materialise as diagrams grow.
* **import** and **paste** are largely unchanged (~1.1×) — they're dominated by moddle parsing / SVG creation and command-stack work that these changes don't target.

## Related

* bpmn-io/diagram-js#1064
* bpmn-io/diagram-js#1066
* bpmn-io/diagram-js#1065
* bpmn-io/diagram-js#1063
* bpmn-io/diagram-js#1062
* bpmn-io/diagram-js#1067
* bpmn-io/diagram-js#1068
* bpmn-io/diagram-js#1069
* bpmn-io/diagram-js#1070
* bpmn-io/diagram-js#1071

---

> [!NOTE]
> Benchmarks were run with the combined diagram-js perf branch checked out locally (linked). The "before" column was captured by temporarily checking out `v15.18.1` in the linked diagram-js.
