### PR TITLE
feat: add tooltips with title + shortcut key for palette entries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add tooltip with title and shortcut on palette entries ([#2465](https://github.com/bpmn-io/bpmn-js/pull/2465))
 * `FIX`: point label link to the closest point of the connection ([#2493](https://github.com/bpmn-io/bpmn-js/pull/2493))
+* `DEPS`: update to `diagram-js@15.26.0`
 
 ## 18.26.0
 

--- a/lib/features/keyboard/BpmnKeyboardBindings.js
+++ b/lib/features/keyboard/BpmnKeyboardBindings.js
@@ -1,5 +1,7 @@
 import inherits from 'inherits-browser';
 
+import { forEach } from 'min-dash';
+
 import KeyboardBindings from 'diagram-js/lib/features/keyboard/KeyboardBindings';
 
 /**
@@ -25,6 +27,24 @@ BpmnKeyboardBindings.$inject = [
 
 
 /**
+ * The keyboard binding for each editor action: the `key` that triggers it,
+ * optionally requiring the `cmd` modifier (CTRL/CMD).
+ *
+ * @type {Record<string, { key: string, modifier?: 'cmd' }>}
+ */
+export var SHORTCUTS_KEY_BINDINGS = {
+  selectElements: { key: 'A', modifier: 'cmd' },
+  find: { key: 'F', modifier: 'cmd' },
+  spaceTool: { key: 'S' },
+  lassoTool: { key: 'L' },
+  handTool: { key: 'H' },
+  globalConnectTool: { key: 'C' },
+  directEditing: { key: 'E' },
+  replaceElement: { key: 'R' }
+};
+
+
+/**
  * Register available keyboard bindings.
  *
  * @param {Keyboard} keyboard
@@ -35,146 +55,35 @@ BpmnKeyboardBindings.prototype.registerBindings = function(keyboard, editorActio
   // inherit default bindings
   KeyboardBindings.prototype.registerBindings.call(this, keyboard, editorActions);
 
-  /**
-   * Add keyboard binding if respective editor action
-   * is registered.
-   *
-   * @param {string} action name
-   * @param {Function} fn that implements the key binding
-   */
-  function addListener(action, fn) {
+  forEach(SHORTCUTS_KEY_BINDINGS, function(binding, action) {
 
-    if (editorActions.isRegistered(action)) {
-      keyboard.addListener(fn);
-    }
-  }
-
-  // select all elements
-  // CTRL + A
-  addListener('selectElements', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.isKey([ 'a', 'A' ], event) && keyboard.isCmd(event)) {
-      editorActions.trigger('selectElements');
-
-      return true;
-    }
-  });
-
-  // search labels
-  // CTRL + F
-  addListener('find', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.isKey([ 'f', 'F' ], event) && keyboard.isCmd(event)) {
-      editorActions.trigger('find');
-
-      return true;
-    }
-  });
-
-  // activate space tool
-  // S
-  addListener('spaceTool', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
+    if (!editorActions.isRegistered(action)) {
       return;
     }
 
-    if (keyboard.isKey([ 's', 'S' ], event)) {
-      editorActions.trigger('spaceTool');
+    var keys = [ binding.key.toLowerCase(), binding.key.toUpperCase() ],
+        requiresCmd = binding.modifier === 'cmd';
+
+    keyboard.addListener(function(context) {
+
+      var event = context.keyEvent;
+
+      if (!keyboard.isKey(keys, event)) {
+        return;
+      }
+
+      if (requiresCmd) {
+        if (!keyboard.isCmd(event)) {
+          return;
+        }
+      } else if (keyboard.hasModifier(event)) {
+        return;
+      }
+
+      editorActions.trigger(action, event);
 
       return true;
-    }
-  });
-
-  // activate lasso tool
-  // L
-  addListener('lassoTool', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
-      return;
-    }
-
-    if (keyboard.isKey([ 'l', 'L' ], event)) {
-      editorActions.trigger('lassoTool');
-
-      return true;
-    }
-  });
-
-  // activate hand tool
-  // H
-  addListener('handTool', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
-      return;
-    }
-
-    if (keyboard.isKey([ 'h', 'H' ], event)) {
-      editorActions.trigger('handTool');
-
-      return true;
-    }
-  });
-
-  // activate global connect tool
-  // C
-  addListener('globalConnectTool', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
-      return;
-    }
-
-    if (keyboard.isKey([ 'c', 'C' ], event)) {
-      editorActions.trigger('globalConnectTool');
-
-      return true;
-    }
-  });
-
-  // activate direct editing
-  // E
-  addListener('directEditing', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
-      return;
-    }
-
-    if (keyboard.isKey([ 'e', 'E' ], event)) {
-      editorActions.trigger('directEditing');
-
-      return true;
-    }
-  });
-
-  // activate replace element
-  // R
-  addListener('replaceElement', function(context) {
-
-    var event = context.keyEvent;
-
-    if (keyboard.hasModifier(event)) {
-      return;
-    }
-
-    if (keyboard.isKey([ 'r', 'R' ], event)) {
-      editorActions.trigger('replaceElement', event);
-
-      return true;
-    }
+    });
   });
 
 };

