### PR TITLE
fix(export): pad exported SVG to avoid clipping strokes

### DIFF
--- a/lib/BaseViewer.js
+++ b/lib/BaseViewer.js
@@ -14,6 +14,7 @@ import {
 import {
   domify,
   assignStyle,
+  classes as domClasses,
   query as domQuery,
   remove as domRemove
 } from 'min-dom';
@@ -30,6 +31,23 @@ import inherits from 'inherits-browser';
 import {
   importBpmnDiagram
 } from './import/Importer';
+
+/**
+ * Padding added around the diagram bounds on SVG export.
+ *
+ * `getBBox` returns the geometry bounds only, excluding element strokes, so
+ * without padding strokes at the diagram edges get clipped. Historically this
+ * padding was provided implicitly by element outlines, which diagram-js now
+ * creates lazily (diagram-js@15.19, bpmn-io/diagram-js#1064).
+ */
+const EXPORT_PADDING = 5;
+
+/**
+ * Class set on the canvas container to hide element outlines, which diagram-js
+ * excludes from rendering while present. Applied when measuring the export
+ * bounds so lazily created outlines do not skew them.
+ */
+const OUTLINE_HIDDEN_CLS = 'djs-outline-hidden';
 
 /**
  * @template T
@@ -481,15 +499,31 @@ BaseViewer.prototype.saveSVG = async function saveSVG() {
     const contents = innerSVG(contentNode),
           defs = defsNode ? '<defs>' + innerSVG(defsNode) + '</defs>' : '';
 
-    const bbox = contentNode.getBBox();
+    // hide outlines so they do not skew the measured bounds
+    const container = canvas.getContainer();
+
+    domClasses(container).add(OUTLINE_HIDDEN_CLS);
+
+    let bbox;
+
+    try {
+      bbox = contentNode.getBBox();
+    } finally {
+      domClasses(container).remove(OUTLINE_HIDDEN_CLS);
+    }
+
+    const x = bbox.x - EXPORT_PADDING,
+          y = bbox.y - EXPORT_PADDING,
+          width = bbox.width + EXPORT_PADDING * 2,
+          height = bbox.height + EXPORT_PADDING * 2;
 
     svg =
       '<?xml version="1.0" encoding="utf-8"?>\n' +
       '<!-- created with bpmn-js / http://bpmn.io -->\n' +
       '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
       '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
-      'width="' + bbox.width + '" height="' + bbox.height + '" ' +
-      'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" version="1.1">' +
+      'width="' + width + '" height="' + height + '" ' +
+      'viewBox="' + x + ' ' + y + ' ' + width + ' ' + height + '" version="1.1">' +
       defs + contents +
       '</svg>';
   } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.23.0",
+        "diagram-js": "^15.23.2",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3927,9 +3927,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.23.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.0.tgz",
-      "integrity": "sha512-cCgL+4Ep0xrLe6TtdvRVgo6bWYjUbrQg+ES/9rpltqmTD2YaPoC+NYcRsKYw/fDO+1RN0q16NzErP1svVZhNQg==",
+      "version": "15.23.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.2.tgz",
+      "integrity": "sha512-J/CSCKSq62z7aYr643sf+IBiBv3oaJVJc0PivNi09Wdnd/aUOGpIl8PC0HrJn8sLC/lVNtd80MyscbSg2xDZmA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.23.0",
+    "diagram-js": "^15.23.2",
     "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",

--- a/test/spec/ViewerSpec.js
+++ b/test/spec/ViewerSpec.js
@@ -1418,6 +1418,13 @@ describe('Viewer', function() {
       return new Date().getTime();
     }
 
+    function getViewBox(svg) {
+      return new DOMParser()
+        .parseFromString(svg, 'image/svg+xml')
+        .querySelector('svg')
+        .getAttribute('viewBox');
+    }
+
     function validSVG(svg) {
       var expectedStart = '<?xml version="1.0" encoding="utf-8"?>';
       var expectedEnd = '</svg>';
@@ -1471,6 +1478,95 @@ describe('Viewer', function() {
 
         // then
         expect(validSVG(svg)).to.be.true;
+      });
+    });
+
+
+    it('should pad viewport to not clip strokes at diagram bounds', function() {
+
+      // given
+      var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      return createViewer(container, Viewer, xml).then(function(result) {
+
+        var err = result.error;
+        var viewer = result.viewer;
+
+        if (err) {
+          throw err;
+        }
+
+        var bbox = viewer.get('canvas').getActiveLayer().getBBox();
+
+        // when
+        return viewer.saveSVG().then(function(result) {
+          return { bbox: bbox, svg: result.svg };
+        });
+      }).then(function(result) {
+
+        var bbox = result.bbox;
+
+        var svgNode = new DOMParser()
+          .parseFromString(result.svg, 'image/svg+xml')
+          .querySelector('svg');
+
+        // then
+        expect(svgNode.getAttribute('width')).to.eql(String(bbox.width + 10));
+        expect(svgNode.getAttribute('height')).to.eql(String(bbox.height + 10));
+        expect(svgNode.getAttribute('viewBox')).to.eql(
+          [ bbox.x - 5, bbox.y - 5, bbox.width + 10, bbox.height + 10 ].join(' ')
+        );
+      });
+    });
+
+
+    it('should ignore outlines when computing export bounds', function() {
+
+      // given
+      var xml = require('../fixtures/bpmn/simple.bpmn');
+
+      var viewer;
+
+      return createViewer(container, Viewer, xml).then(function(result) {
+
+        if (result.error) {
+          throw result.error;
+        }
+
+        viewer = result.viewer;
+
+        // export bounds without any outline present
+        return viewer.saveSVG();
+      }).then(function(withoutOutline) {
+
+        var elementRegistry = viewer.get('elementRegistry');
+
+        var element = elementRegistry.get('EndEvent_1'),
+            gfx = elementRegistry.getGraphics(element);
+
+        // simulate a lazily created outline (as after hover / selection),
+        // extending well beyond the diagram bounds
+        var outline = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+
+        outline.setAttribute('class', 'djs-outline');
+        outline.setAttribute('x', -1000);
+        outline.setAttribute('y', -1000);
+        outline.setAttribute('width', element.width + 2000);
+        outline.setAttribute('height', element.height + 2000);
+
+        gfx.appendChild(outline);
+
+        // when
+        return viewer.saveSVG().then(function(withOutline) {
+          return {
+            withoutOutline: withoutOutline.svg,
+            withOutline: withOutline.svg
+          };
+        });
+      }).then(function(result) {
+
+        // then
+        expect(getViewBox(result.withOutline)).to.eql(getViewBox(result.withoutOutline));
       });
     });
 


### PR DESCRIPTION
### Proposed Changes

Exporting a freshly opened diagram produced a slightly smaller image with clipped edge strokes (e.g. start-/end-event borders), and the exported size depended on hover/selection state. Since [diagram-js#1064](https://github.com/bpmn-io/diagram-js/pull/1064) (15.19) outlines are created lazily, so they no longer implicitly pad the export bounds.

`saveSVG` now hides outlines while measuring the bounds and pads them by 5px, keeping exports stable and unclipped. Requires `diagram-js@^15.23.2` (ships the `.djs-outline-hidden` class).

Related to https://github.com/camunda/camunda-modeler/issues/6065

### Steps to try out

1. Open a diagram with an element flush against the right/bottom edge (e.g. an end event).
2. Export to SVG/PNG **without** hovering or selecting anything.
3. The full border is visible (before: clipped), and the size no longer changes based on prior interaction.

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
