### PR TITLE
Add `categoryValueRef` support for elements visually inside groups

### DIFF
--- a/lib/features/modeling/Modeling.js
+++ b/lib/features/modeling/Modeling.js
@@ -9,6 +9,7 @@ import AddLaneHandler from './cmd/AddLaneHandler';
 import SplitLaneHandler from './cmd/SplitLaneHandler';
 import ResizeLaneHandler from './cmd/ResizeLaneHandler';
 import UpdateFlowNodeRefsHandler from './cmd/UpdateFlowNodeRefsHandler';
+import UpdateCategoryValueRefsHandler from './cmd/UpdateCategoryValueRefsHandler';
 import IdClaimHandler from './cmd/IdClaimHandler';
 import SetColorHandler from './cmd/SetColorHandler';
 
@@ -37,6 +38,11 @@ import UpdateLabelHandler from '../label-editing/cmd/UpdateLabelHandler';
  * @typedef { {
  *   removeShape?: boolean;
  * } } UpdateLabelHints
+ *
+ * @typedef { {
+ *   categoryValue?: ModdleElement;
+ *   groupShape: Shape;
+ * } } GroupEntry
  */
 
 /**
@@ -87,6 +93,7 @@ Modeling.prototype.getHandlers = function() {
   handlers['lane.resize'] = ResizeLaneHandler;
   handlers['lane.split'] = SplitLaneHandler;
   handlers['lane.updateRefs'] = UpdateFlowNodeRefsHandler;
+  handlers['group.updateRefs'] = UpdateCategoryValueRefsHandler;
   handlers['id.updateClaim'] = IdClaimHandler;
   handlers['element.setColor'] = SetColorHandler;
   handlers['element.updateLabel'] = UpdateLabelHandler;
@@ -261,6 +268,20 @@ Modeling.prototype.updateLaneRefs = function(flowNodeShapes, laneShapes) {
   this._commandStack.execute('lane.updateRefs', {
     flowNodeShapes: flowNodeShapes,
     laneShapes: laneShapes
+  });
+};
+
+/**
+ * Update the referenced category values of each flow element.
+ *
+ * @param {Element[]} affectedFlowElements The flow elements to update.
+ * @param {GroupEntry[]} affectedGroupEntries The groups to update.
+ */
+Modeling.prototype.updateCategoryValueRefs = function(affectedFlowElements, affectedGroupEntries) {
+
+  this._commandStack.execute('group.updateRefs', {
+    affectedFlowElements: affectedFlowElements,
+    affectedGroupEntries: affectedGroupEntries
   });
 };
 

--- a/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
@@ -104,6 +104,22 @@ export default function CategoryRootElementReferenceBehavior(
     }
   }, true);
 
+  this.executed('group.updateRefs', function(context) {
+    getGroupUpdates(context).forEach(function(update) {
+      link(update.categoryValue, update.category);
+    });
+  }, true);
+
+  this.reverted('group.updateRefs', function(context) {
+    getGroupUpdates(context).forEach(function(update) {
+      unlink(
+        update.categoryValue,
+        update.category,
+        getBusinessObject(update.groupShape)
+      );
+    });
+  }, true);
+
   this.executed('shape.delete', function(context) {
     var shape = context.shape;
 
@@ -132,3 +148,10 @@ CategoryRootElementReferenceBehavior.$inject = [
 ];
 
 inherits(CategoryRootElementReferenceBehavior, CommandInterceptor);
+
+
+// helpers //////////
+
+function getGroupUpdates(context) {
+  return context.updates?.groups || [];
+}

--- a/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
@@ -1,0 +1,120 @@
+import inherits from 'inherits-browser';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import {
+  getBusinessObject,
+  is
+} from '../../../util/ModelUtil';
+
+import {
+  linkCategoryValue,
+  unlinkCategory,
+  unlinkCategoryValue
+} from './util/CategoryUtil';
+
+/**
+ * @typedef {import('../../../Modeler').default} Modeler
+ * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
+ * @typedef {import('didi').Injector} Injector
+ */
+
+/**
+ * Maintains a group's category (value) inside definitions#rootElements.
+ *
+ * @param {Modeler} bpmnjs
+ * @param {ElementRegistry} elementRegistry
+ * @param {Injector} injector
+ */
+export default function CategoryRootElementReferenceBehavior(
+    bpmnjs, elementRegistry, injector
+) {
+  injector.invoke(CommandInterceptor, this);
+
+  function getGroupBusinessObjects(ignoredBusinessObject) {
+    return elementRegistry.filter(function(element) {
+      return is(element, 'bpmn:Group') && !element.labelTarget;
+    }).map(getBusinessObject).filter(function(businessObject) {
+      return businessObject !== ignoredBusinessObject;
+    });
+  }
+
+  function isCategoryValueReferenced(categoryValue, ignoredBusinessObject) {
+    return getGroupBusinessObjects(ignoredBusinessObject).some(function(businessObject) {
+      return businessObject.get('categoryValueRef') === categoryValue;
+    });
+  }
+
+  function isCategoryReferenced(category, ignoredBusinessObject) {
+    return getGroupBusinessObjects(ignoredBusinessObject).some(function(businessObject) {
+      var categoryValue = businessObject.get('categoryValueRef');
+
+      return categoryValue && categoryValue.$parent === category;
+    });
+  }
+
+  function link(categoryValue, category) {
+    if (categoryValue && category) {
+      linkCategoryValue(categoryValue, category, bpmnjs.getDefinitions());
+    }
+  }
+
+  function unlink(categoryValue, category, ignoredBusinessObject) {
+    if (category && !isCategoryReferenced(category, ignoredBusinessObject)) {
+      unlinkCategory(category);
+    }
+
+    if (categoryValue && !isCategoryValueReferenced(categoryValue, ignoredBusinessObject)) {
+      unlinkCategoryValue(categoryValue);
+    }
+  }
+
+
+  this.executed([ 'shape.create', 'label.create' ], function(context) {
+    var shape = context.labelTarget || context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
+
+    link(context.categoryValue, context.category);
+  }, true);
+
+  this.reverted([ 'shape.create', 'label.create' ], function(context) {
+    var shape = context.labelTarget || context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
+
+    unlink(context.categoryValue, context.category, getBusinessObject(shape));
+  }, true);
+
+  this.executed('shape.delete', function(context) {
+    var shape = context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
+
+    unlink(context.categoryValue, context.category, getBusinessObject(shape));
+  }, true);
+
+  this.reverted('shape.delete', function(context) {
+    var shape = context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
+      return;
+    }
+
+    link(context.categoryValue, context.category);
+  }, true);
+}
+
+CategoryRootElementReferenceBehavior.$inject = [
+  'bpmnjs',
+  'elementRegistry',
+  'injector'
+];
+
+inherits(CategoryRootElementReferenceBehavior, CommandInterceptor);

--- a/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
+++ b/lib/features/modeling/behavior/CategoryRootElementReferenceBehavior.js
@@ -13,6 +13,8 @@ import {
   unlinkCategoryValue
 } from './util/CategoryUtil';
 
+var LOW_PRIORITY = 500;
+
 /**
  * @typedef {import('../../../Modeler').default} Modeler
  * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
@@ -88,6 +90,18 @@ export default function CategoryRootElementReferenceBehavior(
     }
 
     unlink(context.categoryValue, context.category, getBusinessObject(shape));
+  }, true);
+
+  this.executed([ 'shape.move', 'shape.resize' ], LOW_PRIORITY, function(context) {
+    link(context.categoryValue, context.category);
+  }, true);
+
+  this.reverted([ 'shape.move', 'shape.resize' ], function(context) {
+    var shape = context.shape;
+
+    if (context.categoryValue) {
+      unlink(context.categoryValue, context.category, getBusinessObject(shape));
+    }
   }, true);
 
   this.executed('shape.delete', function(context) {

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -9,24 +9,15 @@ import {
 
 import {
   createCategory,
-  createCategoryValue,
-  linkCategoryValue,
-  unlinkCategory,
-  unlinkCategoryValue
+  createCategoryValue
 } from './util/CategoryUtil';
 
 /**
  * @typedef {import('../BpmnFactory').default} BpmnFactory
- * @typedef {import('../../../Modeler').default} Modeler
- * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('didi').Injector} Injector
  * @typedef {import('../../copy-paste/ModdleCopy').default} ModdleCopy
  *
- * @typedef {import('../../../model/Types').Element} Element
- * @typedef {import('../../../model/Types').Shape} Shape
- *
- * @typedef {import('diagram-js/lib/util/Types').DirectionTRBL} DirectionTRBL
  */
 
 var LOWER_PRIORITY = 770;
@@ -36,100 +27,17 @@ var LOWER_PRIORITY = 770;
  * BPMN specific group behavior.
  *
  * @param {BpmnFactory} bpmnFactory
- * @param {Modeler} bpmnjs
- * @param {ElementRegistry} elementRegistry
  * @param {EventBus} eventBus
  * @param {Injector} injector
  * @param {ModdleCopy} moddleCopy
  */
 export default function GroupBehavior(
     bpmnFactory,
-    bpmnjs,
-    elementRegistry,
     eventBus,
     injector,
     moddleCopy
 ) {
   injector.invoke(CommandInterceptor, this);
-
-  /**
-   * Returns all group element in the current registry.
-   *
-   * @return {Shape[]}
-   */
-  function getGroupElements() {
-    return elementRegistry.filter(function(e) {
-      return is(e, 'bpmn:Group');
-    });
-  }
-
-  /**
-   * Returns true if given category is referenced in one of the given elements.
-   *
-   * @param {Element[]} elements
-   * @param {ModdleElement} category
-   *
-   * @return {boolean}
-   */
-  function isReferencedCategory(elements, category) {
-    return elements.some(function(element) {
-      var businessObject = getBusinessObject(element);
-
-      var _category = businessObject.categoryValueRef && businessObject.categoryValueRef.$parent;
-
-      return _category === category;
-    });
-  }
-
-  /**
-   * Returns true if given categoryValue is referenced in one of the given elements.
-   *
-   * @param {Element[]} elements
-   * @param {ModdleElement} categoryValue
-   *
-   * @return {boolean}
-   */
-  function isReferencedCategoryValue(elements, categoryValue) {
-    return elements.some(function(element) {
-      var businessObject = getBusinessObject(element);
-
-      return businessObject.categoryValueRef === categoryValue;
-    });
-  }
-
-  /**
-   * Remove category value unless it is still referenced.
-   *
-   * @param {ModdleElement} categoryValue
-   * @param {ModdleElement} category
-   * @param {ModdleElement} businessObject
-   */
-  function removeCategoryValue(categoryValue, category, businessObject) {
-
-    var groups = getGroupElements().filter(function(element) {
-      return element.businessObject !== businessObject;
-    });
-
-    if (category && !isReferencedCategory(groups, category)) {
-      unlinkCategory(category);
-    }
-
-    if (categoryValue && !isReferencedCategoryValue(groups, categoryValue)) {
-      unlinkCategoryValue(categoryValue);
-    }
-  }
-
-  /**
-   * Add category value.
-   *
-   * @param {ModdleElement} categoryValue
-   * @param {ModdleElement} category
-   *
-   * @return {ModdleElement}
-   */
-  function addCategoryValue(categoryValue, category) {
-    return linkCategoryValue(categoryValue, category, bpmnjs.getDefinitions());
-  }
 
   function setCategoryValue(element, context) {
     var businessObject = getBusinessObject(element),
@@ -153,7 +61,8 @@ export default function GroupBehavior(
       );
     }
 
-    addCategoryValue(categoryValue, category, bpmnjs.getDefinitions());
+    context.categoryValue = categoryValue;
+    context.category = category;
   }
 
   function unsetCategoryValue(element, context) {
@@ -164,9 +73,6 @@ export default function GroupBehavior(
     if (categoryValue) {
       businessObject.categoryValueRef = null;
 
-      removeCategoryValue(categoryValue, category, businessObject);
-    } else {
-      removeCategoryValue(null, businessObject.categoryValueRef.$parent, businessObject);
     }
   }
 
@@ -208,14 +114,10 @@ export default function GroupBehavior(
       return;
     }
 
-    var categoryValue = context.categoryValue = businessObject.categoryValueRef,
-        category;
+    var categoryValue = context.categoryValue = businessObject.categoryValueRef;
 
     if (categoryValue) {
-      category = context.category = categoryValue.$parent;
-
-      removeCategoryValue(categoryValue, category, businessObject);
-
+      context.category = categoryValue.$parent;
       businessObject.categoryValueRef = null;
     }
   });
