### PR TITLE
Make `label-link` use native `Selection#isSelected` API

### DIFF
--- a/lib/features/label-link/LabelLink.js
+++ b/lib/features/label-link/LabelLink.js
@@ -59,9 +59,9 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
     if (allowedElements.length === 1) {
       const element = allowedElements[0];
       if (isLabel(element)) {
-        createLink(element, element.labelTarget, newSelection);
+        createLink(element, element.labelTarget);
       } else if (element.labels?.length) {
-        createLink(element.labels[0], element, newSelection);
+        createLink(element.labels[0], element);
       }
     }
 
@@ -70,7 +70,7 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
       const label = allowedElements.find(isLabel);
       const target = allowedElements.find(el => el.labels?.includes(label));
       if (label && target) {
-        createLink(label, target, newSelection);
+        createLink(label, target);
       }
     }
   });
@@ -82,9 +82,9 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
     }
 
     if (isLabel(element)) {
-      createLink(element, element.labelTarget, selection.get());
+      createLink(element, element.labelTarget);
     } else if (element.labels?.length) {
-      createLink(element.labels[0], element, selection.get());
+      createLink(element.labels[0], element);
     }
   });
 
@@ -93,9 +93,8 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
    *
    * @param {Element} label
    * @param {Element} target
-   * @param {Element[]} selection
    */
-  function createLink(label, target, selection = []) {
+  function createLink(label, target) {
 
     // Create an auxiliary line between label and target mid points
     const line = createLine(
@@ -105,7 +104,7 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
     const linePath = line.getAttribute('d');
 
     // Calculate the intersection point between line and label
-    const labelSelected = selection.includes(label);
+    const labelSelected = selection.isSelected(label);
     const labelPath = labelSelected ? getElementOutlinePath(label) : getElementPath(label);
     const labelInter = getElementLineIntersection(labelPath, linePath);
 
@@ -117,7 +116,7 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
     // Calculate the intersection point between line and label
     // If the target is a sequence flow, there is no intersection,
     // so we link to the middle of it.
-    const targetSelected = selection.includes(target);
+    const targetSelected = selection.isSelected(target);
     const targetPath = targetSelected ? getElementOutlinePath(target) : getElementPath(target);
     const targetInter = getElementLineIntersection(targetPath, linePath) || getMid(target);
 
@@ -182,7 +181,7 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
   }
 
   function isElementSelected(element) {
-    return selection.get().includes(element);
+    return selection.isSelected(element);
   }
 }
 


### PR DESCRIPTION
### Proposed Changes

`label-link` now uses native `Selection#isSelected` API for check - prevent re-implementation of a feature offered "out of the box".

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
