### PR TITLE
Auto complete direct editing on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: restore canvas focus in next render cycle ([bpmn-io/diagram-js#1081](https://github.com/bpmn-io/diagram-js/pull/1081))
+* `FEAT`: use auto width with max value of 300px for popup menu ([bpmn-io/diagram-js#1078](https://github.com/bpmn-io/diagram-js/pull/1078))
+* `DEPS`: update to `min-dash@5.1.0`
+* `DEPS`: update to `diagram-js@15.22.0`
+
 ## 18.21.0
 
 * `FEAT`: improve aural interface / accessibility of popup menu ([bpmn-io/diagram-js#1059](https://github.com/bpmn-io/diagram-js/pull/1059), [bpmn-io/diagram-js#735](https://github.com/bpmn-io/diagram-js/issues/735))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: complete direct editing on blur ([bpmn-io/diagram-js-direct-editing#74](https://github.com/bpmn-io/diagram-js-direct-editing/pull/74), [#2327](https://github.com/bpmn-io/bpmn-js/issues/2327), [#2464](https://github.com/bpmn-io/bpmn-js/pull/2464))
 * `FEAT`: restore canvas focus in next render cycle ([bpmn-io/diagram-js#1081](https://github.com/bpmn-io/diagram-js/pull/1081))
 * `FEAT`: use auto width with max value of 300px for popup menu ([bpmn-io/diagram-js#1078](https://github.com/bpmn-io/diagram-js/pull/1078))
 * `DEPS`: update to `min-dash@5.1.0`
 * `DEPS`: update to `diagram-js@15.22.0`
+* `DEPS`: update to `diagram-js-direct-editing@3.5.1`
 
 ## 18.21.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "diagram-js-direct-editing": "^3.4.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
@@ -8606,9 +8606,10 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
+      "license": "MIT"
     },
     "node_modules/min-dom": {
       "version": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
         "diagram-js": "^15.22.0",
-        "diagram-js-direct-editing": "^3.4.0",
+        "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.1.0",
@@ -3947,13 +3947,13 @@
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.4.0.tgz",
-      "integrity": "sha512-eXfd+nxJr5xt3YlCrs+E53mPi+gqBWRBkAXkR99ZPL7Pl0B3H5nkv/uiwx4Q4vJU/Sp8Jy3zVdhP/Y2c6loTjw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.1.tgz",
+      "integrity": "sha512-fEQCQ/x5oKVV0m7Nmgv7i85Vhw+kJkKNXF8zcV5Vm0KwF8x/8e3Ax0aJgdXt8/fDPymEkY8HmZweXIipCeeh+g==",
       "license": "MIT",
       "dependencies": {
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0"
       },
       "engines": {
         "node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.20.0",
+        "diagram-js": "^15.22.0",
         "diagram-js-direct-editing": "^3.4.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3927,16 +3927,16 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.20.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.20.0.tgz",
-      "integrity": "sha512-35BxXuzXZm8WSRwtqvWnxmhe0oqtAKHN+i5jK9b1DKo9Ha3CzEsE1r2d9EGfU8zZDrkn++Q1nxSTHRsMEnbpWA==",
+      "version": "15.22.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.22.0.tgz",
+      "integrity": "sha512-xcX1e4lmRCrpwlnNqNHVqY8Xp4i70tXUZwO39IzRJsXWq6F+/osNs4biehnb5ZlHIzjZcEHWzOx/vlIui4qS8w==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
     "diagram-js": "^15.22.0",
-    "diagram-js-direct-editing": "^3.4.0",
+    "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "diagram-js-direct-editing": "^3.4.0",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",
-    "min-dash": "^5.0.0",
+    "min-dash": "^5.1.0",
     "min-dom": "^5.3.0",
     "tiny-svg": "^4.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.20.0",
+    "diagram-js": "^15.22.0",
     "diagram-js-direct-editing": "^3.4.0",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",


### PR DESCRIPTION
### Proposed Changes

Trigger auto complete of direct editing on edit box blur - follows existing convention ("auto-save") and prevents dangling updates:

<img width="1071" height="789" alt="capture vawJQ4_optimized" src="https://github.com/user-attachments/assets/0a505020-2c64-4471-a656-3f2c4910057a" />

> [!NOTE]
> Heads-up that there is a minimal flicker on completion - this is to be root caused and fixed separately (explicitly out of scope for this PR).

Closes https://github.com/bpmn-io/bpmn-js/issues/2327

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

`sr bpmn-io/bpmn-js#direct-editing-auto-complete`

<!--

Thanks for creating this pull request! ❤️

-->