@@ -236,7 +138,7 @@ export default function GroupBehavior(
     if (categoryValue) {
       businessObject.categoryValueRef = categoryValue;
 
-      addCategoryValue(categoryValue, category);
+      categoryValue.$parent = category;
     }
   });
 
@@ -251,7 +153,7 @@ export default function GroupBehavior(
       return;
     }
 
-    if (getBusinessObject(shape).categoryValueRef) {
+    if (getBusinessObject(shape).categoryValueRef || context.categoryValue) {
       setCategoryValue(shape, context);
     }
   });
@@ -323,8 +225,6 @@ export default function GroupBehavior(
 
 GroupBehavior.$inject = [
   'bpmnFactory',
-  'bpmnjs',
-  'elementRegistry',
   'eventBus',
   'injector',
   'moddleCopy'

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -8,8 +8,8 @@ import {
 } from '../../../util/ModelUtil';
 
 import {
-  createCategory,
-  createCategoryValue
+  getOrCreateCategoryValueForGroup,
+  createCategory
 } from './util/CategoryUtil';
 
 /**
@@ -17,7 +17,6 @@ import {
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
  * @typedef {import('didi').Injector} Injector
  * @typedef {import('../../copy-paste/ModdleCopy').default} ModdleCopy
- *
  */
 
 var LOWER_PRIORITY = 770;
@@ -41,38 +40,31 @@ export default function GroupBehavior(
 
   function setCategoryValue(element, context) {
     var businessObject = getBusinessObject(element),
-        categoryValue = businessObject.categoryValueRef;
+        categoryValue = context.categoryValue || businessObject.categoryValueRef;
 
     if (!categoryValue) {
-      categoryValue =
-      businessObject.categoryValueRef =
-      context.categoryValue = (
-        context.categoryValue || createCategoryValue(bpmnFactory)
-      );
+      categoryValue = getOrCreateCategoryValueForGroup(bpmnFactory, businessObject);
     }
 
-    var category = categoryValue.$parent;
+    var category = context.category || categoryValue.$parent || createCategory(bpmnFactory);
 
-    if (!category) {
-      category =
-      categoryValue.$parent =
-      context.category = (
-        context.category || createCategory(bpmnFactory)
-      );
-    }
+    businessObject.categoryValueRef = categoryValue;
+    categoryValue.$parent = category;
 
     context.categoryValue = categoryValue;
     context.category = category;
   }
 
   function unsetCategoryValue(element, context) {
-    var category = context.category,
-        categoryValue = context.categoryValue,
-        businessObject = getBusinessObject(element);
+    var businessObject = getBusinessObject(element),
+        categoryValue = context.categoryValue || businessObject.categoryValueRef,
+        category = context.category || (categoryValue && categoryValue.$parent);
 
     if (categoryValue) {
-      businessObject.categoryValueRef = null;
+      context.categoryValue = categoryValue;
+      context.category = category;
 
+      businessObject.categoryValueRef = null;
     }
   }
 
@@ -137,39 +129,51 @@ export default function GroupBehavior(
 
     if (categoryValue) {
       businessObject.categoryValueRef = categoryValue;
-
       categoryValue.$parent = category;
     }
   });
 
 
-  // create new category + value when group was created
+  // create new category + value when group was created so that visually
+  // enclosed elements can be categorized against it, even if it is unlabeled
 
   this.execute('shape.create', function(event) {
     var context = event.context,
-        shape = context.shape;
+        shape = context.shape,
+        hints = context.hints || {};
 
     if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
       return;
     }
 
-    if (getBusinessObject(shape).categoryValueRef || context.categoryValue) {
-      setCategoryValue(shape, context);
+    // during paste the category value (if any) is carried over from the
+    // source; only fabricate one for genuinely new groups
+    if (hints.createElementsBehavior === false &&
+        !getBusinessObject(shape).categoryValueRef &&
+        !context.categoryValue) {
+      return;
     }
+
+    setCategoryValue(shape, context);
   });
 
   this.reverted('shape.create', function(event) {
 
     var context = event.context,
-        shape = context.shape;
+        shape = context.shape,
+        hints = context.hints || {};
 
     if (!is(shape, 'bpmn:Group') || shape.labelTarget) {
       return;
     }
 
-    if (getBusinessObject(shape).categoryValueRef) {
-      unsetCategoryValue(shape, context);
+    if (hints.createElementsBehavior === false &&
+        !getBusinessObject(shape).categoryValueRef &&
+        !context.categoryValue) {
+      return;
     }
+
+    unsetCategoryValue(shape, context);
   });
 
 

--- a/lib/features/modeling/behavior/GroupBehavior.js
+++ b/lib/features/modeling/behavior/GroupBehavior.js
@@ -15,6 +15,7 @@ import {
 /**
  * @typedef {import('../BpmnFactory').default} BpmnFactory
  * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
  * @typedef {import('didi').Injector} Injector
  * @typedef {import('../../copy-paste/ModdleCopy').default} ModdleCopy
  */
@@ -170,6 +171,32 @@ export default function GroupBehavior(
     if (hints.createElementsBehavior === false &&
         !getBusinessObject(shape).categoryValueRef &&
         !context.categoryValue) {
+      return;
+    }
+
+    unsetCategoryValue(shape, context);
+  });
+
+
+  // add category -> categoryValue for groups when they change
+
+  this.executed([ 'shape.move', 'shape.resize' ], function(event) {
+    var context = event.context,
+        shape = context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget ||
+        getBusinessObject(shape).categoryValueRef) {
+      return;
+    }
+
+    setCategoryValue(shape, context);
+  });
+
+  this.reverted([ 'shape.move', 'shape.resize' ], function(event) {
+    var context = event.context,
+        shape = context.shape;
+
+    if (!is(shape, 'bpmn:Group') || shape.labelTarget || !context.categoryValue) {
       return;
     }
 

--- a/lib/features/modeling/behavior/UpdateCategoryValueRefsBehavior.js
+++ b/lib/features/modeling/behavior/UpdateCategoryValueRefsBehavior.js
@@ -1,0 +1,169 @@
+import inherits from 'inherits-browser';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import {
+  is
+} from '../../../util/ModelUtil';
+
+/**
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('../Modeling').default} Modeling
+ */
+
+var LOW_PRIORITY = 500,
+    HIGH_PRIORITY = 5000;
+
+// Commands that provide a shape or connection whose references must be updated.
+var categoryValueRefShapeAndConnectionEvents = [
+  'connection.create',
+  'connection.delete',
+  'connection.layout',
+  'connection.move',
+  'connection.reconnect',
+  'connection.updateWaypoints',
+  'shape.create',
+  'shape.delete',
+  'shape.move',
+  'shape.resize'
+];
+
+// Commands that bracket a complete reference update, including nested commands.
+var categoryValueRefUpdateEvents = [
+  ...categoryValueRefShapeAndConnectionEvents,
+  'elements.create',
+  'elements.delete',
+  'elements.move',
+  'label.create',
+  'spaceTool'
+];
+
+/**
+ * Synchronizes group category references after geometry changes.
+ *
+ * @param {EventBus} eventBus
+ * @param {Modeling} modeling
+ */
+export default function UpdateCategoryValueRefsBehavior(eventBus, modeling) {
+
+  CommandInterceptor.call(this, eventBus);
+
+  var context;
+
+  function initContext() {
+    context = context || new UpdateContext();
+    context.enter();
+
+    return context;
+  }
+
+  function getContext() {
+    if (!context) {
+      throw new Error('out of bounds release');
+    }
+
+    return context;
+  }
+
+  function releaseContext() {
+    if (!context) {
+      throw new Error('out of bounds release');
+    }
+
+    var triggerUpdate = context.leave();
+
+    if (triggerUpdate) {
+      modeling.updateCategoryValueRefs(
+        Array.from(context.affectedFlowElements),
+        Array.from(context.affectedGroupEntries.values())
+      );
+
+      context = null;
+    }
+
+    return triggerUpdate;
+  }
+
+  /**
+   * Sets up the context for category value reference updates before executing
+   * commands that may affect them.
+   */
+  this.preExecute(categoryValueRefUpdateEvents, HIGH_PRIORITY, function() {
+    initContext();
+  });
+
+  /**
+   * Releases the context for category value reference updates after executing
+   * commands that may affect them.
+   */
+  this.postExecuted(categoryValueRefUpdateEvents, LOW_PRIORITY, function() {
+    releaseContext();
+  });
+
+  /**
+   * Handles updates to category value references for shapes and connections.
+   */
+  this.preExecute(categoryValueRefShapeAndConnectionEvents, function(event) {
+    var shape = event.context.connection || event.context.shape,
+        updateContext = getContext();
+
+    if (!shape || shape.labelTarget) {
+      return;
+    }
+
+    if (is(shape, 'bpmn:FlowElement')) {
+      updateContext.addFlowElement(shape);
+    }
+
+    if (is(shape, 'bpmn:Group')) {
+      updateContext.addGroup(shape);
+    }
+  });
+
+  this.preExecute('label.create', function(event) {
+    var labelTarget = event.context.labelTarget;
+
+    if (is(labelTarget, 'bpmn:Group')) {
+      getContext().addGroup(labelTarget);
+    }
+  });
+}
+
+UpdateCategoryValueRefsBehavior.$inject = [
+  'eventBus',
+  'modeling'
+];
+
+inherits(UpdateCategoryValueRefsBehavior, CommandInterceptor);
+
+
+function UpdateContext() {
+
+  this.affectedFlowElements = new Set();
+  this.affectedGroupEntries = new Map();
+
+  this.counter = 0;
+
+  this.addFlowElement = function(flowElement) {
+    this.affectedFlowElements.add(flowElement);
+  };
+
+  this.addGroup = function(group) {
+    if (!this.affectedGroupEntries.has(group)) {
+      this.affectedGroupEntries.set(group, {
+        categoryValue: group.businessObject.categoryValueRef,
+        groupShape: group
+      });
+    }
+  };
+
+  this.enter = function() {
+    this.counter++;
+  };
+
+  this.leave = function() {
+    this.counter--;
+
+    return !this.counter;
+  };
+}

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -40,6 +40,7 @@ import ToggleElementCollapseBehaviour from './ToggleElementCollapseBehaviour';
 import UnclaimIdBehavior from './UnclaimIdBehavior';
 import UnsetDefaultFlowBehavior from './UnsetDefaultFlowBehavior';
 import UpdateFlowNodeRefsBehavior from './UpdateFlowNodeRefsBehavior';
+import UpdateCategoryValueRefsBehavior from './UpdateCategoryValueRefsBehavior';
 import SetCompensationActivityAfterPasteBehavior from './SetCompensationActivityAfterPasteBehavior';
 
 /**
@@ -88,6 +89,7 @@ export default {
     'toggleElementCollapseBehaviour',
     'unclaimIdBehavior',
     'updateFlowNodeRefsBehavior',
+    'updateCategoryValueRefsBehavior',
     'unsetDefaultFlowBehavior',
     'setCompensationActivityAfterPasteBehavior'
   ],
@@ -133,5 +135,6 @@ export default {
   unclaimIdBehavior: [ 'type', UnclaimIdBehavior ],
   unsetDefaultFlowBehavior: [ 'type', UnsetDefaultFlowBehavior ],
   updateFlowNodeRefsBehavior: [ 'type', UpdateFlowNodeRefsBehavior ],
+  updateCategoryValueRefsBehavior: [ 'type', UpdateCategoryValueRefsBehavior ],
   setCompensationActivityAfterPasteBehavior: [ 'type', SetCompensationActivityAfterPasteBehavior ]
 };

--- a/lib/features/modeling/behavior/index.js
+++ b/lib/features/modeling/behavior/index.js
@@ -4,6 +4,7 @@ import ArtifactBehavior from './ArtifactBehavior';
 import AssociationBehavior from './AssociationBehavior';
 import AttachEventBehavior from './AttachEventBehavior';
 import BoundaryEventBehavior from './BoundaryEventBehavior';
+import CategoryRootElementReferenceBehavior from './CategoryRootElementReferenceBehavior';
 import CompensateBoundaryEventBehavior from './CompensateBoundaryEventBehavior';
 import CreateBehavior from './CreateBehavior';
 import CreateDataObjectBehavior from './CreateDataObjectBehavior';
@@ -52,6 +53,7 @@ export default {
     'associationBehavior',
     'attachEventBehavior',
     'boundaryEventBehavior',
+    'categoryRootElementReferenceBehavior',
     'compensateBoundaryEventBehaviour',
     'createBehavior',
     'createDataObjectBehavior',
@@ -95,6 +97,7 @@ export default {
   attachEventBehavior: [ 'type', AttachEventBehavior ],
   artifactBehavior: [ 'type', ArtifactBehavior ],
   boundaryEventBehavior: [ 'type', BoundaryEventBehavior ],
+  categoryRootElementReferenceBehavior: [ 'type', CategoryRootElementReferenceBehavior ],
   compensateBoundaryEventBehaviour: [ 'type', CompensateBoundaryEventBehavior ],
   createBehavior: [ 'type', CreateBehavior ],
   createDataObjectBehavior: [ 'type', CreateDataObjectBehavior ],

--- a/lib/features/modeling/behavior/util/CategoryUtil.js
+++ b/lib/features/modeling/behavior/util/CategoryUtil.js
@@ -6,7 +6,7 @@ import {
 /**
  * @typedef {import('../../BpmnFactory').default} BpmnFactory
  *
- * @typedef {import('../../../model/Types').ModdleElement} ModdleElement
+ * @typedef {import('../../../../model/Types').ModdleElement} ModdleElement
  */
 
 /**
@@ -29,6 +29,29 @@ export function createCategory(bpmnFactory) {
  */
 export function createCategoryValue(bpmnFactory) {
   return bpmnFactory.create('bpmn:CategoryValue');
+}
+
+/**
+ * Returns a group's category value, creating one (including a
+ * category) if needed.
+ *
+ * @param {BpmnFactory} bpmnFactory
+ * @param {ModdleElement} groupBo
+ *
+ * @return {ModdleElement}
+ */
+export function getOrCreateCategoryValueForGroup(bpmnFactory, groupBo) {
+  var categoryValue = groupBo.get('categoryValueRef');
+
+  if (!categoryValue) {
+    categoryValue = groupBo.categoryValueRef = createCategoryValue(bpmnFactory);
+  }
+
+  if (!categoryValue.$parent) {
+    categoryValue.$parent = createCategory(bpmnFactory);
+  }
+
+  return categoryValue;
 }
 
 /**

--- a/lib/features/modeling/cmd/UpdateCategoryValueRefsHandler.js
+++ b/lib/features/modeling/cmd/UpdateCategoryValueRefsHandler.js
@@ -1,0 +1,424 @@
+import {
+  add as collectionAdd,
+  remove as collectionRemove
+} from 'diagram-js/lib/util/Collections';
+
+import {
+  getEnclosedElements
+} from 'diagram-js/lib/util/Elements';
+
+import {
+  isLabel
+} from '../../../util/LabelUtil';
+
+import {
+  getBusinessObject,
+  is
+} from '../../../util/ModelUtil';
+
+import {
+  getOrCreateCategoryValueForGroup
+} from '../behavior/util/CategoryUtil';
+
+/**
+ * @typedef {import('diagram-js/lib/command/CommandHandler').default} CommandHandler
+ * @typedef {import('diagram-js/lib/core/ElementRegistry').default} ElementRegistry
+ * @typedef {import('../BpmnFactory').default} BpmnFactory
+ *
+ * @typedef {import('../../../model/Types').Element} Element
+ * @typedef {import('../../../model/Types').ModdleElement} ModdleElement
+ *
+ * @typedef { {
+ *   categoryValue: ModdleElement;
+ *   root?: Element;
+ * } } CategoryGroupEntry
+ */
+
+var CATEGORY_VALUE_REFS_ATTR = 'categoryValueRef';
+
+
+/**
+ * Updates category value references for flow elements visually enclosed by groups.
+ *
+ * A flow element is grouped only when it shares the group's diagram root and
+ * is geometrically enclosed by the group. Consequently, visible children of an
+ * expanded subprocess are grouped, while children of a collapsed subprocess
+ * are not.
+ *
+ * Groups without a category value are auto-healed: if such a group visually
+ * encloses an affected flow element a category value is created for it on the
+ * fly, so that legacy diagrams (groups modeled without a category value) start
+ * to categorize their contents as soon as they are interacted with.
+ *
+ * @implements {CommandHandler}
+ *
+ * @param {BpmnFactory} bpmnFactory
+ * @param {ElementRegistry} elementRegistry
+ */
+export default function UpdateCategoryValueRefsHandler(bpmnFactory, elementRegistry) {
+  this._bpmnFactory = bpmnFactory;
+  this._elementRegistry = elementRegistry;
+}
+
+UpdateCategoryValueRefsHandler.$inject = [
+  'bpmnFactory',
+  'elementRegistry'
+];
+
+
+/**
+ * @param { Element[] } affectedFlowElements
+ * @param { {
+ *   categoryValue: ModdleElement;
+ *   groupShape: Element;
+ * }[] } affectedGroupEntries
+ *
+ * @return { {
+ *   flowElements: {
+ *     businessObject: ModdleElement;
+ *     categoryValuesToAdd: ModdleElement[];
+ *     categoryValuesToRemove: ModdleElement[];
+ *   }[];
+ *   groups: {
+ *     groupShape: Element;
+ *     categoryValue: ModdleElement;
+ *     category: ModdleElement;
+ *   }[];
+ * } }
+ */
+UpdateCategoryValueRefsHandler.prototype._computeUpdates = function(affectedFlowElements, affectedGroupEntries) {
+  var elementRegistry = this._elementRegistry,
+      bpmnFactory = this._bpmnFactory;
+
+  /** @type {Map<Element, ModdleElement>} */
+  var flowElementBusinessObjects = new Map();
+
+  var groupUpdates = [];
+
+  /**
+   * @type {Map<Element, {
+   *   present?: CategoryGroupEntry;
+   *   past?: CategoryGroupEntry;
+   * }>}
+   */
+  var categoryGroups = new Map();
+
+  /**
+   * Adds a group to the list of groups to consider for category value updates.
+   *
+   * @param {Element} groupShape
+   * @param {ModdleElement} categoryValue
+   * @param {boolean} isPresent
+   */
+  function addGroup(groupShape, categoryValue, isPresent) {
+    if (!categoryValue) {
+      return;
+    }
+
+    var categoryGroup = categoryGroups.get(groupShape);
+
+    if (!categoryGroup) {
+      categoryGroup = {};
+      categoryGroups.set(groupShape, categoryGroup);
+    }
+
+    if (isPresent && categoryGroup.present) {
+      return;
+    }
+
+    if (!isPresent && categoryGroup.past) {
+      return;
+    }
+
+    if (isPresent) {
+      categoryGroup.present = {
+        categoryValue: categoryValue,
+        root: getRoot(groupShape)
+      };
+    } else {
+      categoryGroup.past = {
+        categoryValue: categoryValue
+      };
+    }
+  }
+
+  /**
+   * Adds a flow element to the list of flow elements to consider for category
+   * value updates.
+   *
+   * @param {Element} flowElement
+   */
+  function addFlowElement(flowElement) {
+    flowElementBusinessObjects.set(
+      flowElement,
+      getBusinessObject(flowElement)
+    );
+  }
+
+  /**
+   * Adds all flow elements on the diagram to the list of flow elements to
+   * consider; skips root elements (e.g. sub process planes) which share a
+   * business object with their collapsed shape but carry no diagram position.
+   */
+  function addAllFlowElements() {
+    elementRegistry.filter(function(element) {
+      return is(element, 'bpmn:FlowElement') && !isLabel(element) && element.parent;
+    }).forEach(addFlowElement);
+  }
+
+  /**
+   * Returns a group's category value, creating one on the fly for
+   * legacy groups modeled without one. Retrieving the value in order to
+   * reference it materializes it; the fresh value is recorded as a heal so
+   * CategoryRootElementReferenceBehavior can maintain its root element.
+   *
+   * @param {Element} groupShape
+   *
+   * @return {ModdleElement}
+   */
+  function getCategoryValue(groupShape) {
+    var groupBo = getBusinessObject(groupShape),
+        categoryValue = groupBo.get('categoryValueRef');
+
+    if (!categoryValue) {
+      categoryValue = getOrCreateCategoryValueForGroup(bpmnFactory, groupBo);
+
+      groupUpdates.push(createGroupUpdate(groupShape, categoryValue));
+    }
+
+    return categoryValue;
+  }
+
+  function getElementsByRoot(elements) {
+    return elements.reduce(function(elementsByRoot, element) {
+      var root = getRoot(element),
+          elementsInRoot = elementsByRoot.get(root);
+
+      if (!elementsInRoot) {
+        elementsInRoot = [];
+        elementsByRoot.set(root, elementsInRoot);
+      }
+
+      elementsInRoot.push(element);
+
+      return elementsByRoot;
+    }, new Map());
+  }
+
+  affectedFlowElements = Array.from(affectedFlowElements || []);
+
+  var affectedFlowElementsByRoot = getElementsByRoot(affectedFlowElements);
+
+  // when a group is moved, resized, added or removed, the category value
+  // references of all flow elements must be rechecked
+  if (affectedGroupEntries.length) {
+    addAllFlowElements();
+  }
+
+  // flow elements that were genuinely moved or created; unrelated groups
+  // will not be touched
+  affectedFlowElements.forEach(addFlowElement);
+
+  // add all present groups to the list of groups to consider for category
+  // value updates, auto-healing legacy groups only when an affected flow
+  // element moves into them
+  elementRegistry.filter(function(element) {
+    return is(element, 'bpmn:Group') && !isLabel(element) && element.parent;
+  }).forEach(function(groupShape) {
+    var categoryValue = getBusinessObject(groupShape).get('categoryValueRef');
+
+    if (!categoryValue) {
+      var groupRoot = getRoot(groupShape),
+          affectedFlowElementsInRoot = affectedFlowElementsByRoot.get(groupRoot) || [],
+          enclosedAffectedFlowElements = getEnclosedElements(
+            affectedFlowElementsInRoot,
+            groupShape
+          ),
+          enclosesAffectedFlowElement = Object.keys(enclosedAffectedFlowElements).length > 0;
+
+      if (enclosesAffectedFlowElement) {
+        categoryValue = getCategoryValue(groupShape);
+      }
+    }
+
+    addGroup(groupShape, categoryValue, true);
+  });
+
+  affectedGroupEntries.forEach(function(groupEntry) {
+    addGroup(groupEntry.groupShape, groupEntry.categoryValue, false);
+  });
+
+  // a healed group receives a fresh category value; recheck all flow elements
+  // so that everything it visually encloses is tagged consistently, not just
+  // the flow element that triggered the healing
+  if (groupUpdates.length) {
+    addAllFlowElements();
+  }
+
+  var flowElements = Array.from(flowElementBusinessObjects.keys());
+
+  var managedCategoryValues = Array.from(categoryGroups.values()).reduce(function(set, group) {
+    if (group.present) {
+      set.add(group.present.categoryValue);
+    }
+
+    if (group.past) {
+      set.add(group.past.categoryValue);
+    }
+
+    return set;
+  }, new Set());
+
+  var categoryValuesByFlowElement = new Map(),
+      flowElementsByRoot = getElementsByRoot(flowElements);
+
+  // Containment is calculated once per group and diagram root. This avoids
+  // allocating an enclosure result for every flow element / group pair.
+  categoryGroups.forEach(function(categoryGroup, groupShape) {
+    var presentGroup = categoryGroup.present;
+
+    if (!presentGroup) {
+      return;
+    }
+
+    var flowElementsInRoot = flowElementsByRoot.get(presentGroup.root) || [],
+        enclosedFlowElements = getEnclosedElements(flowElementsInRoot, groupShape);
+
+    flowElementsInRoot.forEach(function(flowElement) {
+      if (!enclosedFlowElements[flowElement.id]) {
+        return;
+      }
+
+      var categoryValues = categoryValuesByFlowElement.get(flowElement);
+
+      if (!categoryValues) {
+        categoryValues = new Set();
+        categoryValuesByFlowElement.set(flowElement, categoryValues);
+      }
+
+      categoryValues.add(presentGroup.categoryValue);
+    });
+  });
+
+  // compute updates for all flow elements based on the groups they are inside
+  var flowElementUpdates = flowElements.reduce(function(flowElementUpdates, flowElement) {
+    var flowElementBo = flowElementBusinessObjects.get(flowElement),
+        categoryValueRefs = flowElementBo.get(CATEGORY_VALUE_REFS_ATTR),
+        categoryValueRefSet = new Set(categoryValueRefs),
+        enclosingCategoryValues = categoryValuesByFlowElement.get(flowElement) || new Set(),
+        categoryValuesToAdd = Array.from(enclosingCategoryValues).filter(function(categoryValue) {
+          return !categoryValueRefSet.has(categoryValue);
+        }),
+        categoryValuesToRemove = categoryValueRefs.filter(function(categoryValue) {
+          return managedCategoryValues.has(categoryValue) &&
+            !enclosingCategoryValues.has(categoryValue);
+        });
+
+    if (categoryValuesToAdd.length || categoryValuesToRemove.length) {
+      flowElementUpdates.push({
+        businessObject: flowElementBo,
+        categoryValuesToAdd,
+        categoryValuesToRemove
+      });
+    }
+
+    return flowElementUpdates;
+  }, []);
+
+  return {
+    flowElements: flowElementUpdates,
+    groups: groupUpdates
+  };
+};
+
+
+UpdateCategoryValueRefsHandler.prototype.execute = function(context) {
+  var updates = context.updates;
+
+  if (!updates) {
+    updates = context.updates = this._computeUpdates(
+      context.affectedFlowElements,
+      context.affectedGroupEntries
+    );
+  }
+
+  // set auto-healed category values first so that flow element updates can
+  // reference them; root element linking is handled by
+  // CategoryRootElementReferenceBehavior
+  applyGroupUpdates(updates.groups);
+
+  applyFlowElementUpdates(updates.flowElements);
+
+  return [];
+};
+
+
+UpdateCategoryValueRefsHandler.prototype.revert = function(context) {
+  var updates = context.updates;
+
+  revertFlowElementUpdates(updates.flowElements);
+
+  revertGroupUpdates(updates.groups);
+
+  return [];
+};
+
+
+function createGroupUpdate(groupShape, categoryValue) {
+  return {
+    groupShape: groupShape,
+    categoryValue: categoryValue,
+    category: categoryValue.$parent
+  };
+}
+
+function applyGroupUpdates(groupUpdates) {
+  groupUpdates.forEach(function(groupUpdate) {
+    getBusinessObject(groupUpdate.groupShape).categoryValueRef = groupUpdate.categoryValue;
+    groupUpdate.categoryValue.$parent = groupUpdate.category;
+  });
+}
+
+function revertGroupUpdates(groupUpdates) {
+  groupUpdates.forEach(function(groupUpdate) {
+    getBusinessObject(groupUpdate.groupShape).categoryValueRef = null;
+  });
+}
+
+function applyFlowElementUpdates(flowElementUpdates) {
+  flowElementUpdates.forEach(function(flowElementUpdate) {
+    var businessObject = flowElementUpdate.businessObject,
+        categoryValueRefs = businessObject.get(CATEGORY_VALUE_REFS_ATTR);
+
+    flowElementUpdate.categoryValuesToRemove.forEach(function(categoryValue) {
+      collectionRemove(categoryValueRefs, categoryValue);
+    });
+
+    flowElementUpdate.categoryValuesToAdd.forEach(function(categoryValue) {
+      collectionAdd(categoryValueRefs, categoryValue, true);
+    });
+  });
+}
+
+function revertFlowElementUpdates(flowElementUpdates) {
+  flowElementUpdates.forEach(function(flowElementUpdate) {
+    var businessObject = flowElementUpdate.businessObject,
+        categoryValueRefs = businessObject.get(CATEGORY_VALUE_REFS_ATTR);
+
+    flowElementUpdate.categoryValuesToAdd.forEach(function(categoryValue) {
+      collectionRemove(categoryValueRefs, categoryValue);
+    });
+
+    flowElementUpdate.categoryValuesToRemove.forEach(function(categoryValue) {
+      collectionAdd(categoryValueRefs, categoryValue, true);
+    });
+  });
+}
+
+function getRoot(element) {
+  while (element.parent) {
+    element = element.parent;
+  }
+
+  return element;
+}

--- a/test/spec/features/modeling/UpdateCategoryValueRefs.bpmn
+++ b/test/spec/features/modeling/UpdateCategoryValueRefs.bpmn
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.50.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <process id="Process_1" name="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_1" name="StartEvent_1">
+      <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+      <outgoing>SequenceFlow_1</outgoing>
+    </startEvent>
+    <task id="Task_1" name="Task_1">
+      <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+      <incoming>SequenceFlow_1</incoming>
+    </task>
+    <sequenceFlow id="SequenceFlow_1" name="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1">
+      <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+    </sequenceFlow>
+    <startEvent id="StartEvent_2" name="StartEvent_2">
+      <outgoing>SequenceFlow_2</outgoing>
+    </startEvent>
+    <task id="Task_2" name="Task_2">
+      <incoming>SequenceFlow_2</incoming>
+    </task>
+    <sequenceFlow id="SequenceFlow_2" name="SequenceFlow_2" sourceRef="StartEvent_2" targetRef="Task_2" />
+    <subProcess id="SubProcess_1" name="SubProcess_1">
+      <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+      <startEvent id="StartEvent_3" name="StartEvent_3">
+        <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+      </startEvent>
+    </subProcess>
+    <subProcess id="SubProcess_2" name="SubProcess_2">
+      <categoryValueRef>CategoryValue_1yqwe1e</categoryValueRef>
+      <startEvent id="StartEvent_4" name="StartEvent_4" />
+    </subProcess>
+    <subProcess id="SubProcess_3" name="SubProcess_3">
+      <startEvent id="StartEvent_5" name="StartEvent_5" />
+    </subProcess>
+    <subProcess id="SubProcess_4" name="SubProcess_4">
+      <startEvent id="StartEvent_6" name="StartEvent_6" />
+    </subProcess>
+    <task id="LegacyTask_1" name="LegacyTask_1" />
+    <task id="LegacyTask_2" name="LegacyTask_2" />
+    <group id="Group_1" categoryValueRef="CategoryValue_1yqwe1e" />
+    <group id="Group_2" />
+    <group id="Group_3" categoryValueRef="CategoryValue_1tb5ag1" />
+  </process>
+  <category id="Category_04kjnxl">
+    <categoryValue id="CategoryValue_1yqwe1e" value="Group_1" />
+  </category>
+  <category id="Category_1d45ztk">
+    <categoryValue id="CategoryValue_1tb5ag1" value="Group_3" />
+  </category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1tjnmc5_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="272" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258" y="285" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_081habt_di" bpmnElement="Task_1">
+        <dc:Bounds x="450" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tkoq2s" bpmnElement="StartEvent_2">
+        <dc:Bounds x="272" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258" y="595" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_180enku" bpmnElement="Task_2">
+        <dc:Bounds x="450" y="530" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0842jx7_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="630" y="160" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02frjla_di" bpmnElement="StartEvent_3">
+        <dc:Bounds x="670" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="656" y="285" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1u2v734" bpmnElement="SubProcess_2" isExpanded="false">
+        <dc:Bounds x="1060" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ufk62a" bpmnElement="SubProcess_3" isExpanded="true">
+        <dc:Bounds x="630" y="470" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0g81v47" bpmnElement="StartEvent_5">
+        <dc:Bounds x="670" y="552" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="656" y="595" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n59xef" bpmnElement="SubProcess_4" isExpanded="false">
+        <dc:Bounds x="1060" y="530" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_12fzybf_di" bpmnElement="Group_1">
+        <dc:Bounds x="160" y="110" width="1090" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="685" y="80" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1buwmkz_di" bpmnElement="Group_2">
+        <dc:Bounds x="160" y="820" width="520" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_legacy1_di" bpmnElement="LegacyTask_1">
+        <dc:Bounds x="250" y="900" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_legacy2_di" bpmnElement="LegacyTask_2">
+        <dc:Bounds x="250" y="1250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1ax9hk9_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="308" y="260" />
+        <di:waypoint x="450" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="336" y="242" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1ccw3w0" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="308" y="570" />
+        <di:waypoint x="450" y="570" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="336" y="552" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0e6imtm" bpmnElement="Group_3">
+        <dc:Bounds x="1265" y="110" width="1090" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1790" y="80" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1kzkwt5">
+    <bpmndi:BPMNPlane id="BPMNPlane_0g3hwu1" bpmnElement="SubProcess_2">
+      <bpmndi:BPMNShape id="BPMNShape_151vlf1" bpmnElement="StartEvent_4">
+        <dc:Bounds x="194" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="203" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_12aj2xs">
+    <bpmndi:BPMNPlane id="BPMNPlane_1rfa5k5" bpmnElement="SubProcess_4">
+      <bpmndi:BPMNShape id="BPMNShape_1m57uqx" bpmnElement="StartEvent_6">
+        <dc:Bounds x="194" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="203" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/modeling/UpdateCategoryValueRefs.collaboration.bpmn
+++ b/test/spec/features/modeling/UpdateCategoryValueRefs.collaboration.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.50.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <collaboration id="Collaboration_1">
+    <participant id="Participant_1" name="Participant_1" processRef="Process_1" />
+    <group id="Group_1" categoryValueRef="CategoryValue_0qy0dl2" />
+  </collaboration>
+  <process id="Process_1" isExecutable="false">
+    <task id="Task_1" name="Task_1">
+      <categoryValueRef>CategoryValue_0qy0dl2</categoryValueRef>
+    </task>
+  </process>
+  <category id="Category_0ly6y5v">
+    <categoryValue id="CategoryValue_0qy0dl2" value="Group_1" />
+  </category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_0brfdm5_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="130" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ugl7ae_di" bpmnElement="Task_1">
+        <dc:Bounds x="260" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_1he2thi_di" bpmnElement="Group_1">
+        <dc:Bounds x="210" y="105" width="300" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="75" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/features/modeling/UpdateCategoryValueRefsSpec.js
+++ b/test/spec/features/modeling/UpdateCategoryValueRefsSpec.js
@@ -1,0 +1,795 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import bpmnCopyPasteModule from 'lib/features/copy-paste';
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+
+import copyPasteModule from 'diagram-js/lib/features/copy-paste';
+
+import {
+  getBusinessObject
+} from 'lib/util/ModelUtil';
+
+import {
+  find
+} from 'min-dash';
+
+
+describe('features/modeling - updateCategoryValueRefs', function() {
+
+  var diagramXML = require('./UpdateCategoryValueRefs.bpmn');
+
+  var flowElementsReferencingCategoryValue = [
+    'StartEvent_1',
+    'Task_1',
+    'SequenceFlow_1',
+    'SubProcess_1',
+    'StartEvent_3',
+    'SubProcess_2'
+  ];
+
+  var flowElementsNotReferencingCategoryValue = [
+    'StartEvent_2',
+    'Task_2',
+    'SequenceFlow_2',
+    'SubProcess_3',
+    'StartEvent_5',
+    'SubProcess_4'
+  ];
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      bpmnCopyPasteModule,
+      copyPasteModule,
+      coreModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('should synchronize flow element references', function() {
+
+    it('when moving a flow element into a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var task = elementRegistry.get('Task_2'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.moveShape(task, { x: 0, y: -250 });
+
+      // then
+      expectCategoryValueRefs([ 'Task_2' ], [ categoryValue ]);
+    }));
+
+
+    it('when moving a flow element out of a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var task = elementRegistry.get('Task_1');
+
+      // when
+      modeling.moveShape(task, { x: 0, y: 250 });
+
+      // then
+      expectCategoryValueRefs([ 'Task_1' ], []);
+    }));
+
+
+    it('when resizing a flow element into a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var task = elementRegistry.get('Task_2'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.resizeShape(task, {
+        x: task.x,
+        y: 300,
+        width: task.width,
+        height: task.height
+      });
+
+      // then
+      expectCategoryValueRefs([ 'Task_2' ], [ categoryValue ]);
+    }));
+
+
+    it('when moving a connection into a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var source = elementRegistry.get('StartEvent_2'),
+          target = elementRegistry.get('Task_2'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.moveShape(source, { x: 0, y: -250 });
+      modeling.moveShape(target, { x: 0, y: -250 });
+
+      // then
+      expectCategoryValueRefs([
+        'StartEvent_2',
+        'Task_2',
+        'SequenceFlow_2'
+      ], [ categoryValue ]);
+    }));
+
+
+    it('when moving a connection out of a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var source = elementRegistry.get('StartEvent_1'),
+          target = elementRegistry.get('Task_1');
+
+      // when
+      modeling.moveShape(source, { x: 0, y: 250 });
+      modeling.moveShape(target, { x: 0, y: 250 });
+
+      // then
+      expectCategoryValueRefs([
+        'StartEvent_1',
+        'Task_1',
+        'SequenceFlow_1'
+      ], []);
+    }));
+
+
+    it('when reconnecting a connection outside a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var connection = elementRegistry.get('SequenceFlow_1'),
+          target = elementRegistry.get('Task_2');
+
+      // when
+      modeling.reconnectEnd(connection, target, { x: target.x, y: target.y });
+
+      // then
+      expectCategoryValueRefs([ 'SequenceFlow_1' ], []);
+    }));
+
+
+    it('when creating a flow element inside a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var categoryValue = getCategoryValue('Group_1');
+
+      // when
+      var task = modeling.createShape(
+        { type: 'bpmn:Task' },
+        { x: 300, y: 300 },
+        elementRegistry.get('Process_1')
+      );
+
+      // then
+      expect(getBusinessObject(task).get('categoryValueRef')).to.eql([ categoryValue ]);
+    }));
+
+
+    it('when creating a connection inside a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var source = elementRegistry.get('StartEvent_1'),
+          target = elementRegistry.get('Task_1'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      var connection = modeling.connect(source, target);
+
+      // then
+      expect(getBusinessObject(connection).get('categoryValueRef')).to.eql([ categoryValue ]);
+    }));
+
+
+    it('when moving an external label', inject(function(elementRegistry, modeling) {
+
+      // given
+      var startEvent = elementRegistry.get('StartEvent_1'),
+          categoryValue = getCategoryValue('Group_1');
+
+      modeling.updateLabel(startEvent, 'Start event 1');
+
+      // when
+      modeling.moveShape(startEvent.label, { x: 1000, y: 0 });
+
+      // then
+      expect(getBusinessObject(startEvent).get('categoryValueRef')).to.eql([ categoryValue ]);
+    }));
+
+
+    it('when expanding and collapsing a subprocess inside a group', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_1'),
+            subProcess = elementRegistry.get('SubProcess_2'),
+            categoryValue = getCategoryValue('Group_1'),
+            child = getBusinessObject(subProcess).get('flowElements')[0];
+
+        // when
+        modeling.moveShape(group, { x: 10, y: 0 });
+
+        // then
+        expect(child.get('categoryValueRef')).to.be.empty;
+
+        // when
+        modeling.toggleCollapse(subProcess);
+
+        // then
+        expect(child.get('categoryValueRef')).to.eql([ categoryValue ]);
+
+        // when
+        modeling.toggleCollapse(subProcess);
+
+        // then
+        expect(child.get('categoryValueRef')).to.be.empty;
+      }
+    ));
+
+  });
+
+
+  describe('should synchronize group references', function() {
+
+    it('when creating an unlabeled group on top of flow elements', inject(
+      function(canvas, elementRegistry, modeling) {
+
+        // when
+        var group = modeling.createShape(
+          { type: 'bpmn:Group', width: 1090, height: 300 },
+          { x: 705, y: 570 },
+          canvas.getRootElement()
+        );
+
+        // then
+        // the group is categorized up front ...
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+
+        // ... so that visually enclosed flow elements can reference it
+        expectCategoryValueRefs(
+          flowElementsNotReferencingCategoryValue,
+          [ categoryValue ]
+        );
+      }
+    ));
+
+
+    it('when moving a group', inject(
+      function(commandStack, elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_1'),
+            categoryValue = getCategoryValue('Group_1');
+
+        // when
+        modeling.moveShape(group, { x: 0, y: 310 });
+
+        // then
+        expectCategoryValueRefs(flowElementsReferencingCategoryValue, []);
+        expectCategoryValueRefs(
+          flowElementsNotReferencingCategoryValue,
+          [ categoryValue ]
+        );
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectCategoryValueRefs(
+          flowElementsReferencingCategoryValue,
+          [ categoryValue ]
+        );
+        expectCategoryValueRefs(flowElementsNotReferencingCategoryValue, []);
+
+        // when
+        commandStack.redo();
+
+        // then
+        expectCategoryValueRefs(flowElementsReferencingCategoryValue, []);
+        expectCategoryValueRefs(
+          flowElementsNotReferencingCategoryValue,
+          [ categoryValue ]
+        );
+      }
+    ));
+
+
+    it('when moving a group together with its enclosed flow elements', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var categoryValue = getCategoryValue('Group_1');
+
+        // SubProcess_2 is a collapsed sub process, i.e. it has a plane sharing
+        // its business object; moving it along with the group must not strip the
+        // reference (cf. https://github.com/bpmn-io/bpmn-js/pull/2469)
+        var elements = [
+          'Group_1',
+          'StartEvent_1',
+          'Task_1',
+          'SubProcess_1',
+          'SubProcess_2'
+        ].map(function(id) {
+          return elementRegistry.get(id);
+        });
+
+        // when
+        modeling.moveElements(elements, { x: 100, y: 50 });
+
+        // then
+        // references remain unchanged as the relative position did not change
+        expectCategoryValueRefs(
+          flowElementsReferencingCategoryValue,
+          [ categoryValue ]
+        );
+      }
+    ));
+
+
+    it('when resizing a group', inject(function(elementRegistry, modeling) {
+
+      // given
+      var group = elementRegistry.get('Group_1');
+
+      // when
+      modeling.resizeShape(group, {
+        x: group.x,
+        y: group.y,
+        width: group.width,
+        height: 100
+      });
+
+      // then
+      expectCategoryValueRefs([ 'Task_1' ], []);
+    }));
+
+
+    it('when resizing a group to include more flow elements', inject(function(elementRegistry, modeling) {
+
+      // given
+      var group = elementRegistry.get('Group_1'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.resizeShape(group, {
+        x: group.x,
+        y: group.y,
+        width: group.width,
+        height: 610
+      });
+
+      // then
+      expectCategoryValueRefs(
+        flowElementsReferencingCategoryValue,
+        [ categoryValue ]
+      );
+      expectCategoryValueRefs(
+        flowElementsNotReferencingCategoryValue,
+        [ categoryValue ]
+      );
+    }));
+
+
+    it('when moving a group so that a flow element is inside multiple groups', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var task = elementRegistry.get('Task_1'),
+            group = elementRegistry.get('Group_3'),
+            groupCategoryValue = getCategoryValue('Group_1'),
+            overlappingGroupCategoryValue = getCategoryValue('Group_3');
+
+        // when
+        modeling.moveShape(group, { x: -1100, y: 5 });
+
+        // then
+        expect(getBusinessObject(task).get('categoryValueRef')).to.eql([
+          groupCategoryValue,
+          overlappingGroupCategoryValue
+        ]);
+
+        // when
+        modeling.moveShape(group, { x: 1100, y: 0 });
+
+        // then
+        expect(getBusinessObject(task).get('categoryValueRef')).to.eql([
+          groupCategoryValue
+        ]);
+      }
+    ));
+
+
+    it('when adding a category value to a group', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_2');
+
+        // when
+        modeling.updateLabel(group, 'Group 2');
+
+        // then
+        var categoryValue = getCategoryValue('Group_2');
+
+        expect(categoryValue).to.exist;
+        expectCategoryValueRefs([ 'LegacyTask_1' ], [ categoryValue ]);
+      }
+    ));
+
+
+    it('when removing a group label', inject(function(elementRegistry, modeling) {
+
+      // given
+      var group = elementRegistry.get('Group_1'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.updateLabel(group, null);
+
+      // then
+      expect(group.label).not.to.exist;
+      expect(getBusinessObject(group).get('categoryValueRef')).to.equal(categoryValue);
+      expectCategoryValueRefs(
+        flowElementsReferencingCategoryValue,
+        [ categoryValue ]
+      );
+    }));
+
+
+    it('when deleting a group', inject(
+      function(bpmnjs, commandStack, elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_1'),
+            categoryValue = getCategoryValue('Group_1'),
+            category = categoryValue.$parent,
+            definitions = bpmnjs.getDefinitions(),
+            collapsedSubProcessChild = getBusinessObject(
+              elementRegistry.get('SubProcess_2')
+            ).get('flowElements')[0];
+
+        // when
+        modeling.removeShape(group);
+
+        // then
+        expectCategoryValueRefs(flowElementsReferencingCategoryValue, []);
+        expect(collapsedSubProcessChild.get('categoryValueRef')).to.be.empty;
+        expect(category.get('categoryValue')).to.be.empty;
+        expect(definitions.get('rootElements')).not.to.include(category);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expectCategoryValueRefs(
+          flowElementsReferencingCategoryValue,
+          [ categoryValue ]
+        );
+        expect(collapsedSubProcessChild.get('categoryValueRef')).to.be.empty;
+        expect(definitions.get('rootElements')).to.include(category);
+
+        // when
+        commandStack.redo();
+
+        // then
+        expectCategoryValueRefs(flowElementsReferencingCategoryValue, []);
+        expect(collapsedSubProcessChild.get('categoryValueRef')).to.be.empty;
+        expect(definitions.get('rootElements')).not.to.include(category);
+      }
+    ));
+
+  });
+
+
+  describe('should auto-heal groups without a category value', function() {
+
+    // Group_2 is modeled without a category value but visually encloses
+    // LegacyTask_1 (as in legacy diagrams); interacting with its contents must
+    // create a category value on the fly so the elements can be categorized
+    // (cf. https://github.com/bpmn-io/bpmn-js/pull/2469)
+
+    it('when moving a flow element inside the group', inject(
+      function(bpmnjs, elementRegistry, modeling) {
+
+        // given
+        var task = elementRegistry.get('LegacyTask_1'),
+            group = elementRegistry.get('Group_2'),
+            definitions = bpmnjs.getDefinitions();
+
+        // assume
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+
+        // when
+        modeling.moveShape(task, { x: 10, y: 0 });
+
+        // then
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+        expect(categoryValue.$parent).to.exist;
+        expect(definitions.get('rootElements')).to.include(categoryValue.$parent);
+
+        // the enclosed flow element is categorized
+        expectCategoryValueRefs([ 'LegacyTask_1' ], [ categoryValue ]);
+      }
+    ));
+
+
+    it('should not heal from an external label', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_2'),
+            startEvent = elementRegistry.get('StartEvent_2');
+
+        modeling.updateLabel(startEvent, 'Start event 2');
+
+        // when
+        modeling.moveShape(startEvent.label, { x: 0, y: 350 });
+
+        // then
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+      }
+    ));
+
+
+    it('when moving a flow element into the group from outside', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var task = elementRegistry.get('LegacyTask_2'),
+            group = elementRegistry.get('Group_2');
+
+        // assume
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+
+        // when
+        // move LegacyTask_2 up into Group_2's area
+        modeling.moveShape(task, { x: 0, y: -300 });
+
+        // then
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+
+        // both the moved and the already enclosed flow element are categorized
+        expectCategoryValueRefs(
+          [ 'LegacyTask_1', 'LegacyTask_2' ],
+          [ categoryValue ]
+        );
+      }
+    ));
+
+
+    it('should undo/redo healing', inject(
+      function(bpmnjs, commandStack, elementRegistry, modeling) {
+
+        // given
+        var task = elementRegistry.get('LegacyTask_1'),
+            group = elementRegistry.get('Group_2'),
+            definitions = bpmnjs.getDefinitions();
+
+        // when
+        modeling.moveShape(task, { x: 10, y: 0 });
+
+        var categoryValue = getBusinessObject(group).get('categoryValueRef'),
+            category = categoryValue.$parent;
+
+        // when
+        commandStack.undo();
+
+        // then
+        // healing is reverted
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+        expect(definitions.get('rootElements')).not.to.include(category);
+        expectCategoryValueRefs([ 'LegacyTask_1' ], []);
+
+        // when
+        commandStack.redo();
+
+        // then
+        expect(getBusinessObject(group).get('categoryValueRef')).to.equal(categoryValue);
+        expect(definitions.get('rootElements')).to.include(category);
+        expectCategoryValueRefs([ 'LegacyTask_1' ], [ categoryValue ]);
+      }
+    ));
+
+
+    it('when creating a flow element inside the group', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_2');
+
+        // assume
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+
+        // when
+        var task = modeling.createShape(
+          { type: 'bpmn:Task' },
+          { x: 400, y: 960 },
+          elementRegistry.get('Process_1')
+        );
+
+        // then
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+        expect(getBusinessObject(task).get('categoryValueRef')).to.eql([ categoryValue ]);
+      }
+    ));
+
+
+    it('when resizing the group to include a flow element', inject(
+      function(bpmnjs, elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_2'),
+            definitions = bpmnjs.getDefinitions();
+
+        // assume
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+
+        // when
+        // grow Group_2 downwards so that it also encloses LegacyTask_2
+        modeling.resizeShape(group, {
+          x: group.x,
+          y: group.y,
+          width: group.width,
+          height: 610
+        });
+
+        // then
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+        expect(definitions.get('rootElements')).to.include(categoryValue.$parent);
+
+        // both enclosed flow elements are categorized
+        expectCategoryValueRefs(
+          [ 'LegacyTask_1', 'LegacyTask_2' ],
+          [ categoryValue ]
+        );
+      }
+    ));
+
+
+    it('when moving the group onto a flow element', inject(
+      function(elementRegistry, modeling) {
+
+        // given
+        var group = elementRegistry.get('Group_2');
+
+        // assume
+        expect(getBusinessObject(group).get('categoryValueRef')).not.to.exist;
+
+        // when
+        // move Group_2 down so that it now encloses LegacyTask_2 instead of
+        // LegacyTask_1
+        modeling.moveShape(group, { x: 0, y: 300 });
+
+        // then
+        var categoryValue = getBusinessObject(group).get('categoryValueRef');
+
+        expect(categoryValue).to.exist;
+
+        expectCategoryValueRefs([ 'LegacyTask_2' ], [ categoryValue ]);
+        expectCategoryValueRefs([ 'LegacyTask_1' ], []);
+      }
+    ));
+
+  });
+
+
+  describe('should copy category values', function() {
+
+    it('when copying and pasting a group', inject(function(canvas, copyPaste, elementRegistry) {
+
+      // given
+      var group = elementRegistry.get('Group_1'),
+          task = elementRegistry.get('Task_1'),
+          sourceCategoryValue = getCategoryValue('Group_1');
+
+      copyPaste.copy([ group, task ]);
+
+      // when
+      var pastedElements = copyPaste.paste({
+        element: canvas.getRootElement(),
+        point: { x: 2500, y: 800 }
+      });
+
+      // then
+      var pastedGroup = find(pastedElements, function(element) {
+            return element.type === 'bpmn:Group';
+          }),
+          pastedTask = find(pastedElements, function(element) {
+            return element.type === 'bpmn:Task';
+          }),
+          categoryValue = getBusinessObject(pastedGroup).get('categoryValueRef');
+
+      expect(categoryValue).not.to.equal(sourceCategoryValue);
+      expect(getBusinessObject(pastedTask).get('categoryValueRef')).to.eql([ categoryValue ]);
+      expect(getBusinessObject(task).get('categoryValueRef')).to.eql([ sourceCategoryValue ]);
+    }));
+
+  });
+
+});
+
+
+describe('features/modeling - categoryValueRefs in collaboration', function() {
+
+  var diagramXML = require('./UpdateCategoryValueRefs.collaboration.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule
+    ]
+  }));
+
+
+  it('should synchronize participant flow elements when a group is moved', inject(
+    function(elementRegistry, modeling) {
+
+      // given
+      var group = elementRegistry.get('Group_1'),
+          categoryValue = getCategoryValue('Group_1');
+
+      // when
+      modeling.moveShape(group, { x: 500, y: 0 });
+
+      // then
+      expectCategoryValueRefs([ 'Task_1' ], []);
+
+      // when
+      modeling.moveShape(group, { x: -500, y: 0 });
+
+      // then
+      expectCategoryValueRefs([ 'Task_1' ], [ categoryValue ]);
+    }
+  ));
+
+});
+
+/**
+ * @param {string} id
+ *
+ * @return {import('diagram-js/lib/model').Element}
+ */
+function findElement(id) {
+
+  return getBpmnJS().invoke((elementRegistry) => {
+
+    const element = elementRegistry.get(id);
+
+    expect(element, `element <#${id}>`).to.exist;
+
+    return element;
+  });
+}
+
+/**
+ * @param {string} groupId
+ *
+ * @return {any} category value ref
+ */
+function getCategoryValue(groupId) {
+  return getBusinessObject(findElement(groupId)).get('categoryValueRef');
+}
+
+function expectCategoryValueRefs(elementIds, expectedCategoryValueRefs) {
+
+  for (const elementId of elementIds) {
+    var businessObject = getBusinessObject(findElement(elementId));
+
+    expect(businessObject.get('categoryValueRef')).to.eql(expectedCategoryValueRefs);
+  }
+}

