### PR TITLE
fix(css): give breadcrumbs a background so they stay readable over elements

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -42,11 +42,14 @@
   align-items: center;
   top: 30px;
   left: 30px;
-  padding: 0px;
+  padding: 6px 10px;
   margin: 0px;
   font-family: var(--breadcrumbs-font-family);
   font-size: 16px;
   line-height: normal;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 }
 
 .bjs-breadcrumbs-shown .bjs-breadcrumbs {
@@ -143,3 +146,4 @@
   height: 20px;
   width: 20px;
 }
+


### PR DESCRIPTION
## What

Give the drilldown breadcrumbs a readable background so they no longer visually overlap with BPMN elements.

## Why

When modeling complex processes, BPMN elements can fill the screen. Inside a subprocess, the breadcrumb navigation is drawn on top of the canvas with no background, so breadcrumb text collides with the elements beneath it and becomes hard to read.

## How

`.bjs-breadcrumbs` now gets a translucent white background, subtle shadow, and a bit of padding — similar to how the modeling palette is visually separated from the canvas:

```css
.bjs-breadcrumbs {
  /* ... */
  padding: 6px 10px;
  border-radius: 4px;
  background-color: rgba(255, 255, 255, 0.9);
  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
}
```

Fixes #2482