### PR TITLE
feat(popup-menu): add shared popup entries list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add shared popup entries list ([#2463](https://github.com/bpmn-io/bpmn-js/pull/2463))
+* `FEAT`: make replace menu width configurable via css variable ([#2463](https://github.com/bpmn-io/bpmn-js/pull/2463))
 * `FEAT`: complete direct editing on blur ([bpmn-io/diagram-js-direct-editing#74](https://github.com/bpmn-io/diagram-js-direct-editing/pull/74), [#2327](https://github.com/bpmn-io/bpmn-js/issues/2327), [#2464](https://github.com/bpmn-io/bpmn-js/pull/2464))
 * `FEAT`: restore canvas focus in next render cycle ([bpmn-io/diagram-js#1081](https://github.com/bpmn-io/diagram-js/pull/1081))
 * `FEAT`: use auto width with max value of 300px for popup menu ([bpmn-io/diagram-js#1078](https://github.com/bpmn-io/diagram-js/pull/1078))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: restore canvas focus in next render cycle ([bpmn-io/diagram-js#1081](https://github.com/bpmn-io/diagram-js/pull/1081))
 * `FEAT`: use auto width with max value of 300px for popup menu ([bpmn-io/diagram-js#1078](https://github.com/bpmn-io/diagram-js/pull/1078))
 * `DEPS`: update to `min-dash@5.1.0`
-* `DEPS`: update to `diagram-js@15.22.0`
+* `DEPS`: update to `diagram-js@15.23.0`
 * `DEPS`: update to `diagram-js-direct-editing@3.5.1`
 
 ## 18.21.0

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -466,7 +466,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
             popupMenu.open(element, 'bpmn-replace', position, {
               title: translate('Change element'),
-              width: 300,
+              width: 'var(--bpmn-replace-popup-width, 300px)',
               search: true
             });
           }

--- a/lib/features/popup-menu/PopupEntries.js
+++ b/lib/features/popup-menu/PopupEntries.js
@@ -1,0 +1,627 @@
+/**
+ * Shared catalog of BPMN element popup entry definitions.
+ *
+ * Each entry is the context-independent identity of an element — its `target`
+ * (moddle type + discriminating attributes), plus the `label` and `className`
+ * shared across every menu that offers it (create, append, replace).
+ *
+ * Menus compose their own option lists from these atoms, adding menu-specific fields
+ *
+ * @typedef { {
+ *   label: string;
+ *   className: string;
+ *   target: {
+ *     type: string;
+ *     isExpanded?: boolean;
+ *     triggeredByEvent?: boolean;
+ *     instantiate?: boolean;
+ *     eventGatewayType?: string;
+ *     isInterrupting?: boolean;
+ *     cancelActivity?: boolean;
+ *     eventDefinitionType?: string;
+ *     eventDefinitionAttrs?: Record<string, any>;
+ *   };
+ * } } ElementDefinition
+ *
+ * @type {Record<string, ElementDefinition>}
+ */
+export const PopupEntries = {
+
+  // Tasks
+  'task': {
+    label: 'Task',
+    className: 'bpmn-icon-task',
+    target: {
+      type: 'bpmn:Task'
+    }
+  },
+  'user-task': {
+    label: 'User task',
+    className: 'bpmn-icon-user',
+    target: {
+      type: 'bpmn:UserTask'
+    }
+  },
+  'service-task': {
+    label: 'Service task',
+    className: 'bpmn-icon-service',
+    target: {
+      type: 'bpmn:ServiceTask'
+    }
+  },
+  'send-task': {
+    label: 'Send task',
+    className: 'bpmn-icon-send',
+    target: {
+      type: 'bpmn:SendTask'
+    }
+  },
+  'receive-task': {
+    label: 'Receive task',
+    className: 'bpmn-icon-receive',
+    target: {
+      type: 'bpmn:ReceiveTask'
+    }
+  },
+  'manual-task': {
+    label: 'Manual task',
+    className: 'bpmn-icon-manual',
+    target: {
+      type: 'bpmn:ManualTask'
+    }
+  },
+  'rule-task': {
+    label: 'Business rule task',
+    className: 'bpmn-icon-business-rule',
+    target: {
+      type: 'bpmn:BusinessRuleTask'
+    }
+  },
+  'script-task': {
+    label: 'Script task',
+    className: 'bpmn-icon-script',
+    target: {
+      type: 'bpmn:ScriptTask'
+    }
+  },
+
+  // Sub-processes
+  'call-activity': {
+    label: 'Call activity',
+    className: 'bpmn-icon-call-activity',
+    target: {
+      type: 'bpmn:CallActivity'
+    }
+  },
+  'transaction': {
+    label: 'Transaction',
+    className: 'bpmn-icon-transaction',
+    target: {
+      type: 'bpmn:Transaction',
+      isExpanded: true
+    }
+  },
+  'event-subprocess': {
+    label: 'Event sub-process',
+    className: 'bpmn-icon-event-subprocess-expanded',
+    target: {
+      type: 'bpmn:SubProcess',
+      triggeredByEvent: true,
+      isExpanded: true
+    }
+  },
+  'collapsed-subprocess': {
+    label: 'Sub-process (collapsed)',
+    className: 'bpmn-icon-subprocess-collapsed',
+    target: {
+      type: 'bpmn:SubProcess',
+      isExpanded: false
+    }
+  },
+  'expanded-subprocess': {
+    label: 'Sub-process (expanded)',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:SubProcess',
+      isExpanded: true
+    }
+  },
+  'collapsed-ad-hoc-subprocess': {
+    label: 'Ad-hoc sub-process (collapsed)',
+    className: 'bpmn-icon-subprocess-collapsed',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
+      isExpanded: false
+    }
+  },
+  'expanded-ad-hoc-subprocess': {
+    label: 'Ad-hoc sub-process (expanded)',
+    className: 'bpmn-icon-subprocess-expanded',
+    target: {
+      type: 'bpmn:AdHocSubProcess',
+      isExpanded: true
+    }
+  },
+
+  // Gateways
+  'exclusive-gateway': {
+    label: 'Exclusive gateway',
+    className: 'bpmn-icon-gateway-xor',
+    target: {
+      type: 'bpmn:ExclusiveGateway'
+    }
+  },
+  'parallel-gateway': {
+    label: 'Parallel gateway',
+    className: 'bpmn-icon-gateway-parallel',
+    target: {
+      type: 'bpmn:ParallelGateway'
+    }
+  },
+  'inclusive-gateway': {
+    label: 'Inclusive gateway',
+    className: 'bpmn-icon-gateway-or',
+    target: {
+      type: 'bpmn:InclusiveGateway'
+    }
+  },
+  'complex-gateway': {
+    label: 'Complex gateway',
+    className: 'bpmn-icon-gateway-complex',
+    target: {
+      type: 'bpmn:ComplexGateway'
+    }
+  },
+  'event-based-gateway': {
+    label: 'Event-based gateway',
+    className: 'bpmn-icon-gateway-eventbased',
+    target: {
+      type: 'bpmn:EventBasedGateway',
+      instantiate: false,
+      eventGatewayType: 'Exclusive'
+    }
+  },
+
+  // Data
+  'data-store-reference': {
+    label: 'Data store reference',
+    className: 'bpmn-icon-data-store',
+    target: {
+      type: 'bpmn:DataStoreReference'
+    }
+  },
+  'data-object-reference': {
+    label: 'Data object reference',
+    className: 'bpmn-icon-data-object',
+    target: {
+      type: 'bpmn:DataObjectReference'
+    }
+  },
+
+  // Participants
+  'expanded-pool': {
+    label: 'Expanded pool/participant',
+    className: 'bpmn-icon-participant',
+    target: {
+      type: 'bpmn:Participant',
+      isExpanded: true
+    }
+  },
+  'collapsed-pool': {
+    label: 'Empty pool/participant',
+    className: 'bpmn-icon-lane',
+    target: {
+      type: 'bpmn:Participant',
+      isExpanded: false
+    }
+  },
+
+  // Events — none
+  'none-start-event': {
+    label: 'Start event',
+    className: 'bpmn-icon-start-event-none',
+    target: {
+      type: 'bpmn:StartEvent'
+    }
+  },
+  'none-intermediate-throwing': {
+    label: 'Intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-none',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent'
+    }
+  },
+  'none-boundary-event': {
+    label: 'Boundary event',
+    className: 'bpmn-icon-intermediate-event-none',
+    target: {
+      type: 'bpmn:BoundaryEvent'
+    }
+  },
+  'none-end-event': {
+    label: 'End event',
+    className: 'bpmn-icon-end-event-none',
+    target: {
+      type: 'bpmn:EndEvent'
+    }
+  },
+
+  // Events — typed start
+  'message-start': {
+    label: 'Message start event',
+    className: 'bpmn-icon-start-event-message',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'timer-start': {
+    label: 'Timer start event',
+    className: 'bpmn-icon-start-event-timer',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'conditional-start': {
+    label: 'Conditional start event',
+    className: 'bpmn-icon-start-event-condition',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'signal-start': {
+    label: 'Signal start event',
+    className: 'bpmn-icon-start-event-signal',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'error-start': {
+    label: 'Error start event',
+    className: 'bpmn-icon-start-event-error',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:ErrorEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'escalation-start': {
+    label: 'Escalation start event',
+    className: 'bpmn-icon-start-event-escalation',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      isInterrupting: true
+    }
+  },
+  'compensation-start': {
+    label: 'Compensation start event',
+    className: 'bpmn-icon-start-event-compensation',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:CompensateEventDefinition',
+      isInterrupting: true
+    }
+  },
+
+  // Events — non-interrupting start (event subprocess)
+  'non-interrupting-message-start': {
+    label: 'Message start event (non-interrupting)',
+    className: 'bpmn-icon-start-event-non-interrupting-message',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      isInterrupting: false
+    }
+  },
+  'non-interrupting-timer-start': {
+    label: 'Timer start event (non-interrupting)',
+    className: 'bpmn-icon-start-event-non-interrupting-timer',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      isInterrupting: false
+    }
+  },
+  'non-interrupting-conditional-start': {
+    label: 'Conditional start event (non-interrupting)',
+    className: 'bpmn-icon-start-event-non-interrupting-condition',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      isInterrupting: false
+    }
+  },
+  'non-interrupting-signal-start': {
+    label: 'Signal start event (non-interrupting)',
+    className: 'bpmn-icon-start-event-non-interrupting-signal',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      isInterrupting: false
+    }
+  },
+  'non-interrupting-escalation-start': {
+    label: 'Escalation start event (non-interrupting)',
+    className: 'bpmn-icon-start-event-non-interrupting-escalation',
+    target: {
+      type: 'bpmn:StartEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      isInterrupting: false
+    }
+  },
+
+  // Events — intermediate (catch/throw)
+  'message-intermediate-catch': {
+    label: 'Message intermediate catch event',
+    className: 'bpmn-icon-intermediate-event-catch-message',
+    target: {
+      type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition'
+    }
+  },
+  'message-intermediate-throw': {
+    label: 'Message intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-throw-message',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition'
+    }
+  },
+  'timer-intermediate-catch': {
+    label: 'Timer intermediate catch event',
+    className: 'bpmn-icon-intermediate-event-catch-timer',
+    target: {
+      type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition'
+    }
+  },
+  'escalation-intermediate-throw': {
+    label: 'Escalation intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-throw-escalation',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition'
+    }
+  },
+  'conditional-intermediate-catch': {
+    label: 'Conditional intermediate catch event',
+    className: 'bpmn-icon-intermediate-event-catch-condition',
+    target: {
+      type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
+    }
+  },
+  'link-intermediate-catch': {
+    label: 'Link intermediate catch event',
+    className: 'bpmn-icon-intermediate-event-catch-link',
+    target: {
+      type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitionType: 'bpmn:LinkEventDefinition',
+      eventDefinitionAttrs: {
+        name: ''
+      }
+    }
+  },
+  'link-intermediate-throw': {
+    label: 'Link intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-throw-link',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent',
+      eventDefinitionType: 'bpmn:LinkEventDefinition',
+      eventDefinitionAttrs: {
+        name: ''
+      }
+    }
+  },
+  'compensation-intermediate-throw': {
+    label: 'Compensation intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-throw-compensation',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent',
+      eventDefinitionType: 'bpmn:CompensateEventDefinition'
+    }
+  },
+  'signal-intermediate-catch': {
+    label: 'Signal intermediate catch event',
+    className: 'bpmn-icon-intermediate-event-catch-signal',
+    target: {
+      type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition'
+    }
+  },
+  'signal-intermediate-throw': {
+    label: 'Signal intermediate throw event',
+    className: 'bpmn-icon-intermediate-event-throw-signal',
+    target: {
+      type: 'bpmn:IntermediateThrowEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition'
+    }
+  },
+
+  // Events — boundary (interrupting)
+  'message-boundary': {
+    label: 'Message boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-message',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'timer-boundary': {
+    label: 'Timer boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-timer',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'escalation-boundary': {
+    label: 'Escalation boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-escalation',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'conditional-boundary': {
+    label: 'Conditional boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-condition',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'error-boundary': {
+    label: 'Error boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-error',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:ErrorEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'cancel-boundary': {
+    label: 'Cancel boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-cancel',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:CancelEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'signal-boundary': {
+    label: 'Signal boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-signal',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      cancelActivity: true
+    }
+  },
+  'compensation-boundary': {
+    label: 'Compensation boundary event',
+    className: 'bpmn-icon-intermediate-event-catch-compensation',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:CompensateEventDefinition',
+      cancelActivity: true
+    }
+  },
+
+  // Events — boundary (non-interrupting)
+  'non-interrupting-message-boundary': {
+    label: 'Message boundary event (non-interrupting)',
+    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-message',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition',
+      cancelActivity: false
+    }
+  },
+  'non-interrupting-timer-boundary': {
+    label: 'Timer boundary event (non-interrupting)',
+    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-timer',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:TimerEventDefinition',
+      cancelActivity: false
+    }
+  },
+  'non-interrupting-escalation-boundary': {
+    label: 'Escalation boundary event (non-interrupting)',
+    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-escalation',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition',
+      cancelActivity: false
+    }
+  },
+  'non-interrupting-conditional-boundary': {
+    label: 'Conditional boundary event (non-interrupting)',
+    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-condition',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
+      cancelActivity: false
+    }
+  },
+  'non-interrupting-signal-boundary': {
+    label: 'Signal boundary event (non-interrupting)',
+    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-signal',
+    target: {
+      type: 'bpmn:BoundaryEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition',
+      cancelActivity: false
+    }
+  },
+
+  // Events — typed end
+  'message-end': {
+    label: 'Message end event',
+    className: 'bpmn-icon-end-event-message',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:MessageEventDefinition'
+    }
+  },
+  'escalation-end': {
+    label: 'Escalation end event',
+    className: 'bpmn-icon-end-event-escalation',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:EscalationEventDefinition'
+    }
+  },
+  'error-end': {
+    label: 'Error end event',
+    className: 'bpmn-icon-end-event-error',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:ErrorEventDefinition'
+    }
+  },
+  'cancel-end': {
+    label: 'Cancel end event',
+    className: 'bpmn-icon-end-event-cancel',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:CancelEventDefinition'
+    }
+  },
+  'compensation-end': {
+    label: 'Compensation end event',
+    className: 'bpmn-icon-end-event-compensation',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:CompensateEventDefinition'
+    }
+  },
+  'signal-end': {
+    label: 'Signal end event',
+    className: 'bpmn-icon-end-event-signal',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:SignalEventDefinition'
+    }
+  },
+  'terminate-end': {
+    label: 'Terminate end event',
+    className: 'bpmn-icon-end-event-terminate',
+    target: {
+      type: 'bpmn:EndEvent',
+      eventDefinitionType: 'bpmn:TerminateEventDefinition'
+    }
+  }
+};