--- a/test/spec/features/modeling/behavior/CategoryRootElementReferenceBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CategoryRootElementReferenceBehaviorSpec.js
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapModeler,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+
+import {
+  getBusinessObject
+} from 'lib/util/ModelUtil';
+
+
+describe('features/modeling - category root element reference behavior', function() {
+
+  var diagramXML = require('./GroupBehaviorSpec.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('should add unlinked categories', function() {
+
+    var category,
+        categoryValue,
+        group;
+
+    beforeEach(inject(function(bpmnFactory, canvas, elementFactory, modeling) {
+
+      // given
+      category = bpmnFactory.create('bpmn:Category');
+      categoryValue = bpmnFactory.create('bpmn:CategoryValue');
+      categoryValue.$parent = category;
+
+      group = elementFactory.createShape({ type: 'bpmn:Group' });
+      getBusinessObject(group).categoryValueRef = categoryValue;
+
+      // when
+      group = modeling.createShape(group, { x: 100, y: 100 }, canvas.getRootElement());
+    }));
+
+
+    it('<do>', function() {
+
+      // then
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    });
+
+
+    it('<undo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).not.to.exist;
+      expect(category.get('categoryValue')).not.to.include(categoryValue);
+      expectNoRootElement(category);
+    }));
+
+
+    it('<redo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).to.equal(categoryValue);
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    }));
+
+  });
+
+
+  describe('should add label categories', function() {
+
+    var category,
+        categoryValue,
+        group;
+
+    beforeEach(inject(function(elementRegistry, modeling) {
+
+      // given
+      group = elementRegistry.get('Group_NO_CATEGORY_VALUE');
+
+      // when
+      modeling.updateLabel(group, 'Group');
+
+      categoryValue = getBusinessObject(group).categoryValueRef;
+      category = categoryValue.$parent;
+    }));
+
+
+    it('<do>', function() {
+
+      // then
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    });
+
+
+    it('<undo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).not.to.exist;
+      expect(category.get('categoryValue')).not.to.include(categoryValue);
+      expectNoRootElement(category);
+    }));
+
+
+    it('<redo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).to.equal(categoryValue);
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    }));
+
+  });
+
+
+  describe('should remove unreferenced categories', function() {
+
+    var category,
+        categoryValue,
+        group;
+
+    beforeEach(inject(function(elementRegistry, modeling) {
+
+      // given
+      group = elementRegistry.get('Group_4');
+      categoryValue = getBusinessObject(group).categoryValueRef;
+      category = categoryValue.$parent;
+
+      // when
+      modeling.removeShape(group);
+    }));
+
+
+    it('<do>', function() {
+
+      // then
+      expect(category.get('categoryValue')).not.to.include(categoryValue);
+      expectNoRootElement(category);
+    });
+
+
+    it('<undo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).to.equal(categoryValue);
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    }));
+
+
+    it('<redo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(category.get('categoryValue')).not.to.include(categoryValue);
+      expectNoRootElement(category);
+    }));
+
+  });
+
+});
+
+
+// helpers //////////
+
+function expectRootElement(category) {
+  expect(hasRootElement(category)).to.be.true;
+}
+
+function expectNoRootElement(category) {
+  expect(hasRootElement(category)).to.be.false;
+}
+
+function hasRootElement(category) {
+  return getBpmnJS().getDefinitions().get('rootElements').includes(category);
+}

