### PR TITLE
fix(drilldown): restore focus outline on drilldown button

### DIFF
--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -35,6 +35,7 @@
   --breadcrumbs-border-color: var(--color-grey-225-10-75);
   --drilldown-fill-color: var(--color-white);
   --drilldown-background-color: var(--color-blue-205-100-50);
+  --drilldown-focus-outline-color: var(--color-blue-205-100-50);
 }
 
 .bjs-breadcrumbs {
@@ -107,10 +108,14 @@
   cursor: pointer;
   border: none;
   border-radius: 2px;
-  outline: none;
 
   fill: var(--drilldown-fill-color);
   background-color: var(--drilldown-background-color);
+}
+
+.bjs-drilldown:focus-visible {
+  outline: solid 1px var(--drilldown-focus-outline-color);
+  outline-offset: 1px;
 }
 
 .bjs-drilldown-empty {

--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -33,6 +33,7 @@
   --breadcrumbs-arrow-color: var(--color-black);
   --breadcrumbs-background-color: var(--color-grey-225-10-97);
   --breadcrumbs-border-color: var(--color-grey-225-10-75);
+  --breadcrumbs-focus-outline-color: var(--color-blue-205-100-50);
   --drilldown-fill-color: var(--color-white);
   --drilldown-background-color: var(--color-blue-205-100-50);
   --drilldown-focus-outline-color: var(--color-blue-205-100-50);
@@ -73,14 +74,15 @@
   align-items: center;
 }
 
-.bjs-breadcrumbs li a {
+.bjs-breadcrumbs a.bjs-crumb {
   cursor: pointer;
   color: var(--breadcrumbs-item-color);
+  text-decoration: none;
 }
 
-.bjs-breadcrumbs li:last-of-type a {
-  color: inherit;
-  cursor: default;
+.bjs-breadcrumbs a.bjs-crumb:focus-visible {
+  outline: solid 1px var(--breadcrumbs-focus-outline-color);
+  outline-offset: 1px;
 }
 
 .bjs-breadcrumbs li:not(:first-child)::before {

--- a/lib/features/drilldown/DrilldownBreadcrumbs.js
+++ b/lib/features/drilldown/DrilldownBreadcrumbs.js
@@ -83,14 +83,7 @@ export default function DrilldownBreadcrumbs(eventBus, elementRegistry, canvas) 
         return [];
       }
 
-      var title = escapeHTML(parent.name || parent.id);
-      var link = domify('<li><span class="bjs-crumb"><a title="' + title + '">' + title + '</a></span></li>');
-
-      link.addEventListener('click', function() {
-        canvas.setRootElement(parentPlane);
-      });
-
-      return link;
+      return [ { parent: parent, parentPlane: parentPlane } ];
     });
 
     breadcrumbs.innerHTML = '';
@@ -100,8 +93,39 @@ export default function DrilldownBreadcrumbs(eventBus, elementRegistry, canvas) 
 
     containerClasses.toggle(OPEN_CLASS, visible);
 
-    path.forEach(function(element) {
-      breadcrumbs.appendChild(element);
+    path.forEach(function(entry, index) {
+      var parent = entry.parent,
+          parentPlane = entry.parentPlane,
+          title = escapeHTML(parent.name || parent.id);
+
+      // the last crumb represents the current plane; render it as
+      // plain, non-interactive text
+      var isCurrent = index === path.length - 1;
+
+      var crumb;
+
+      if (isCurrent) {
+        crumb = domify(
+          '<li><span class="bjs-crumb" title="' + title + '">' + title + '</span></li>'
+        );
+      } else {
+
+        // render navigable crumbs as local links so they are focusable
+        // and keyboard-operable
+        var href = '#' + escapeHTML(parent.id);
+
+        crumb = domify(
+          '<li><a class="bjs-crumb" href="' + href + '" title="' + title + '">' + title + '</a></li>'
+        );
+
+        crumb.addEventListener('click', function(event) {
+          event.preventDefault();
+
+          canvas.setRootElement(parentPlane);
+        });
+      }
+
+      breadcrumbs.appendChild(crumb);
     });
   }
 

--- a/test/spec/features/drilldown/DrilldownSpec.js
+++ b/test/spec/features/drilldown/DrilldownSpec.js
@@ -176,6 +176,39 @@ describe('features - drilldown', function() {
       ).to.equal(subRoot);
     }));
 
+
+    it('should render navigable crumbs as focusable links', inject(function(canvas) {
+
+      // given
+      canvas.setRootElement(canvas.findRoot('collapsedProcess_2_plane'));
+
+      // when
+      var crumbs = getCrumbs();
+
+      // then
+      // all but the last (current) crumb are navigable links
+      crumbs.slice(0, -1).forEach(function(crumb) {
+        expect(crumb.tagName).to.equal('A');
+        expect(crumb.getAttribute('href')).to.exist;
+      });
+    }));
+
+
+    it('should render current crumb as plain, non-focusable text', inject(function(canvas) {
+
+      // given
+      canvas.setRootElement(canvas.findRoot('collapsedProcess_2_plane'));
+
+      // when
+      var crumbs = getCrumbs();
+
+      // then
+      var current = crumbs[crumbs.length - 1];
+
+      expect(current.tagName).to.equal('SPAN');
+      expect(current.getAttribute('href')).not.to.exist;
+    }));
+
   });
 
 
@@ -677,4 +710,8 @@ function expectBreadcrumbs(expected) {
 
 function clickBreadcrumb(index) {
   getBreadcrumbs().children[index].click();
+}
+
+function getCrumbs() {
+  return Array.from(getBreadcrumbs().querySelectorAll('.bjs-crumb'));
 }


### PR DESCRIPTION
### Proposed Changes

<img width="872" height="626" alt="image" src="https://github.com/user-attachments/assets/69345426-8f68-4611-b707-eaaef9dcf25a" />

Improves keyboard accessibility of drilldown navigation, following [WCAG 2.4.7 (Focus Visible)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html):

* **Drilldown button** — the `.bjs-drilldown` button set `outline: none`, removing the focus indicator entirely. Restore a visible focus ring via `:focus-visible`, matching the focus styling convention used across bpmn-io (diagram-js, form-js, properties-panel). Mouse interaction stays visually unchanged.
* **Breadcrumbs** — crumbs were rendered as `<a>` without `href`, so they were neither focusable nor keyboard-operable. Navigable crumbs are now local anchors (`href="#<id>"`) that switch the active plane and can be reached and activated via keyboard; the current plane stays plain, non-interactive text.

Closes #2453

<!-- screenshot to be added -->

### Steps to try out

1. Open a diagram with a collapsed subprocess and drill into it.
2. `Tab` through the diagram — the drilldown button and breadcrumb links now show a visible focus outline.
3. Press `Enter` on a focused breadcrumb link to switch back to that plane.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)