### PR TITLE
feat: add themeable, WCAG AA compliant primary accent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: use WCAG AA compliant primary accent color ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
 * `DEPS`: update to `diagram-js@15.25.0`
 * `DEPS`: update to `bpmn-moddle@10.2.0`
+* `DEPS`: update to `bpmn-font@0.13.0`
 
 ## 18.25.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: give resize handle a border radius ([bpmn-io/diagram-js#1100](https://github.com/bpmn-io/diagram-js/pull/1100))
+* `FEAT`: give segment dragger a border radius ([bpmn-io/diagram-js#1100](https://github.com/bpmn-io/diagram-js/pull/1100))
 * `FEAT`: add `--accent-color` theming token ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
 * `FIX`: use WCAG AA compliant primary accent color ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
+* `DEPS`: update to `diagram-js@15.25.0`
 
 ## 18.25.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: add `--accent-color` theming token ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
 * `FIX`: use WCAG AA compliant primary accent color ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
 * `DEPS`: update to `diagram-js@15.25.0`
+* `DEPS`: update to `bpmn-moddle@10.2.0`
 
 ## 18.25.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: add `--accent-color` theming token ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
+* `FIX`: use WCAG AA compliant primary accent color ([#2492](https://github.com/bpmn-io/bpmn-js/pull/2492))
+
 ## 18.25.1
 
 * `FIX`: make breadcrumps keyboard accessible ([#2487](https://github.com/bpmn-io/bpmn-js/pull/2487))

--- a/assets/bpmn-js.css
+++ b/assets/bpmn-js.css
@@ -11,6 +11,7 @@
   --color-grey-225-10-95: hsl(225, 10%, 95%);
   --color-grey-225-10-97: hsl(225, 10%, 97%);
 
+  --color-blue-205-100-40: hsl(205, 100%, 40%);
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-45-opacity-30: hsla(205, 100%, 45%, 30%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
@@ -28,15 +29,17 @@
   --color-black-opacity-05: hsla(0, 0%, 0%, 5%);
   --color-black-opacity-10: hsla(0, 0%, 0%, 10%);
 
+  --accent-color: var(--color-blue-205-100-40);
+
   --breadcrumbs-font-family: var(--bjs-font-family);
-  --breadcrumbs-item-color: var(--color-blue-205-100-50);
+  --breadcrumbs-item-color: var(--accent-color);
   --breadcrumbs-arrow-color: var(--color-black);
   --breadcrumbs-background-color: var(--color-grey-225-10-97);
   --breadcrumbs-border-color: var(--color-grey-225-10-75);
-  --breadcrumbs-focus-outline-color: var(--color-blue-205-100-50);
+  --breadcrumbs-focus-outline-color: var(--accent-color);
   --drilldown-fill-color: var(--color-white);
-  --drilldown-background-color: var(--color-blue-205-100-50);
-  --drilldown-focus-outline-color: var(--color-blue-205-100-50);
+  --drilldown-background-color: var(--accent-color);
+  --drilldown-focus-outline-color: var(--accent-color);
 }
 
 .bjs-breadcrumbs {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "18.25.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "bpmn-moddle": "^10.0.0",
+        "bpmn-moddle": "^10.2.0",
         "diagram-js": "^15.25.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
@@ -3034,14 +3034,14 @@
       "dev": true
     },
     "node_modules/bpmn-moddle": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz",
-      "integrity": "sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-10.2.0.tgz",
+      "integrity": "sha512-rjPr+hvh43DH9BXUHnXHVNcILYJbZ4rJdYY0GRV7ve99MURNjpIp/mCL8UJSz923uXJ4Doa/bEgBEsG01fPoYQ==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^5.0.0",
-        "moddle": "^8.0.0",
-        "moddle-xml": "^12.0.0"
+        "min-dash": "^5.1.0",
+        "moddle": "^8.2.1",
+        "moddle-xml": "^12.2.0"
       },
       "engines": {
         "node": ">= 20.12"
@@ -8850,22 +8850,22 @@
       }
     },
     "node_modules/moddle": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
-      "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.2.1.tgz",
+      "integrity": "sha512-20qzO/ZpMGO9j9gdQgXk9bfGxb9wA3JKnGth/21YZKODLrZE4RW/uVMIL5pTskYm34Z61DucBEPkq93qByNsBQ==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^5.0.0"
+        "min-dash": "^5.1.0"
       }
     },
     "node_modules/moddle-xml": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz",
-      "integrity": "sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.2.0.tgz",
+      "integrity": "sha512-kqjdAod5n2v3IVJGudJKRUa1PU/p8GpIb0HbfbVXCppt/MEHtRs+Qi/Q3KTy31JbZCUF9L36mY4wUx7PqqMX4g==",
       "license": "MIT",
       "dependencies": {
-        "min-dash": "^5.0.0",
-        "saxen": "^11.0.2"
+        "min-dash": "^5.1.0",
+        "saxen": "^11.1.0"
       },
       "engines": {
         "node": ">= 18"
@@ -11884,9 +11884,9 @@
       "license": "MIT"
     },
     "node_modules/saxen": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz",
-      "integrity": "sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+      "integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.24.0",
+        "diagram-js": "^15.25.0",
         "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
@@ -3927,9 +3927,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.24.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.24.0.tgz",
-      "integrity": "sha512-RVSeGHVNAWQHM7reWAP0geb245GMVPMeDlsYsilNUrQwR/t+rp8ov0agZArCfV7hUaj8VqIQCMROo50L5MLbbg==",
+      "version": "15.25.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.25.0.tgz",
+      "integrity": "sha512-2TKn4hBy1rHf5/6jVubiLdq09BivmhPq3QexH40YXIOnszYGVx0HKP4bW03bTQzrh7GIqMFbNYDkSXlFREWgmA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^8.0.0",
         "bio-dts": "^0.15.3",
-        "bpmn-font": "^0.12.1",
+        "bpmn-font": "^0.13.0",
         "camunda-bpmn-moddle": "^4.0.1",
         "chai": "^6.2.2",
         "chai-match": "^1.1.1",
@@ -3028,10 +3028,11 @@
       }
     },
     "node_modules/bpmn-font": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.12.1.tgz",