--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -2,6 +2,8 @@ import {
   assign
 } from 'min-dash';
 
+import { SHORTCUTS_KEY_BINDINGS } from '../keyboard/BpmnKeyboardBindings';
+
 /**
  * @typedef {import('diagram-js/lib/features/palette/Palette').default} Palette
  * @typedef {import('diagram-js/lib/features/create/Create').default} Create
@@ -118,6 +120,7 @@ PaletteProvider.prototype.getPaletteEntries = function() {
       group: 'tools',
       className: 'bpmn-icon-hand-tool',
       title: translate('Activate hand tool'),
+      shortcut: SHORTCUTS_KEY_BINDINGS.handTool.key,
       action: {
         click: function(event) {
           handTool.activateHand(event);
@@ -128,6 +131,7 @@ PaletteProvider.prototype.getPaletteEntries = function() {
       group: 'tools',
       className: 'bpmn-icon-lasso-tool',
       title: translate('Activate lasso tool'),
+      shortcut: SHORTCUTS_KEY_BINDINGS.lassoTool.key,
       action: {
         click: function(event) {
           lassoTool.activateSelection(event);
@@ -138,6 +142,7 @@ PaletteProvider.prototype.getPaletteEntries = function() {
       group: 'tools',
       className: 'bpmn-icon-space-tool',
       title: translate('Activate create/remove space tool'),
+      shortcut: SHORTCUTS_KEY_BINDINGS.spaceTool.key,
       action: {
         click: function(event) {
           spaceTool.activateSelection(event);
@@ -148,6 +153,7 @@ PaletteProvider.prototype.getPaletteEntries = function() {
       group: 'tools',
       className: 'bpmn-icon-connection-multi',
       title: translate('Activate global connect tool'),
+      shortcut: SHORTCUTS_KEY_BINDINGS.globalConnectTool.key,
       action: {
         click: function(event) {
           globalConnect.start(event);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.2.0",
-        "diagram-js": "^15.25.0",
+        "diagram-js": "^15.26.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3928,9 +3928,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.25.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.25.0.tgz",
-      "integrity": "sha512-2TKn4hBy1rHf5/6jVubiLdq09BivmhPq3QexH40YXIOnszYGVx0HKP4bW03bTQzrh7GIqMFbNYDkSXlFREWgmA==",
+      "version": "15.26.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.26.0.tgz",
+      "integrity": "sha512-AxhMvXu7ctWyLKtnxTTLRpsLsDP+qtq8cRx8U1ETe++Gll7pA5YMD3P9oMLsJQNNBNSKS2diNCEqMk0mviVbkw==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.2.0",
-    "diagram-js": "^15.25.0",
+    "diagram-js": "^15.26.0",
     "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",

--- a/test/spec/features/palette/PaletteProviderSpec.js
+++ b/test/spec/features/palette/PaletteProviderSpec.js
@@ -50,6 +50,19 @@ describe('features/palette', function() {
   }));
 
 
+  it('should provide keyboard shortcuts on tool entries', inject(function(palette) {
+
+    // when
+    var entries = palette.getEntries();
+
+    // then
+    expect(entries[ 'hand-tool' ].shortcut).to.eql('H');
+    expect(entries[ 'lasso-tool' ].shortcut).to.eql('L');
+    expect(entries[ 'space-tool' ].shortcut).to.eql('S');
+    expect(entries[ 'global-connect-tool' ].shortcut).to.eql('C');
+  }));
+
+
   describe('sub process', function() {
 
     it('should create sub process with start event', inject(function(dragging) {


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6011
Depends on [bpmn-io/diagram-js#1082](https://github.com/bpmn-io/diagram-js/pull/1082)

Adds `shortcut` to the hand/lasso/space/global-connect tool entries so the diagram-js palette tooltip shows the key hint.

Additionally some refactoring of keyboard bindings registration and exposing `SHORTCUTS_KEY_BINDINGS` map.

https://github.com/user-attachments/assets/17baf956-6de9-4828-928b-27085f350909

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
