### PR TITLE
fix(drilldown): give breadcrumbs a solid background

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -31,6 +31,8 @@
   --breadcrumbs-font-family: var(--bjs-font-family);
   --breadcrumbs-item-color: var(--color-blue-205-100-50);
   --breadcrumbs-arrow-color: var(--color-black);
+  --breadcrumbs-background-color: var(--color-grey-225-10-97);
+  --breadcrumbs-border-color: var(--color-grey-225-10-75);
   --drilldown-fill-color: var(--color-white);
   --drilldown-background-color: var(--color-blue-205-100-50);
 }
@@ -40,13 +42,17 @@
   display: none;
   flex-wrap: wrap;
   align-items: center;
-  top: 30px;
-  left: 30px;
-  padding: 0px;
+  top: 20px;
+  left: 20px;
+  padding: 5px 10px;
   margin: 0px;
   font-family: var(--breadcrumbs-font-family);
   font-size: 16px;
   line-height: normal;
+  background-color: var(--breadcrumbs-background-color);
+  border: solid 1px var(--breadcrumbs-border-color);
+  border-radius: 2px;
+  row-gap: 5px;
 }
 
 .bjs-breadcrumbs-shown .bjs-breadcrumbs {
@@ -63,7 +69,6 @@
 
 .bjs-breadcrumbs li {
   display: inline-flex;
-  padding-bottom: 5px;
   align-items: center;
 }
 


### PR DESCRIPTION
### Proposed Changes

<img width="794" height="589" alt="screenshot quZRDc" src="https://github.com/user-attachments/assets/c82b1505-b007-4c8b-8457-2acd595dd564" />

The drilldown breadcrumbs were transparent, so when a subprocess diagram was moved under them they visually overlapped with BPMN elements and became unreadable.

This PR styles the breadcrumbs like the modeling palette with a solid (non-transparent) background, a subtle border and rounded corners — and aligns them to the same `top`/`left` grid as the palette so the two controls line up.

Closes #2482

### Try out via

```
npm start

# turn expanded sub-process into a collapsed one
# drill down
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes #2482`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)