--- a/lib/features/popup-menu/index.js
+++ b/lib/features/popup-menu/index.js
@@ -4,6 +4,8 @@ import ReplaceModule from '../replace';
 import ReplaceMenuProvider from './ReplaceMenuProvider';
 import AutoPlaceModule from '../auto-place';
 
+export { PopupEntries } from './PopupEntries';
+
 export default {
   __depends__: [
     PopupMenuModule,

--- a/lib/features/replace/ReplaceOptions.js
+++ b/lib/features/replace/ReplaceOptions.js
@@ -17,367 +17,97 @@
  * } } ReplaceOption
  */
 
+import { PopupEntries } from '../popup-menu/PopupEntries';
+
+/**
+ * Build a replace option from the shared `PopupEntries` catalog. The `actionName`
+ * defaults to `replace-with-<id>`.
+ *
+ * @param {string} id popup entry id
+ * @param {Object} [extra] fields to override or add (e.g. `actionName`, `label`)
+ *
+ * @return {ReplaceOption}
+ */
+function replaceWith(id, extra = {}) {
+  var entry = PopupEntries[id];
+
+  if (!entry) {
+    throw new Error('unknown popup entry <' + id + '>');
+  }
+
+  return {
+    ...entry,
+    actionName: 'replace-with-' + id,
+    ...extra
+  };
+}
+
 /**
  * @type {ReplaceOption[]}
  */
 export var START_EVENT = [
-  {
-    label: 'Start event',
-    actionName: 'replace-with-none-start',
-    className: 'bpmn-icon-start-event-none',
-    target: {
-      type: 'bpmn:StartEvent'
-    }
-  },
-  {
-    label: 'Intermediate throw event',
-    actionName: 'replace-with-none-intermediate-throwing',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent'
-    }
-  },
-  {
-    label: 'End event',
-    actionName: 'replace-with-none-end',
-    className: 'bpmn-icon-end-event-none',
-    target: {
-      type: 'bpmn:EndEvent'
-    }
-  },
-  {
-    label: 'Message start event',
-    actionName: 'replace-with-message-start',
-    className: 'bpmn-icon-start-event-message',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Timer start event',
-    actionName: 'replace-with-timer-start',
-    className: 'bpmn-icon-start-event-timer',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
-    }
-  },
-  {
-    label: 'Conditional start event',
-    actionName: 'replace-with-conditional-start',
-    className: 'bpmn-icon-start-event-condition',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-    }
-  },
-  {
-    label: 'Signal start event',
-    actionName: 'replace-with-signal-start',
-    className: 'bpmn-icon-start-event-signal',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  }
+  replaceWith('none-start-event', { actionName: 'replace-with-none-start' }),
+  replaceWith('none-intermediate-throwing'),
+  replaceWith('none-end-event', { actionName: 'replace-with-none-end' }),
+  replaceWith('message-start'),
+  replaceWith('timer-start'),
+  replaceWith('conditional-start'),
+  replaceWith('signal-start')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var START_EVENT_SUB_PROCESS = [
-  {
-    label: 'Start event',
-    actionName: 'replace-with-none-start',
-    className: 'bpmn-icon-start-event-none',
-    target: {
-      type: 'bpmn:StartEvent'
-    }
-  },
-  {
-    label: 'Intermediate throw event',
-    actionName: 'replace-with-none-intermediate-throwing',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent'
-    }
-  },
-  {
-    label: 'End event',
-    actionName: 'replace-with-none-end',
-    className: 'bpmn-icon-end-event-none',
-    target: {
-      type: 'bpmn:EndEvent'
-    }
-  }
+  replaceWith('none-start-event', { actionName: 'replace-with-none-start' }),
+  replaceWith('none-intermediate-throwing'),
+  replaceWith('none-end-event', { actionName: 'replace-with-none-end' })
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var INTERMEDIATE_EVENT = [
-  {
-    label: 'Start event',
-    actionName: 'replace-with-none-start',
-    className: 'bpmn-icon-start-event-none',
-    target: {
-      type: 'bpmn:StartEvent'
-    }
-  },
-  {
-    label: 'Intermediate throw event',
-    actionName: 'replace-with-none-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent'
-    }
-  },
-  {
-    label: 'End event',
-    actionName: 'replace-with-none-end',
-    className: 'bpmn-icon-end-event-none',
-    target: {
-      type: 'bpmn:EndEvent'
-    }
-  },
-  {
-    label: 'Message intermediate catch event',
-    actionName: 'replace-with-message-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-message',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Message intermediate throw event',
-    actionName: 'replace-with-message-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-message',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Timer intermediate catch event',
-    actionName: 'replace-with-timer-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-timer',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition'
-    }
-  },
-  {
-    label: 'Escalation intermediate throw event',
-    actionName: 'replace-with-escalation-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-escalation',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
-    }
-  },
-  {
-    label: 'Conditional intermediate catch event',
-    actionName: 'replace-with-conditional-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-condition',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-    }
-  },
-  {
-    label: 'Link intermediate catch event',
-    actionName: 'replace-with-link-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-link',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:LinkEventDefinition',
-      eventDefinitionAttrs: {
-        name: ''
-      }
-    }
-  },
-  {
-    label: 'Link intermediate throw event',
-    actionName: 'replace-with-link-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-link',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:LinkEventDefinition',
-      eventDefinitionAttrs: {
-        name: ''
-      }
-    }
-  },
-  {
-    label: 'Compensation intermediate throw event',
-    actionName: 'replace-with-compensation-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-compensation',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
-    }
-  },
-  {
-    label: 'Signal intermediate catch event',
-    actionName: 'replace-with-signal-intermediate-catch',
-    className: 'bpmn-icon-intermediate-event-catch-signal',
-    target: {
-      type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  },
-  {
-    label: 'Signal intermediate throw event',
-    actionName: 'replace-with-signal-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-throw-signal',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  }
+  replaceWith('none-start-event', { actionName: 'replace-with-none-start' }),
+  replaceWith('none-intermediate-throwing', { actionName: 'replace-with-none-intermediate-throw' }),
+  replaceWith('none-end-event', { actionName: 'replace-with-none-end' }),
+  replaceWith('message-intermediate-catch'),
+  replaceWith('message-intermediate-throw'),
+  replaceWith('timer-intermediate-catch'),
+  replaceWith('escalation-intermediate-throw'),
+  replaceWith('conditional-intermediate-catch'),
+  replaceWith('link-intermediate-catch'),
+  replaceWith('link-intermediate-throw'),
+  replaceWith('compensation-intermediate-throw'),
+  replaceWith('signal-intermediate-catch'),
+  replaceWith('signal-intermediate-throw')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var END_EVENT = [
-  {
-    label: 'Start event',
-    actionName: 'replace-with-none-start',
-    className: 'bpmn-icon-start-event-none',
-    target: {
-      type: 'bpmn:StartEvent'
-    }
-  },
-  {
-    label: 'Intermediate throw event',
-    actionName: 'replace-with-none-intermediate-throw',
-    className: 'bpmn-icon-intermediate-event-none',
-    target: {
-      type: 'bpmn:IntermediateThrowEvent'
-    }
-  },
-  {
-    label: 'End event',
-    actionName: 'replace-with-none-end',
-    className: 'bpmn-icon-end-event-none',
-    target: {
-      type: 'bpmn:EndEvent'
-    }
-  },
-  {
-    label: 'Message end event',
-    actionName: 'replace-with-message-end',
-    className: 'bpmn-icon-end-event-message',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition'
-    }
-  },
-  {
-    label: 'Escalation end event',
-    actionName: 'replace-with-escalation-end',
-    className: 'bpmn-icon-end-event-escalation',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition'
-    }
-  },
-  {
-    label: 'Error end event',
-    actionName: 'replace-with-error-end',
-    className: 'bpmn-icon-end-event-error',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition'
-    }
-  },
-  {
-    label: 'Cancel end event',
-    actionName: 'replace-with-cancel-end',
-    className: 'bpmn-icon-end-event-cancel',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:CancelEventDefinition'
-    }
-  },
-  {
-    label: 'Compensation end event',
-    actionName: 'replace-with-compensation-end',
-    className: 'bpmn-icon-end-event-compensation',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition'
-    }
-  },
-  {
-    label: 'Signal end event',
-    actionName: 'replace-with-signal-end',
-    className: 'bpmn-icon-end-event-signal',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition'
-    }
-  },
-  {
-    label: 'Terminate end event',
-    actionName: 'replace-with-terminate-end',
-    className: 'bpmn-icon-end-event-terminate',
-    target: {
-      type: 'bpmn:EndEvent',
-      eventDefinitionType: 'bpmn:TerminateEventDefinition'
-    }
-  }
+  replaceWith('none-start-event', { actionName: 'replace-with-none-start' }),
+  replaceWith('none-intermediate-throwing', { actionName: 'replace-with-none-intermediate-throw' }),
+  replaceWith('none-end-event', { actionName: 'replace-with-none-end' }),
+  replaceWith('message-end'),
+  replaceWith('escalation-end'),
+  replaceWith('error-end'),
+  replaceWith('cancel-end'),
+  replaceWith('compensation-end'),
+  replaceWith('signal-end'),
+  replaceWith('terminate-end')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var GATEWAY = [
-  {
-    label: 'Exclusive gateway',
-    actionName: 'replace-with-exclusive-gateway',
-    className: 'bpmn-icon-gateway-xor',
-    target: {
-      type: 'bpmn:ExclusiveGateway'
-    }
-  },
-  {
-    label: 'Parallel gateway',
-    actionName: 'replace-with-parallel-gateway',
-    className: 'bpmn-icon-gateway-parallel',
-    target: {
-      type: 'bpmn:ParallelGateway'
-    }
-  },
-  {
-    label: 'Inclusive gateway',
-    actionName: 'replace-with-inclusive-gateway',
-    className: 'bpmn-icon-gateway-or',
-    target: {
-      type: 'bpmn:InclusiveGateway'
-    }
-  },
-  {
-    label: 'Complex gateway',
-    actionName: 'replace-with-complex-gateway',
-    className: 'bpmn-icon-gateway-complex',
-    target: {
-      type: 'bpmn:ComplexGateway'
-    }
-  },
-  {
-    label: 'Event-based gateway',
-    actionName: 'replace-with-event-based-gateway',
-    className: 'bpmn-icon-gateway-eventbased',
-    target: {
-      type: 'bpmn:EventBasedGateway',
-      instantiate: false,
-      eventGatewayType: 'Exclusive'
-    }
-  }
+  replaceWith('exclusive-gateway'),
+  replaceWith('parallel-gateway'),
+  replaceWith('inclusive-gateway'),
+  replaceWith('complex-gateway'),
+  replaceWith('event-based-gateway')
 
   // Gateways deactivated until https://github.com/bpmn-io/bpmn-js/issues/194
   // {
@@ -408,129 +138,30 @@ export var GATEWAY = [
  * @type {ReplaceOption[]}
  */
 export var SUBPROCESS_EXPANDED = [
-  {
-    label: 'Transaction',
-    actionName: 'replace-with-transaction',
-    className: 'bpmn-icon-transaction',
-    target: {
-      type: 'bpmn:Transaction',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Event sub-process',
-    actionName: 'replace-with-event-subprocess',
-    className: 'bpmn-icon-event-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      triggeredByEvent: true,
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process',
-    actionName: 'replace-with-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Sub-process (collapsed)',
-    actionName: 'replace-with-collapsed-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: false
-    }
-  }
+  replaceWith('transaction'),
+  replaceWith('event-subprocess'),
+  replaceWith('expanded-ad-hoc-subprocess', { actionName: 'replace-with-ad-hoc-subprocess', label: 'Ad-hoc sub-process' }),
+  replaceWith('collapsed-subprocess')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var AD_HOC_SUBPROCESS_EXPANDED = [
-  {
-    label: 'Sub-process',
-    actionName: 'replace-with-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Transaction',
-    actionName: 'replace-with-transaction',
-    className: 'bpmn-icon-transaction',
-    target: {
-      type: 'bpmn:Transaction',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Event sub-process',
-    actionName: 'replace-with-event-subprocess',
-    className: 'bpmn-icon-event-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      triggeredByEvent: true,
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process (collapsed)',
-    actionName: 'replace-with-collapsed-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: false
-    }
-  }
+  replaceWith('expanded-subprocess', { actionName: 'replace-with-subprocess', label: 'Sub-process' }),
+  replaceWith('transaction'),
+  replaceWith('event-subprocess'),
+  replaceWith('collapsed-ad-hoc-subprocess')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var TRANSACTION = [
-  {
-    label: 'Transaction',
-    actionName: 'replace-with-transaction',
-    className: 'bpmn-icon-transaction',
-    target: {
-      type: 'bpmn:Transaction',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Sub-process',
-    actionName: 'replace-with-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process',
-    actionName: 'replace-with-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Event sub-process',
-    actionName: 'replace-with-event-subprocess',
-    className: 'bpmn-icon-event-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      triggeredByEvent: true,
-      isExpanded: true
-    }
-  }
+  replaceWith('transaction'),
+  replaceWith('expanded-subprocess', { actionName: 'replace-with-subprocess', label: 'Sub-process' }),
+  replaceWith('expanded-ad-hoc-subprocess', { actionName: 'replace-with-ad-hoc-subprocess', label: 'Ad-hoc sub-process' }),
+  replaceWith('event-subprocess')
 ];
 
 /**
@@ -542,404 +173,70 @@ export var EVENT_SUB_PROCESS = TRANSACTION;
  * @type {ReplaceOption[]}
  */
 export var TASK = [
-  {
-    label: 'Task',
-    actionName: 'replace-with-task',
-    className: 'bpmn-icon-task',
-    target: {
-      type: 'bpmn:Task'
-    }
-  },
-  {
-    label: 'User task',
-    actionName: 'replace-with-user-task',
-    className: 'bpmn-icon-user',
-    target: {
-      type: 'bpmn:UserTask'
-    }
-  },
-  {
-    label: 'Service task',
-    actionName: 'replace-with-service-task',
-    className: 'bpmn-icon-service',
-    target: {
-      type: 'bpmn:ServiceTask'
-    }
-  },
-  {
-    label: 'Send task',
-    actionName: 'replace-with-send-task',
-    className: 'bpmn-icon-send',
-    target: {
-      type: 'bpmn:SendTask'
-    }
-  },
-  {
-    label: 'Receive task',
-    actionName: 'replace-with-receive-task',
-    className: 'bpmn-icon-receive',
-    target: {
-      type: 'bpmn:ReceiveTask'
-    }
-  },
-  {
-    label: 'Manual task',
-    actionName: 'replace-with-manual-task',
-    className: 'bpmn-icon-manual',
-    target: {
-      type: 'bpmn:ManualTask'
-    }
-  },
-  {
-    label: 'Business rule task',
-    actionName: 'replace-with-rule-task',
-    className: 'bpmn-icon-business-rule',
-    target: {
-      type: 'bpmn:BusinessRuleTask'
-    }
-  },
-  {
-    label: 'Script task',
-    actionName: 'replace-with-script-task',
-    className: 'bpmn-icon-script',
-    target: {
-      type: 'bpmn:ScriptTask'
-    }
-  },
-  {
-    label: 'Call activity',
-    actionName: 'replace-with-call-activity',
-    className: 'bpmn-icon-call-activity',
-    target: {
-      type: 'bpmn:CallActivity'
-    }
-  },
-  {
-    label: 'Sub-process (collapsed)',
-    actionName: 'replace-with-collapsed-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: false
-    }
-  },
-  {
-    label: 'Sub-process (expanded)',
-    actionName: 'replace-with-expanded-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:SubProcess',
-      isExpanded: true
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process (collapsed)',
-    actionName: 'replace-with-collapsed-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-collapsed',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: false
-    }
-  },
-  {
-    label: 'Ad-hoc sub-process (expanded)',
-    actionName: 'replace-with-ad-hoc-subprocess',
-    className: 'bpmn-icon-subprocess-expanded',
-    target: {
-      type: 'bpmn:AdHocSubProcess',
-      isExpanded: true
-    }
-  }
+  replaceWith('task'),
+  replaceWith('user-task'),
+  replaceWith('service-task'),
+  replaceWith('send-task'),
+  replaceWith('receive-task'),
+  replaceWith('manual-task'),
+  replaceWith('rule-task'),
+  replaceWith('script-task'),
+  replaceWith('call-activity'),
+  replaceWith('collapsed-subprocess'),
+  replaceWith('expanded-subprocess'),
+  replaceWith('collapsed-ad-hoc-subprocess'),
+  replaceWith('expanded-ad-hoc-subprocess', { actionName: 'replace-with-ad-hoc-subprocess' })
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var DATA_OBJECT_REFERENCE = [
-  {
-    label: 'Data store reference',
-    actionName: 'replace-with-data-store-reference',
-    className: 'bpmn-icon-data-store',
-    target: {
-      type: 'bpmn:DataStoreReference'
-    }
-  }
+  replaceWith('data-store-reference')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var DATA_STORE_REFERENCE = [
-  {
-    label: 'Data object reference',
-    actionName: 'replace-with-data-object-reference',
-    className: 'bpmn-icon-data-object',
-    target: {
-      type: 'bpmn:DataObjectReference'
-    }
-  }
+  replaceWith('data-object-reference')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var BOUNDARY_EVENT = [
-  {
-    label: 'Message boundary event',
-    actionName: 'replace-with-message-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-message',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Timer boundary event',
-    actionName: 'replace-with-timer-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-timer',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Escalation boundary event',
-    actionName: 'replace-with-escalation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-escalation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Conditional boundary event',
-    actionName: 'replace-with-conditional-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-condition',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Error boundary event',
-    actionName: 'replace-with-error-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-error',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Cancel boundary event',
-    actionName: 'replace-with-cancel-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-cancel',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CancelEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Signal boundary event',
-    actionName: 'replace-with-signal-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-signal',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Compensation boundary event',
-    actionName: 'replace-with-compensation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-compensation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition',
-      cancelActivity: true
-    }
-  },
-  {
-    label: 'Message boundary event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-message-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-message',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Timer boundary event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-timer-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-timer',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Escalation boundary event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-escalation-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-escalation',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Conditional boundary event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-conditional-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-condition',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      cancelActivity: false
-    }
-  },
-  {
-    label: 'Signal boundary event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-signal-boundary',
-    className: 'bpmn-icon-intermediate-event-catch-non-interrupting-signal',
-    target: {
-      type: 'bpmn:BoundaryEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      cancelActivity: false
-    }
-  }
+  replaceWith('message-boundary'),
+  replaceWith('timer-boundary'),
+  replaceWith('escalation-boundary'),
+  replaceWith('conditional-boundary'),
+  replaceWith('error-boundary'),
+  replaceWith('cancel-boundary'),
+  replaceWith('signal-boundary'),
+  replaceWith('compensation-boundary'),
+  replaceWith('non-interrupting-message-boundary'),
+  replaceWith('non-interrupting-timer-boundary'),
+  replaceWith('non-interrupting-escalation-boundary'),
+  replaceWith('non-interrupting-conditional-boundary'),
+  replaceWith('non-interrupting-signal-boundary')
 ];
 
 /**
  * @type {ReplaceOption[]}
  */
 export var EVENT_SUB_PROCESS_START_EVENT = [
-  {
-    label: 'Message start event',
-    actionName: 'replace-with-message-start',
-    className: 'bpmn-icon-start-event-message',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Timer start event',
-    actionName: 'replace-with-timer-start',
-    className: 'bpmn-icon-start-event-timer',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Conditional start event',
-    actionName: 'replace-with-conditional-start',
-    className: 'bpmn-icon-start-event-condition',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Signal start event',
-    actionName: 'replace-with-signal-start',
-    className: 'bpmn-icon-start-event-signal',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Error start event',
-    actionName: 'replace-with-error-start',
-    className: 'bpmn-icon-start-event-error',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ErrorEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Escalation start event',
-    actionName: 'replace-with-escalation-start',
-    className: 'bpmn-icon-start-event-escalation',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Compensation start event',
-    actionName: 'replace-with-compensation-start',
-    className: 'bpmn-icon-start-event-compensation',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:CompensateEventDefinition',
-      isInterrupting: true
-    }
-  },
-  {
-    label: 'Message start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-message-start',
-    className: 'bpmn-icon-start-event-non-interrupting-message',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:MessageEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Timer start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-timer-start',
-    className: 'bpmn-icon-start-event-non-interrupting-timer',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:TimerEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Conditional start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-conditional-start',
-    className: 'bpmn-icon-start-event-non-interrupting-condition',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Signal start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-signal-start',
-    className: 'bpmn-icon-start-event-non-interrupting-signal',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:SignalEventDefinition',
-      isInterrupting: false
-    }
-  },
-  {
-    label: 'Escalation start event (non-interrupting)',
-    actionName: 'replace-with-non-interrupting-escalation-start',
-    className: 'bpmn-icon-start-event-non-interrupting-escalation',
-    target: {
-      type: 'bpmn:StartEvent',
-      eventDefinitionType: 'bpmn:EscalationEventDefinition',
-      isInterrupting: false
-    }
-  }
+  replaceWith('message-start'),
+  replaceWith('timer-start'),
+  replaceWith('conditional-start'),
+  replaceWith('signal-start'),
+  replaceWith('error-start'),
+  replaceWith('escalation-start'),
+  replaceWith('compensation-start'),
+  replaceWith('non-interrupting-message-start'),
+  replaceWith('non-interrupting-timer-start'),
+  replaceWith('non-interrupting-conditional-start'),
+  replaceWith('non-interrupting-signal-start'),
+  replaceWith('non-interrupting-escalation-start')
 ];
 
 /**
@@ -967,16 +264,8 @@ export var SEQUENCE_FLOW = [
  * @type {ReplaceOption[]}
  */
 export var PARTICIPANT = [
-  {
-    label: 'Expanded pool/participant',
-    actionName: 'replace-with-expanded-pool',
-    className: 'bpmn-icon-participant',
-    target: {
-      type: 'bpmn:Participant',
-      isExpanded: true
-    }
-  },
-  {
+  replaceWith('expanded-pool'),
+  replaceWith('collapsed-pool', {
     label: function(element) {
       var label = 'Empty pool/participant';
 
@@ -985,16 +274,8 @@ export var PARTICIPANT = [
       }
 
       return label;
-    },
-    actionName: 'replace-with-collapsed-pool',
-
-    // TODO(@janstuemmel): maybe design new icon
-    className: 'bpmn-icon-lane',
-    target: {
-      type: 'bpmn:Participant',
-      isExpanded: false
     }
-  }
+  })
 ];
 
 /**
@@ -1002,204 +283,37 @@ export var PARTICIPANT = [
  */
 export var TYPED_EVENT = {
   'bpmn:MessageEventDefinition': [
-    {
-      label: 'Message start event',
-      actionName: 'replace-with-message-start',
-      className: 'bpmn-icon-start-event-message',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:MessageEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Message intermediate catch event',
-      actionName: 'replace-with-message-intermediate-catch',
-      className: 'bpmn-icon-intermediate-event-catch-message',
-      target: {
-        type: 'bpmn:IntermediateCatchEvent',
-        eventDefinitionType: 'bpmn:MessageEventDefinition'
-      }
-    },
-    {
-      label: 'Message intermediate throw event',
-      actionName: 'replace-with-message-intermediate-throw',
-      className: 'bpmn-icon-intermediate-event-throw-message',
-      target: {
-        type: 'bpmn:IntermediateThrowEvent',
-        eventDefinitionType: 'bpmn:MessageEventDefinition'
-      }
-    },
-    {
-      label: 'Message end event',
-      actionName: 'replace-with-message-end',
-      className: 'bpmn-icon-end-event-message',
-      target: {
-        type: 'bpmn:EndEvent',
-        eventDefinitionType: 'bpmn:MessageEventDefinition'
-      }
-    }
+    replaceWith('message-start'),
+    replaceWith('message-intermediate-catch'),
+    replaceWith('message-intermediate-throw'),
+    replaceWith('message-end')
   ],
   'bpmn:TimerEventDefinition': [
-    {
-      label: 'Timer start event',
-      actionName: 'replace-with-timer-start',
-      className: 'bpmn-icon-start-event-timer',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:TimerEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Timer intermediate catch event',
-      actionName: 'replace-with-timer-intermediate-catch',
-      className: 'bpmn-icon-intermediate-event-catch-timer',
-      target: {
-        type: 'bpmn:IntermediateCatchEvent',
-        eventDefinitionType: 'bpmn:TimerEventDefinition'
-      }
-    }
+    replaceWith('timer-start'),
+    replaceWith('timer-intermediate-catch')
   ],
   'bpmn:ConditionalEventDefinition': [
-    {
-      label: 'Conditional start event',
-      actionName: 'replace-with-conditional-start',
-      className: 'bpmn-icon-start-event-condition',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:ConditionalEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Conditional intermediate catch event',
-      actionName: 'replace-with-conditional-intermediate-catch',
-      className: 'bpmn-icon-intermediate-event-catch-condition',
-      target: {
-        type: 'bpmn:IntermediateCatchEvent',
-        eventDefinitionType: 'bpmn:ConditionalEventDefinition'
-      }
-    }
+    replaceWith('conditional-start'),
+    replaceWith('conditional-intermediate-catch')
   ],
   'bpmn:SignalEventDefinition': [
-    {
-      label: 'Signal start event',
-      actionName: 'replace-with-signal-start',
-      className: 'bpmn-icon-start-event-signal',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:SignalEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Signal intermediate catch event',
-      actionName: 'replace-with-signal-intermediate-catch',
-      className: 'bpmn-icon-intermediate-event-catch-signal',
-      target: {
-        type: 'bpmn:IntermediateCatchEvent',
-        eventDefinitionType: 'bpmn:SignalEventDefinition'
-      }
-    },
-    {
-      label: 'Signal intermediate throw event',
-      actionName: 'replace-with-signal-intermediate-throw',
-      className: 'bpmn-icon-intermediate-event-throw-signal',
-      target: {
-        type: 'bpmn:IntermediateThrowEvent',
-        eventDefinitionType: 'bpmn:SignalEventDefinition'
-      }
-    },
-    {
-      label: 'Signal end event',
-      actionName: 'replace-with-signal-end',
-      className: 'bpmn-icon-end-event-signal',
-      target: {
-        type: 'bpmn:EndEvent',
-        eventDefinitionType: 'bpmn:SignalEventDefinition'
-      }
-    }
+    replaceWith('signal-start'),
+    replaceWith('signal-intermediate-catch'),
+    replaceWith('signal-intermediate-throw'),
+    replaceWith('signal-end')
   ],
   'bpmn:ErrorEventDefinition': [
-    {
-      label: 'Error start event',
-      actionName: 'replace-with-error-start',
-      className: 'bpmn-icon-start-event-error',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:ErrorEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Error end event',
-      actionName: 'replace-with-error-end',
-      className: 'bpmn-icon-end-event-error',
-      target: {
-        type: 'bpmn:EndEvent',
-        eventDefinitionType: 'bpmn:ErrorEventDefinition'
-      }
-    }
+    replaceWith('error-start'),
+    replaceWith('error-end')
   ],
   'bpmn:EscalationEventDefinition': [
-    {
-      label: 'Escalation start event',
-      actionName: 'replace-with-escalation-start',
-      className: 'bpmn-icon-start-event-escalation',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:EscalationEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Escalation intermediate throw event',
-      actionName: 'replace-with-escalation-intermediate-throw',
-      className: 'bpmn-icon-intermediate-event-throw-escalation',
-      target: {
-        type: 'bpmn:IntermediateThrowEvent',
-        eventDefinitionType: 'bpmn:EscalationEventDefinition'
-      }
-    },
-    {
-      label: 'Escalation end event',
-      actionName: 'replace-with-escalation-end',
-      className: 'bpmn-icon-end-event-escalation',
-      target: {
-        type: 'bpmn:EndEvent',
-        eventDefinitionType: 'bpmn:EscalationEventDefinition'
-      }
-    }
+    replaceWith('escalation-start'),
+    replaceWith('escalation-intermediate-throw'),
+    replaceWith('escalation-end')
   ],
   'bpmn:CompensateEventDefinition': [
-    {
-      label: 'Compensation start event',
-      actionName: 'replace-with-compensation-start',
-      className: 'bpmn-icon-start-event-compensation',
-      target: {
-        type: 'bpmn:StartEvent',
-        eventDefinitionType: 'bpmn:CompensateEventDefinition',
-        isInterrupting: true
-      }
-    },
-    {
-      label: 'Compensation intermediate throw event',
-      actionName: 'replace-with-compensation-intermediate-throw',
-      className: 'bpmn-icon-intermediate-event-throw-compensation',
-      target: {
-        type: 'bpmn:IntermediateThrowEvent',
-        eventDefinitionType: 'bpmn:CompensateEventDefinition'
-      }
-    },
-    {
-      label: 'Compensation end event',
-      actionName: 'replace-with-compensation-end',
-      className: 'bpmn-icon-end-event-compensation',
-      target: {
-        type: 'bpmn:EndEvent',
-        eventDefinitionType: 'bpmn:CompensateEventDefinition'
-      }
-    }
+    replaceWith('compensation-start'),
+    replaceWith('compensation-intermediate-throw'),
+    replaceWith('compensation-end')
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.22.0",
+        "diagram-js": "^15.23.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3927,9 +3927,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.22.0.tgz",
-      "integrity": "sha512-xcX1e4lmRCrpwlnNqNHVqY8Xp4i70tXUZwO39IzRJsXWq6F+/osNs4biehnb5ZlHIzjZcEHWzOx/vlIui4qS8w==",
+      "version": "15.23.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.0.tgz",
+      "integrity": "sha512-cCgL+4Ep0xrLe6TtdvRVgo6bWYjUbrQg+ES/9rpltqmTD2YaPoC+NYcRsKYw/fDO+1RN0q16NzErP1svVZhNQg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.22.0",
+    "diagram-js": "^15.23.0",
     "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",

--- a/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -561,6 +561,21 @@ describe('features - context-pad', function() {
     }));
 
 
+    it('should open popup menu with default width', inject(function(elementRegistry, contextPad) {
+
+      // given
+      var element = elementRegistry.get('StartEvent_1');
+
+      contextPad.open(element);
+
+      // when
+      contextPad.trigger('click', padEvent('replace'));
+
+      // then
+      expect(getComputedStyle(getPopupMenu()).width).to.eql('300px');
+    }));
+
+
     it('should hide wrench if replacement is disallowed', inject(
       function(elementRegistry, contextPad, customRules) {
 

--- a/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
+++ b/test/spec/features/popup-menu/ReplaceMenuProviderSpec.js
@@ -50,6 +50,44 @@ describe('features/popup-menu - replace menu provider', function() {
   ];
 
 
+  describe('element descriptions', function() {
+
+    beforeEach(bootstrapModeler(diagramXMLReplace, { modules: testModules }));
+
+
+    it('should render a provided description', inject(function(elementRegistry, popupMenu) {
+
+      // given
+      var startEvent = elementRegistry.get('StartEvent_1');
+      popupMenu.registerProvider('bpmn-replace', {
+        getPopupMenuEntries() {
+          return function(entries) {
+            return {
+              ...entries,
+              'replace-with-message-start': {
+                ...entries['replace-with-message-start'],
+                description: 'foo'
+              }
+            };
+          };
+        }
+      });
+
+      // when
+      openPopup(startEvent);
+
+      // then
+      var description = domQuery(
+        '.djs-popup-entry-description',
+        queryEntry('replace-with-message-start')
+      );
+
+      expect(description).to.exist;
+      expect(description.textContent).to.eql('foo');
+    }));
+  });
+
+
   describe('data object - collection marker', function() {
 
     beforeEach(bootstrapModeler(diagramXMLDataElements, { modules: testModules }));


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/6037

### Proposed Changes

Adds `PopupEntries` — a shared source of BPMN element popup entry definitions (label, icon, target) exported from the module to be than reused in create/append/replace menus

Also make Replace menu width configurable via css variable to than make it wider to "360px" for better fit the descriptions(introduced in https://github.com/camunda/camunda-bpmn-js/pull/485) for most of elements.

Prerequisite for reusing the same definitions in the create/append menus — see https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/88 for the full context.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
