### PR TITLE
feat: extract default element sizes into ElementSizeUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: expose default element sizes via `lib/util/ElementSizeUtil` ([#2485](https://github.com/bpmn-io/bpmn-js/issues/2485))
+* `FIX`: do not throw when getting default size of participant without DI ([#2485](https://github.com/bpmn-io/bpmn-js/issues/2485))
+
 ## 18.24.0
 
 * `FEAT`: support tabs in popup menu ([bpmn-io/diagram-js#1096](https://github.com/bpmn-io/diagram-js/pull/1096))

--- a/lib/features/modeling/ElementFactory.js
+++ b/lib/features/modeling/ElementFactory.js
@@ -10,8 +10,6 @@ import {
 import inherits from 'inherits-browser';
 
 import {
-  getBusinessObject,
-  getDi,
   is
 } from '../../util/ModelUtil';
 
@@ -28,6 +26,10 @@ import BaseElementFactory from 'diagram-js/lib/core/ElementFactory';
 import {
   DEFAULT_LABEL_SIZE
 } from '../../util/LabelUtil';
+
+import {
+  getDefaultSize
+} from '../../util/ElementSizeUtil';
 
 /**
  * @typedef {import('diagram-js/lib/util/Types').Dimensions} Dimensions
@@ -258,71 +260,12 @@ ElementFactory.prototype.createElement = function(elementType, attrs) {
  * Get the default size of a diagram element.
  *
  * @param {Element} element The element.
- * @param {ModdleElement} di The DI.
+ * @param {ModdleElement} [di] The DI.
  *
  * @return {Dimensions} Default width and height of the element.
  */
 ElementFactory.prototype.getDefaultSize = function(element, di) {
-
-  var bo = getBusinessObject(element);
-  di = di || getDi(element);
-
-  if (is(bo, 'bpmn:SubProcess')) {
-    if (isExpanded(bo, di)) {
-      return { width: 350, height: 200 };
-    } else {
-      return { width: 100, height: 80 };
-    }
-  }
-
-  if (is(bo, 'bpmn:Task')) {
-    return { width: 100, height: 80 };
-  }
-
-  if (is(bo, 'bpmn:Gateway')) {
-    return { width: 50, height: 50 };
-  }
-
-  if (is(bo, 'bpmn:Event')) {
-    return { width: 36, height: 36 };
-  }
-
-  if (is(bo, 'bpmn:Participant')) {
-    var isHorizontalPool = di.isHorizontal === undefined || di.isHorizontal === true;
-    if (isExpanded(bo, di)) {
-      if (isHorizontalPool) {
-        return { width: 600, height: 250 };
-      }
-      return { width: 250, height: 600 };
-    } else {
-      if (isHorizontalPool) {
-        return { width: 400, height: 60 };
-      }
-      return { width: 60, height: 400 };
-    }
-  }
-
-  if (is(bo, 'bpmn:Lane')) {
-    return { width: 400, height: 100 };
-  }
-
-  if (is(bo, 'bpmn:DataObjectReference')) {
-    return { width: 36, height: 50 };
-  }
-
-  if (is(bo, 'bpmn:DataStoreReference')) {
-    return { width: 50, height: 50 };
-  }
-
-  if (is(bo, 'bpmn:TextAnnotation')) {
-    return { width: 100, height: 40 };
-  }
-
-  if (is(bo, 'bpmn:Group')) {
-    return { width: 300, height: 300 };
-  }
-
-  return { width: 100, height: 80 };
+  return getDefaultSize(element, di);
 };
 
 

--- a/lib/util/ElementSizeUtil.js
+++ b/lib/util/ElementSizeUtil.js
@@ -1,0 +1,172 @@
+import {
+  getBusinessObject,
+  getDi,
+  is
+} from './ModelUtil';
+
+import {
+  isExpanded
+} from './DiUtil';
+
+/**
+ * @typedef {import('diagram-js/lib/util/Types').Dimensions} Dimensions
+ *
+ * @typedef {import('../model/Types').Element} Element
+ * @typedef {import('../model/Types').ModdleElement} ModdleElement
+ */
+
+/**
+ * Default size of elements without an explicit default.
+ *
+ * @type {Dimensions}
+ */
+export const DEFAULT_SIZE = { width: 100, height: 80 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_TASK_SIZE = { width: 100, height: 80 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_GATEWAY_SIZE = { width: 50, height: 50 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_EVENT_SIZE = { width: 36, height: 36 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_SUB_PROCESS_SIZE = { width: 350, height: 200 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_COLLAPSED_SUB_PROCESS_SIZE = { width: 100, height: 80 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_PARTICIPANT_SIZE = { width: 600, height: 250 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_VERTICAL_PARTICIPANT_SIZE = { width: 250, height: 600 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_COLLAPSED_PARTICIPANT_SIZE = { width: 400, height: 60 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_VERTICAL_COLLAPSED_PARTICIPANT_SIZE = { width: 60, height: 400 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_LANE_SIZE = { width: 400, height: 100 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_DATA_OBJECT_REFERENCE_SIZE = { width: 36, height: 50 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_DATA_STORE_REFERENCE_SIZE = { width: 50, height: 50 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_TEXT_ANNOTATION_SIZE = { width: 100, height: 40 };
+
+/**
+ * @type {Dimensions}
+ */
+export const DEFAULT_GROUP_SIZE = { width: 300, height: 300 };
+
+
+/**
+ * Get the default size of a BPMN element.
+ *
+ * Elements without an explicit default, e.g. `bpmn:CallActivity`, fall back to
+ * `DEFAULT_SIZE`.
+ *
+ * @param {Element|ModdleElement} element The element.
+ * @param {ModdleElement} [di] The DI; defaults to the DI of the element.
+ *
+ * @return {Dimensions} Default width and height of the element.
+ */
+export function getDefaultSize(element, di) {
+
+  const bo = getBusinessObject(element);
+
+  di = di || getDi(element);
+
+  if (is(bo, 'bpmn:SubProcess')) {
+    if (isExpanded(bo, di)) {
+      return { ...DEFAULT_SUB_PROCESS_SIZE };
+    } else {
+      return { ...DEFAULT_COLLAPSED_SUB_PROCESS_SIZE };
+    }
+  }
+
+  if (is(bo, 'bpmn:Task')) {
+    return { ...DEFAULT_TASK_SIZE };
+  }
+
+  if (is(bo, 'bpmn:Gateway')) {
+    return { ...DEFAULT_GATEWAY_SIZE };
+  }
+
+  if (is(bo, 'bpmn:Event')) {
+    return { ...DEFAULT_EVENT_SIZE };
+  }
+
+  if (is(bo, 'bpmn:Participant')) {
+    const isHorizontalPool = !di || di.isHorizontal === undefined || di.isHorizontal === true;
+
+    if (isExpanded(bo, di)) {
+      if (isHorizontalPool) {
+        return { ...DEFAULT_PARTICIPANT_SIZE };
+      }
+
+      return { ...DEFAULT_VERTICAL_PARTICIPANT_SIZE };
+    } else {
+      if (isHorizontalPool) {
+        return { ...DEFAULT_COLLAPSED_PARTICIPANT_SIZE };
+      }
+
+      return { ...DEFAULT_VERTICAL_COLLAPSED_PARTICIPANT_SIZE };
+    }
+  }
+
+  if (is(bo, 'bpmn:Lane')) {
+    return { ...DEFAULT_LANE_SIZE };
+  }
+
+  if (is(bo, 'bpmn:DataObjectReference')) {
+    return { ...DEFAULT_DATA_OBJECT_REFERENCE_SIZE };
+  }
+
+  if (is(bo, 'bpmn:DataStoreReference')) {
+    return { ...DEFAULT_DATA_STORE_REFERENCE_SIZE };
+  }
+
+  if (is(bo, 'bpmn:TextAnnotation')) {
+    return { ...DEFAULT_TEXT_ANNOTATION_SIZE };
+  }
+
+  if (is(bo, 'bpmn:Group')) {
+    return { ...DEFAULT_GROUP_SIZE };
+  }
+
+  return { ...DEFAULT_SIZE };
+}

--- a/lib/util/ElementSizeUtil.js
+++ b/lib/util/ElementSizeUtil.js
@@ -99,8 +99,21 @@ export const DEFAULT_GROUP_SIZE = { width: 300, height: 300 };
  * Elements without an explicit default, e.g. `bpmn:CallActivity`, fall back to
  * `DEFAULT_SIZE`.
  *
- * @param {Element|ModdleElement} element The element.
+ * @overlord
+ * @param {Element} element The element.
  * @param {ModdleElement} [di] The DI; defaults to the DI of the element.
+ *
+ * @return {Dimensions} Default width and height of the element.
+ */
+
+/**
+ * Get the default size of a BPMN element.
+ *
+ * Elements without an explicit default, e.g. `bpmn:CallActivity`, fall back to
+ * `DEFAULT_SIZE`.
+ *
+ * @param {ModdleElement} element The element.
+ * @param {ModdleElement} di The DI.
  *
  * @return {Dimensions} Default width and height of the element.
  */

--- a/lib/util/ElementSizeUtil.spec.ts
+++ b/lib/util/ElementSizeUtil.spec.ts
@@ -1,0 +1,23 @@
+import {
+  DEFAULT_EVENT_SIZE,
+  DEFAULT_TASK_SIZE,
+  getDefaultSize
+} from './ElementSizeUtil';
+
+const taskWidth: number = DEFAULT_TASK_SIZE.width;
+
+const eventHeight: number = DEFAULT_EVENT_SIZE.height;
+
+const subProcess = {
+  $type: 'bpmn:SubProcess'
+};
+
+const size = getDefaultSize(subProcess);
+
+const sizeWithDi = getDefaultSize(subProcess, {
+  isExpanded: true
+});
+
+const width: number = size.width;
+
+const height: number = sizeWithDi.height;

--- a/lib/util/ElementSizeUtil.spec.ts
+++ b/lib/util/ElementSizeUtil.spec.ts
@@ -4,17 +4,25 @@ import {
   getDefaultSize
 } from './ElementSizeUtil';
 
+import { Element } from '../model/Types';
+
 const taskWidth: number = DEFAULT_TASK_SIZE.width;
 
 const eventHeight: number = DEFAULT_EVENT_SIZE.height;
 
+// element with a resolvable DI => di is optional
 const subProcess = {
-  $type: 'bpmn:SubProcess'
-};
+  type: 'bpmn:SubProcess'
+} as Element;
 
 const size = getDefaultSize(subProcess);
 
-const sizeWithDi = getDefaultSize(subProcess, {
+// moddle element => di must be provided
+const subProcessBo = {
+  $type: 'bpmn:SubProcess'
+};
+
+const sizeWithDi = getDefaultSize(subProcessBo, {
   isExpanded: true
 });
 

--- a/test/spec/features/modeling/ElementFactorySpec.js
+++ b/test/spec/features/modeling/ElementFactorySpec.js
@@ -13,6 +13,10 @@ import {
 } from '../../../../lib/util/ModelUtil';
 
 import {
+  getDefaultSize
+} from '../../../../lib/util/ElementSizeUtil';
+
+import {
   assign
 } from 'min-dash';
 
@@ -317,6 +321,38 @@ describe('features - element factory', function() {
       }));
 
     });
+
+  });
+
+
+  describe('#getDefaultSize', function() {
+
+    it('should delegate to ElementSizeUtil', inject(function(elementFactory, bpmnFactory) {
+
+      // given
+      var task = bpmnFactory.create('bpmn:Task'),
+          gateway = bpmnFactory.create('bpmn:ExclusiveGateway');
+
+      // then
+      expect(elementFactory.getDefaultSize(task)).to.eql(getDefaultSize(task));
+      expect(elementFactory.getDefaultSize(gateway)).to.eql(getDefaultSize(gateway));
+    }));
+
+
+    it('should respect override', inject(function(elementFactory) {
+
+      // given
+      elementFactory.getDefaultSize = function() {
+        return { width: 1, height: 1 };
+      };
+
+      // when
+      var task = elementFactory.createShape({ type: 'bpmn:Task' });
+
+      // then
+      expect(task.width).to.eql(1);
+      expect(task.height).to.eql(1);
+    }));
 
   });
 

--- a/test/spec/util/ElementSizeUtilSpec.js
+++ b/test/spec/util/ElementSizeUtilSpec.js
@@ -1,0 +1,329 @@
+import { expect } from 'chai';
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import coreModule from 'lib/core';
+import modelingModule from 'lib/features/modeling';
+
+import {
+  DEFAULT_TASK_SIZE,
+  getDefaultSize
+} from 'lib/util/ElementSizeUtil';
+
+
+describe('util/ElementSizeUtil', function() {
+
+  var diagramXML = require('../../fixtures/bpmn/simple.bpmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      coreModule,
+      modelingModule
+    ]
+  }));
+
+
+  describe('#getDefaultSize', function() {
+
+    it('should return size of task', inject(function(bpmnFactory) {
+
+      // given
+      var task = bpmnFactory.create('bpmn:Task');
+
+      // when
+      var size = getDefaultSize(task);
+
+      // then
+      expect(size).to.eql({ width: 100, height: 80 });
+    }));
+
+
+    it('should return size of task sub type', inject(function(bpmnFactory) {
+
+      // given
+      var userTask = bpmnFactory.create('bpmn:UserTask');
+
+      // when
+      var size = getDefaultSize(userTask);
+
+      // then
+      expect(size).to.eql({ width: 100, height: 80 });
+    }));
+
+
+    it('should return size of gateway', inject(function(bpmnFactory) {
+
+      // given
+      var gateway = bpmnFactory.create('bpmn:ExclusiveGateway');
+
+      // when
+      var size = getDefaultSize(gateway);
+
+      // then
+      expect(size).to.eql({ width: 50, height: 50 });
+    }));
+
+
+    it('should return size of event', inject(function(bpmnFactory) {
+
+      // given
+      var startEvent = bpmnFactory.create('bpmn:StartEvent');
+
+      // when
+      var size = getDefaultSize(startEvent);
+
+      // then
+      expect(size).to.eql({ width: 36, height: 36 });
+    }));
+
+
+    it('should return size of lane', inject(function(bpmnFactory) {
+
+      // given
+      var lane = bpmnFactory.create('bpmn:Lane');
+
+      // when
+      var size = getDefaultSize(lane);
+
+      // then
+      expect(size).to.eql({ width: 400, height: 100 });
+    }));
+
+
+    it('should return size of data object reference', inject(function(bpmnFactory) {
+
+      // given
+      var dataObjectReference = bpmnFactory.create('bpmn:DataObjectReference');
+
+      // when
+      var size = getDefaultSize(dataObjectReference);
+
+      // then
+      expect(size).to.eql({ width: 36, height: 50 });
+    }));
+
+
+    it('should return size of data store reference', inject(function(bpmnFactory) {
+
+      // given
+      var dataStoreReference = bpmnFactory.create('bpmn:DataStoreReference');
+
+      // when
+      var size = getDefaultSize(dataStoreReference);
+
+      // then
+      expect(size).to.eql({ width: 50, height: 50 });
+    }));
+
+
+    it('should return size of text annotation', inject(function(bpmnFactory) {
+
+      // given
+      var textAnnotation = bpmnFactory.create('bpmn:TextAnnotation');
+
+      // when
+      var size = getDefaultSize(textAnnotation);
+
+      // then
+      expect(size).to.eql({ width: 100, height: 40 });
+    }));
+
+
+    it('should return size of group', inject(function(bpmnFactory) {
+
+      // given
+      var group = bpmnFactory.create('bpmn:Group');
+
+      // when
+      var size = getDefaultSize(group);
+
+      // then
+      expect(size).to.eql({ width: 300, height: 300 });
+    }));
+
+
+    it('should return default size for unknown type', inject(function(bpmnFactory) {
+
+      // given
+      var callActivity = bpmnFactory.create('bpmn:CallActivity');
+
+      // when
+      var size = getDefaultSize(callActivity);
+
+      // then
+      expect(size).to.eql({ width: 100, height: 80 });
+    }));
+
+
+    describe('sub process', function() {
+
+      it('should return size of expanded sub process', inject(function(bpmnFactory) {
+
+        // given
+        var subProcess = bpmnFactory.create('bpmn:SubProcess');
+
+        // when
+        var size = getDefaultSize(subProcess, { isExpanded: true });
+
+        // then
+        expect(size).to.eql({ width: 350, height: 200 });
+      }));
+
+
+      it('should return size of collapsed sub process', inject(function(bpmnFactory) {
+
+        // given
+        var subProcess = bpmnFactory.create('bpmn:SubProcess');
+
+        // when
+        var size = getDefaultSize(subProcess, { isExpanded: false });
+
+        // then
+        expect(size).to.eql({ width: 100, height: 80 });
+      }));
+
+
+      it('should fall back to DI of element', inject(function(elementFactory) {
+
+        // given
+        var subProcess = elementFactory.createShape({
+          type: 'bpmn:SubProcess',
+          isExpanded: true
+        });
+
+        // when
+        var size = getDefaultSize(subProcess);
+
+        // then
+        expect(size).to.eql({ width: 350, height: 200 });
+      }));
+
+    });
+
+
+    describe('participant', function() {
+
+      function createParticipant(bpmnFactory, isExpanded) {
+        return bpmnFactory.create('bpmn:Participant', isExpanded ? {
+          processRef: bpmnFactory.create('bpmn:Process')
+        } : {});
+      }
+
+
+      it('should return size of expanded participant', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, true);
+
+        // when
+        var size = getDefaultSize(participant, { isHorizontal: true });
+
+        // then
+        expect(size).to.eql({ width: 600, height: 250 });
+      }));
+
+
+      it('should return size of expanded vertical participant', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, true);
+
+        // when
+        var size = getDefaultSize(participant, { isHorizontal: false });
+
+        // then
+        expect(size).to.eql({ width: 250, height: 600 });
+      }));
+
+
+      it('should return size of collapsed participant', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, false);
+
+        // when
+        var size = getDefaultSize(participant, { isHorizontal: true });
+
+        // then
+        expect(size).to.eql({ width: 400, height: 60 });
+      }));
+
+
+      it('should return size of collapsed vertical participant', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, false);
+
+        // when
+        var size = getDefaultSize(participant, { isHorizontal: false });
+
+        // then
+        expect(size).to.eql({ width: 60, height: 400 });
+      }));
+
+
+      it('should default to horizontal without <isHorizontal>', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, true);
+
+        // when
+        var size = getDefaultSize(participant, {});
+
+        // then
+        expect(size).to.eql({ width: 600, height: 250 });
+      }));
+
+
+      it('should default to horizontal without DI', inject(function(bpmnFactory) {
+
+        // given
+        var participant = createParticipant(bpmnFactory, true);
+
+        // when
+        var size = getDefaultSize(participant);
+
+        // then
+        expect(size).to.eql({ width: 600, height: 250 });
+      }));
+
+    });
+
+
+    describe('immutability', function() {
+
+      it('should return new object', inject(function(bpmnFactory) {
+
+        // given
+        var task = bpmnFactory.create('bpmn:Task');
+
+        // when
+        var size = getDefaultSize(task);
+
+        // then
+        expect(size).not.to.equal(DEFAULT_TASK_SIZE);
+        expect(size).not.to.equal(getDefaultSize(task));
+      }));
+
+
+      it('should not leak mutations', inject(function(bpmnFactory) {
+
+        // given
+        var task = bpmnFactory.create('bpmn:Task'),
+            size = getDefaultSize(task);
+
+        // when
+        size.width = 999;
+
+        // then
+        expect(getDefaultSize(task)).to.eql({ width: 100, height: 80 });
+        expect(DEFAULT_TASK_SIZE).to.eql({ width: 100, height: 80 });
+      }));
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Default element sizes were only reachable through the DI-injected `ElementFactory`, so consumers (e.g. a bpmnlint rule that enforces default sizes) had to bootstrap a Modeler or hardcode a copy that silently drifts.

Move them into `lib/util/ElementSizeUtil`, a DI-free module exposing the sizes as named constants plus a pure `getDefaultSize(element, di)`. `ElementFactory#getDefaultSize` delegates to it, keeping behavior and the override contract intact.

Also guard the `di.isHorizontal` dereference, which threw when getting the default size of a participant without DI.

Closes #2485

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