-      "integrity": "sha512-quQ47cFuFSZw3y5ta4J2eg+g/UG38pN9Uk8QzR988RyjFP7agdgwmVXPErCGqaFm4UyTTNGtx9jCFdcxw990vg==",
-      "dev": true
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/bpmn-font/-/bpmn-font-0.13.0.tgz",
+      "integrity": "sha512-NrD6fhpCIPyQQmgPJcFUFm55oXD3EIwRhP5bdXTDNTEAfg9HwuvhXThOuM/XPUrruJoATi2ROeOfFeCIM+ftSw==",
+      "dev": true,
+      "license": "SIL"
     },
     "node_modules/bpmn-moddle": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "babel-loader": "^10.1.1",
     "babel-plugin-istanbul": "^8.0.0",
     "bio-dts": "^0.15.3",
-    "bpmn-font": "^0.12.1",
+    "bpmn-font": "^0.13.0",
     "camunda-bpmn-moddle": "^4.0.1",
     "chai": "^6.2.2",
     "chai-match": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "bpmn-moddle": "^10.0.0",
-    "diagram-js": "^15.24.0",
+    "diagram-js": "^15.25.0",
     "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",
     "inherits-browser": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "webpack": "^5.107.2"
   },
   "dependencies": {
-    "bpmn-moddle": "^10.0.0",
+    "bpmn-moddle": "^10.2.0",
     "diagram-js": "^15.25.0",
     "diagram-js-direct-editing": "^3.5.1",
     "ids": "^3.0.2",


### PR DESCRIPTION
### Proposed Changes

Re-anchor the breadcrumbs and drilldown accents from `--color-blue-205-100-50` (**3.12:1** on white — fails WCAG AA [1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)) to the accessible `--color-blue-205-100-40` (**4.66:1**):

<img width="1521" height="963" alt="capture vLp8IN_optimized" src="https://github.com/user-attachments/assets/1327c0b5-f109-44a5-91c3-4394397d6cb4" />

- Add the `--color-blue-205-100-40` palette primitive and a semantic `--accent-color` hook (matching the accent layer in properties-panel).
- Route `--breadcrumbs-item-color`, `--breadcrumbs-focus-outline-color`, `--drilldown-background-color`, `--drilldown-focus-outline-color` through `--accent-color`.
- `-50` primitive retained for theme back-compat.

Breadcrumb items are text and must meet WCAG 1.4.3 (4.5:1); the drilldown badge shares the same accent. This aligns bpmn-js with the shared accessible accent adopted across the stack.

Related to https://github.com/camunda/camunda-modeler/issues/6135

Depends on bpmn-io/diagram-js#1099 (palette alignment). Part of a coordinated cross-repo rollout, released bottom-up: diagram-js → bpmn-js → properties-panel → element-templates.

### Steps to try out

```
npx @bpmn-io/sr bpmn-io/bpmn-js#accessible-primary-accent
```

Drill into a collapsed sub-process (double-click) to see the breadcrumbs + drilldown accent.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