--- a/test/spec/features/modeling/behavior/CategoryRootElementReferenceBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/CategoryRootElementReferenceBehaviorSpec.js
@@ -190,6 +190,76 @@ describe('features/modeling - category root element reference behavior', functio
 });
 
 
+describe('features/modeling - category root element reference behavior (ref updates)', function() {
+
+  var diagramXML = require('../UpdateCategoryValueRefs.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('should maintain healed categories', function() {
+
+    var category,
+        categoryValue,
+        group;
+
+    beforeEach(inject(function(elementRegistry, modeling) {
+
+      // given
+      group = elementRegistry.get('Group_2');
+      var task = elementRegistry.get('LegacyTask_1');
+
+      // when
+      modeling.moveShape(task, { x: 10, y: 0 });
+
+      categoryValue = getBusinessObject(group).categoryValueRef;
+      category = categoryValue.$parent;
+    }));
+
+
+    it('<do>', function() {
+
+      // then
+      expect(categoryValue).to.exist;
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    });
+
+
+    it('<undo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).not.to.exist;
+      expect(category.get('categoryValue')).not.to.include(categoryValue);
+      expectNoRootElement(category);
+    }));
+
+
+    it('<redo>', inject(function(commandStack) {
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(getBusinessObject(group).categoryValueRef).to.equal(categoryValue);
+      expect(category.get('categoryValue')).to.include(categoryValue);
+      expectRootElement(category);
+    }));
+
+  });
+
+});
+
+
 // helpers //////////
 
 function expectRootElement(category) {

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.bpmn
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.bpmn
@@ -9,6 +9,7 @@
   </category>
   <process id="Process_1" isExecutable="false">
     <subProcess id="Subprocess_1" />
+    <task id="LegacyTask_1" />
     <group id="Group_1" categoryValueRef="CategoryValue_1" />
     <group id="Group_2" categoryValueRef="CategoryValue_1" />
     <group id="Group_3" categoryValueRef="CategoryValue_2" />
@@ -37,6 +38,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_NO_CATEGORY_VALUE_di" bpmnElement="Group_NO_CATEGORY_VALUE">
         <omgdc:Bounds x="610" y="320" width="199" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="LegacyTask_1_di" bpmnElement="LegacyTask_1">
+        <omgdc:Bounds x="650" y="370" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -249,6 +249,81 @@ describe('features/modeling/behavior - groups', function() {
   });
 
 
+  describe('auto-healing', function() {
+
+    [ 'move', 'resize' ].forEach(function(type) {
+
+      describe(`should heal group on ${ type }`, function() {
+
+        var group,
+            groupBo,
+            categoryValueBo,
+            categoryBo;
+
+        beforeEach(inject(function(elementRegistry, modeling) {
+
+          // given
+          group = elementRegistry.get('Group_NO_CATEGORY_VALUE');
+          groupBo = getBusinessObject(group);
+
+          // assume
+          expect(groupBo.categoryValueRef).not.to.exist;
+
+          // when
+          if (type === 'move') {
+            modeling.moveShape(group, { x: 10, y: 0 });
+          } else {
+            modeling.resizeShape(group, {
+              x: group.x,
+              y: group.y,
+              width: group.width,
+              height: group.height + 10
+            });
+          }
+
+          categoryValueBo = groupBo.categoryValueRef;
+          categoryBo = categoryValueBo.$parent;
+        }));
+
+
+        it('<do>', function() {
+
+          // then
+          expect(categoryValueBo).to.exist;
+          expectRootElement(categoryBo);
+        });
+
+
+        it('<undo>', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+
+          // then
+          expect(groupBo.categoryValueRef).not.to.exist;
+          expectNoRootElement(categoryBo);
+        }));
+
+
+        it('<redo>', inject(function(commandStack) {
+
+          // when
+          commandStack.undo();
+          commandStack.redo();
+
+          // then
+          expect(groupBo.categoryValueRef).to.equal(categoryValueBo);
+          expect(groupBo.categoryValueRef.$parent).to.equal(categoryBo);
+          expectRootElement(categoryBo);
+        }));
+
+      });
+
+    });
+
+  });
+
+
   describe('deletion', function() {
 
     it('should NOT remove CategoryValue if still referenced', inject(

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import {
   bootstrapModeler,
+  getBpmnJS,
   inject
 } from 'test/TestHelper';
 
@@ -61,9 +62,9 @@ describe('features/modeling/behavior - groups', function() {
     ));
 
 
-    describe('should NOT create Category for new Group', function() {
+    describe('should create Category for new Group', function() {
 
-      it('execute', inject(function(canvas, elementFactory, modeling) {
+      it('execute', inject(function(canvas, elementFactory, modeling, bpmnjs) {
 
         // given
         var root = canvas.getRootElement();
@@ -71,10 +72,16 @@ describe('features/modeling/behavior - groups', function() {
         // when
         var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
             groupBo = getBusinessObject(group),
-            categoryValue = groupBo.categoryValueRef;
+            categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = categoryValueBo?.$parent;
 
         // then
-        expect(categoryValue).not.to.exist;
+        // a category value is created up front so that visually enclosed
+        // elements can be categorized even before the group is labeled
+        expect(categoryValueBo).to.exist;
+        expect(categoryBo).to.exist;
+
+        expectRootElement(categoryBo);
       }));
 
 
@@ -85,18 +92,20 @@ describe('features/modeling/behavior - groups', function() {
 
         // when
         var group = modeling.createShape({ type: 'bpmn:Group' }, { x: 100, y: 100 }, root),
-            groupBo = getBusinessObject(group);
+            groupBo = getBusinessObject(group),
+            categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = groupBo.categoryValueRef?.$parent;
 
         commandStack.undo();
 
-        var categoryValue = groupBo.categoryValueRef;
-
         // then
-        expect(categoryValue).not.to.exist;
+        expect(groupBo.categoryValueRef).not.to.exist;
+        expect(categoryValueBo).to.exist;
+        expect(categoryBo).to.exist;
       }));
 
 
-      it('redo', inject(function(canvas, elementFactory, modeling, commandStack) {
+      it('redo', inject(function(canvas, elementFactory, modeling, commandStack, bpmnjs) {
 
         // given
         var root = canvas.getRootElement();
@@ -108,8 +117,14 @@ describe('features/modeling/behavior - groups', function() {
         commandStack.undo();
         commandStack.redo();
 
+        var categoryValueBo = groupBo.categoryValueRef;
+        var categoryBo = groupBo.categoryValueRef?.$parent;
+
         // then
-        expect(groupBo.categoryValueRef).not.to.exist;
+        expect(categoryValueBo).to.exist;
+        expect(categoryBo).to.exist;
+
+        expectRootElement(categoryBo);
       }));
 
     });
@@ -159,10 +174,17 @@ describe('features/modeling/behavior - groups', function() {
 
       it('<undo>', inject(function(commandStack) {
 
+        // given
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = groupBo.categoryValueRef?.$parent;
+
         // when
         commandStack.undo();
 
         // then
+        expect(groupBo.categoryValueRef).not.to.exist;
+        expect(categoryValueBo).to.exist;
+        expect(categoryBo).to.exist;
         expect(rootElements).to.have.length(3);
       }));
 
@@ -170,16 +192,16 @@ describe('features/modeling/behavior - groups', function() {
       it('<redo>', inject(function(commandStack) {
 
         // given
-        var categoryValue = groupBo.categoryValueRef,
-            category = categoryValue.$parent;
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = groupBo.categoryValueRef?.$parent;
 
         // when
         commandStack.undo();
         commandStack.redo();
 
         // then
-        expect(groupBo.categoryValueRef).to.equal(categoryValue);
-        expect(groupBo.categoryValueRef.$parent).to.equal(category);
+        expect(groupBo.categoryValueRef).to.equal(categoryValueBo);
+        expect(groupBo.categoryValueRef.$parent).to.equal(categoryBo);
 
         expect(rootElements).to.have.length(4);
       }));
@@ -271,20 +293,18 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
-            groupBo = getBusinessObject(groupShape),
-            root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent;
+            groupBo = getBusinessObject(groupShape);
 
-        var categoryValue = groupBo.categoryValueRef,
-            category = categoryValue.$parent;
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = categoryValueBo.$parent;
 
         // when
         modeling.removeShape(groupShape);
 
         // then
-        expect(category.get('categoryValue')).not.to.contain(categoryValue);
+        expect(categoryBo.get('categoryValue')).not.to.contain(categoryValueBo);
 
-        expect(definitions.get('rootElements')).not.to.contain(category);
+        expectNoRootElement(categoryBo);
       }));
 
 
@@ -292,12 +312,10 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
-            groupBo = getBusinessObject(groupShape),
-            root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent;
+            groupBo = getBusinessObject(groupShape);
 
-        var categoryValue = groupBo.categoryValueRef,
-            category = categoryValue.$parent;
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = categoryValueBo.$parent;
 
         // when
         modeling.removeShape(groupShape);
@@ -305,8 +323,9 @@ describe('features/modeling/behavior - groups', function() {
         commandStack.undo();
 
         // then
-        expect(category.get('categoryValue')).to.include(categoryValue);
-        expect(definitions.get('rootElements')).to.include(category);
+        expect(categoryBo.get('categoryValue')).to.include(categoryValueBo);
+
+        expectRootElement(categoryBo);
       }));
 
 
@@ -314,12 +333,10 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var groupShape = elementRegistry.get('Group_4'),
-            groupBo = getBusinessObject(groupShape),
-            root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent;
+            groupBo = getBusinessObject(groupShape);
 
-        var categoryValue = groupBo.categoryValueRef,
-            category = categoryValue.$parent;
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = categoryValueBo.$parent;
 
         // when
         modeling.removeShape(groupShape);
@@ -328,8 +345,9 @@ describe('features/modeling/behavior - groups', function() {
         commandStack.redo();
 
         // then
-        expect(category.get('categoryValue')).not.to.include(categoryValue);
-        expect(definitions.get('rootElements')).not.to.include(category);
+        expect(categoryBo.get('categoryValue')).not.to.include(categoryValueBo);
+
+        expectNoRootElement(categoryBo);
       }));
 
     });
@@ -424,10 +442,15 @@ describe('features/modeling/behavior - groups', function() {
         // when
         modeling.updateLabel(group, 'Foo bar');
 
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = groupBo.categoryValueRef?.$parent;
+
         commandStack.undo();
 
         // then
         expect(groupBo.categoryValueRef).not.to.exist;
+        expect(categoryValueBo).to.exist;
+        expect(categoryBo).to.exist;
       }));
 
 
@@ -443,14 +466,20 @@ describe('features/modeling/behavior - groups', function() {
         // when
         modeling.updateLabel(group, 'Foo bar');
 
+        var categoryValueBo = groupBo.categoryValueRef,
+            categoryBo = groupBo.categoryValueRef?.$parent;
+
         commandStack.undo();
         commandStack.redo();
 
         // then
         expect(groupBo.categoryValueRef).to.exist;
-        expect(groupBo.categoryValueRef.value).to.eql('Foo bar');
+        expect(groupBo.categoryValueRef).to.equal(categoryValueBo);
+        expect(groupBo.categoryValueRef.$parent).to.equal(categoryBo);
 
-        expect(groupBo.categoryValueRef.$parent).to.exist;
+        expect(categoryValueBo.value).to.eql('Foo bar');
+
+        expectRootElement(categoryBo);
       }));
 
     });
@@ -458,3 +487,18 @@ describe('features/modeling/behavior - groups', function() {
   });
 
 });
+
+
+// helpers /////////////
+
+function expectNoRootElement(moddleElement) {
+  const definitions = getBpmnJS().getDefinitions();
+
+  expect(definitions.get('rootElements')).not.to.include(moddleElement);
+}
+
+function expectRootElement(moddleElement) {
+  const definitions = getBpmnJS().getDefinitions();
+
+  expect(definitions.get('rootElements')).to.include(moddleElement);
+}

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -132,15 +132,19 @@ describe('features/modeling/behavior - groups', function() {
     });
 
 
-    describe('should paste with Category', function() {
+    describe('should paste with copied Category', function() {
 
-      var groupBo, rootElements;
+      var groupBo,
+          sourceGroupBo,
+          rootElements;
 
       beforeEach(inject(function(canvas, copyPaste, elementRegistry) {
 
         // given
         var group = elementRegistry.get('Group_1'),
             rootElement = canvas.getRootElement();
+
+        sourceGroupBo = getBusinessObject(group);
 
         copyPaste.copy(group);
 
@@ -169,6 +173,9 @@ describe('features/modeling/behavior - groups', function() {
         expect(groupBo.categoryValueRef).to.exist;
         expect(groupBo.categoryValueRef.$parent).to.exist;
         expect(groupBo.categoryValueRef.value).to.equal('Value 1');
+        expect(groupBo.categoryValueRef).not.to.equal(sourceGroupBo.categoryValueRef);
+        expect(groupBo.categoryValueRef.$parent).not.to.equal(sourceGroupBo.categoryValueRef.$parent);
+
         expect(rootElements).to.have.length(4);
       });
 

--- a/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/GroupBehaviorSpec.js
@@ -41,23 +41,25 @@ describe('features/modeling/behavior - groups', function() {
 
         // given
         var group1 = elementRegistry.get('Group_1'),
-            categoryValue = getBusinessObject(group1).categoryValueRef,
+            categoryValueBo = getBusinessObject(group1).categoryValueRef,
             root = canvas.getRootElement(),
-            definitions = getBusinessObject(root).$parent,
-            originalSize = definitions.get('rootElements').length;
+            definitionsBo = getBusinessObject(root).$parent;
+
+        var originalRootElementCount = definitionsBo.get('rootElements').length;
 
         var group = elementFactory.createShape({ type: 'bpmn:Group' });
 
-        getBusinessObject(group).categoryValueRef = categoryValue;
+        // re-using existing categoryValue
+        getBusinessObject(group).categoryValueRef = categoryValueBo;
 
         // when
         var groupShape = modeling.createShape(group, { x: 100, y: 100 }, root),
-            categoryValueRef = getBusinessObject(groupShape).categoryValueRef;
+            groupBo = getBusinessObject(groupShape);
 
         // then
-        expect(categoryValueRef).to.eql(categoryValue);
+        expect(groupBo.categoryValueRef).to.eql(categoryValueBo);
 
-        expect(definitions.get('rootElements')).to.have.length(originalSize);
+        expect(definitionsBo.get('rootElements')).to.have.length(originalRootElementCount);
       }
     ));
 
@@ -167,7 +169,6 @@ describe('features/modeling/behavior - groups', function() {
         expect(groupBo.categoryValueRef).to.exist;
         expect(groupBo.categoryValueRef.$parent).to.exist;
         expect(groupBo.categoryValueRef.value).to.equal('Value 1');
-
         expect(rootElements).to.have.length(4);
       });
 


### PR DESCRIPTION
### Proposed Changes

`categoryValueRef` was already used by `bpmn:Group` elements to reference the category value they represent. Other elements did not have that reference which made it impossible to tell what elements are part of a group without the DI. This pull request adds support for `categoryValueRef` for elements visually inside groups.

<img width="1446" height="1026" alt="image" src="https://github.com/user-attachments/assets/ec90a388-42ac-4675-871b-179bf5c6d4d2" />

```xml
<bpmn:process id="Process_1" isExecutable="true">
  <bpmn:task id="Task_1" name="Task_1">
    <bpmn:categoryValueRef>CategoryValue_1</bpmn:categoryValueRef>
  </bpmn:task>
  <bpmn:task id="Task_2" name="Task_2" />
  <bpmn:group id="Group_1" categoryValueRef="CategoryValue_1" />
</bpmn:process>
<bpmn:category id="Category_1">
  <bpmn:categoryValue id="CategoryValue_1" value="Group_1" />
</bpmn:category>
```

* Add a reference to a group's category value to flow elements visually enclosed by it.
* Remove the reference when an element is moved out of the group or the group is removed.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
