### PR TITLE
Await published longer

### DIFF
--- a/tasks/stages/await-published
+++ b/tasks/stages/await-published
@@ -5,6 +5,7 @@ shopt -s inherit_errexit nullglob
 
 i=0
 tries=9
+interval=5
 pkg="$PKG"
 until [ $i -gt $tries ]
 do
@@ -17,7 +18,7 @@ do
 
   i=$(($i+1))
 
-  sleep 5s
+  sleep "${interval}s"
 done
 
 echo "Not found after $i tries. Giving up."

--- a/tasks/stages/await-published
+++ b/tasks/stages/await-published
@@ -16,7 +16,7 @@ do
     exit 0
   fi
 
-  i=$(($i+1))
+  i=$((i+1))
 
   sleep "${interval}s"
 done

--- a/tasks/stages/await-published
+++ b/tasks/stages/await-published
@@ -21,5 +21,5 @@ do
   sleep "${interval}s"
 done
 
-echo "Not found after $i tries. Giving up."
+echo "Not found after $((i*interval))s ($i attempts). Giving up."
 exit 1;

--- a/tasks/stages/await-published
+++ b/tasks/stages/await-published
@@ -4,7 +4,7 @@ set -eo pipefail
 shopt -s inherit_errexit nullglob
 
 i=0
-tries=9
+tries=20
 interval=5
 pkg="$PKG"
 until [ $i -gt $tries ]


### PR DESCRIPTION
### Proposed Changes

Our last two consecutive releases failed ([example](https://github.com/bpmn-io/bpmn-js/actions/runs/32225788051/job/95985106755)) because `bpmn-js` was not found in the registry. 

This PR cleans up the await published script, improves reporting and doubles the retry count.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
