### PR TITLE
Correct label link to draw shortest path to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: point label link to the closest point of the connection ([#2493](https://github.com/bpmn-io/bpmn-js/pull/2493))
+
 ## 18.26.0
 
 * `FEAT`: give resize handle a border radius ([bpmn-io/diagram-js#1100](https://github.com/bpmn-io/diagram-js/pull/1100))

--- a/lib/features/label-link/LabelLink.js
+++ b/lib/features/label-link/LabelLink.js
@@ -9,9 +9,10 @@ import {
 import { createLine, updateLine } from 'diagram-js/lib/util/RenderUtil';
 import { getMid, getElementLineIntersection } from 'diagram-js/lib/layout/LayoutUtil';
 import { getDistancePointPoint } from 'diagram-js/lib/features/bendpoints/GeometricUtil';
-import { isLabel } from 'diagram-js/lib/util/ModelUtil';
+import { isConnection, isLabel } from 'diagram-js/lib/util/ModelUtil';
 
 import { isAny } from '../modeling/util/ModelingUtil';
+import { getReferencePoint, asLines } from '../../util/LineUtil';
 import { getRoundRectPath, getCirclePath } from '../../draw/BpmnRenderUtil';
 
 /**
@@ -96,9 +97,17 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
    */
   function createLink(label, target) {
 
-    // Create an auxiliary line between label and target mid points
+    const labelMid = getMid(label);
+
+    // For connections, aim at the closest point on the visible connection
+    // instead of the geometric mid point of the whole connection.
+    const targetReference = isConnection(target)
+      ? getReferencePoint(labelMid, asLines(target.waypoints))
+      : getMid(target);
+
+    // Create an auxiliary line between label and target reference points
     const line = createLine(
-      [ getMid(target), getMid(label) ],
+      [ targetReference, labelMid ],
       LINE_STYLE
     );
     const linePath = line.getAttribute('d');
@@ -113,12 +122,18 @@ export default function LabelLink(eventBus, canvas, graphicsFactory, outline, se
       return;
     }
 
-    // Calculate the intersection point between line and label
-    // If the target is a sequence flow, there is no intersection,
-    // so we link to the middle of it.
-    const targetSelected = selection.isSelected(target);
-    const targetPath = targetSelected ? getElementOutlinePath(target) : getElementPath(target);
-    const targetInter = getElementLineIntersection(targetPath, linePath) || getMid(target);
+    // Calculate the intersection point between line and target.
+    // For connections there is no shape to intersect, so we link to the
+    // closest point on the connection computed above.
+    let targetInter;
+
+    if (isConnection(target)) {
+      targetInter = targetReference;
+    } else {
+      const targetSelected = selection.isSelected(target);
+      const targetPath = targetSelected ? getElementOutlinePath(target) : getElementPath(target);
+      targetInter = getElementLineIntersection(targetPath, linePath) || getMid(target);
+    }
 
     // Do not draw a link if the points are too close
     const distance = getDistancePointPoint(targetInter, labelInter);

--- a/lib/features/modeling/behavior/LabelBehavior.js
+++ b/lib/features/modeling/behavior/LabelBehavior.js
@@ -36,13 +36,9 @@ import {
 } from 'diagram-js/lib/util/PositionUtil';
 
 import {
-  sortBy
-} from 'min-dash';
-
-import {
-  getDistancePointLine,
-  perpendicularFoot
-} from './util/GeometricUtil';
+  getReferencePoint,
+  asEdges
+} from '../../../util/LineUtil';
 
 var NAME_PROPERTY = 'name';
 var TEXT_PROPERTY = 'text';
@@ -299,94 +295,8 @@ export function getReferencePointDelta(referencePoint, oldBounds, newBounds) {
 }
 
 /**
- * Generates the nearest point (reference point) for a given point
- * onto given set of lines
+ * Re-exported for backwards compatibility.
  *
- * @param {Point} point
- * @param {Line[]} lines
- *
- * @return {Point}
+ * @see module:lib/util/LineUtil
  */
-export function getReferencePoint(point, lines) {
-
-  if (!lines.length) {
-    return;
-  }
-
-  var nearestLine = getNearestLine(point, lines);
-
-  return perpendicularFoot(point, nearestLine);
-}
-
-/**
- * Convert the given bounds to a lines array containing all edges
- *
- * @param {Rect|Point} bounds
- *
- * @return {Line[]}
- */
-export function asEdges(bounds) {
-  return [
-    [ // top
-      {
-        x: bounds.x,
-        y: bounds.y
-      },
-      {
-        x: bounds.x + (bounds.width || 0),
-        y: bounds.y
-      }
-    ],
-    [ // right
-      {
-        x: bounds.x + (bounds.width || 0),
-        y: bounds.y
-      },
-      {
-        x: bounds.x + (bounds.width || 0),
-        y: bounds.y + (bounds.height || 0)
-      }
-    ],
-    [ // bottom
-      {
-        x: bounds.x,
-        y: bounds.y + (bounds.height || 0)
-      },
-      {
-        x: bounds.x + (bounds.width || 0),
-        y: bounds.y + (bounds.height || 0)
-      }
-    ],
-    [ // left
-      {
-        x: bounds.x,
-        y: bounds.y
-      },
-      {
-        x: bounds.x,
-        y: bounds.y + (bounds.height || 0)
-      }
-    ]
-  ];
-}
-
-/**
- * Returns the nearest line for a given point by distance
- * @param {Point} point
- * @param {Line[]} lines
- *
- * @return {Line}
- */
-function getNearestLine(point, lines) {
-
-  var distances = lines.map(function(l) {
-    return {
-      line: l,
-      distance: getDistancePointLine(point, l)
-    };
-  });
-
-  var sorted = sortBy(distances, 'distance');
-
-  return sorted[0].line;
-}
+export { getReferencePoint, asEdges } from '../../../util/LineUtil';

--- a/lib/util/LineUtil.js
+++ b/lib/util/LineUtil.js
@@ -3,8 +3,7 @@ import {
 } from 'min-dash';
 
 import {
-  getDistancePointLine,
-  perpendicularFoot
+  getDistancePointPoint
 } from 'diagram-js/lib/features/bendpoints/GeometricUtil';
 
 /**
@@ -18,10 +17,15 @@ import {
  * Generates the nearest point (reference point) for a given point
  * onto a given set of lines.
  *
+ * The reference point is clamped to the actual line segments, i.e. it
+ * always lies on one of the given lines (docking to a segment end /
+ * bendpoint if necessary) instead of on the infinite line extending a
+ * segment.
+ *
  * @param {Point} point
  * @param {Line[]} lines
  *
- * @return {Point}
+ * @return {Point|undefined}
  */
 export function getReferencePoint(point, lines) {
 
@@ -31,7 +35,7 @@ export function getReferencePoint(point, lines) {
 
   var nearestLine = getNearestLine(point, lines);
 
-  return perpendicularFoot(point, nearestLine);
+  return getClosestPointOnLine(point, nearestLine);
 }
 
 /**
@@ -87,7 +91,8 @@ export function asEdges(bounds) {
 }
 
 /**
- * Returns the nearest line for a given point by distance.
+ * Returns the nearest line for a given point by the distance to the
+ * closest point on each (clamped) line segment.
  *
  * @param {Point} point
  * @param {Line[]} lines
@@ -99,11 +104,43 @@ function getNearestLine(point, lines) {
   var distances = lines.map(function(line) {
     return {
       line: line,
-      distance: getDistancePointLine(point, line)
+      distance: getDistancePointPoint(point, getClosestPointOnLine(point, line))
     };
   });
 
   var sorted = sortBy(distances, 'distance');
 
   return sorted[0].line;
+}
+
+/**
+ * Returns the point on a line segment that is closest to the given point,
+ * clamped to the segment's start and end.
+ *
+ * @param {Point} point
+ * @param {Line} line
+ *
+ * @return {Point}
+ */
+function getClosestPointOnLine(point, line) {
+  var start = line[0],
+      end = line[1];
+
+  var dx = end.x - start.x,
+      dy = end.y - start.y;
+
+  var lengthSquared = dx * dx + dy * dy;
+
+  if (lengthSquared === 0) {
+    return { x: start.x, y: start.y };
+  }
+
+  var t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared;
+
+  t = Math.max(0, Math.min(1, t));
+
+  return {
+    x: start.x + t * dx,
+    y: start.y + t * dy
+  };
 }

--- a/lib/util/LineUtil.js
+++ b/lib/util/LineUtil.js
@@ -91,6 +91,23 @@ export function asEdges(bounds) {
 }
 
 /**
+ * Convert the given waypoints to a lines array containing all segments.
+ *
+ * @param {Point[]} waypoints
+ *
+ * @return {Line[]}
+ */
+export function asLines(waypoints) {
+  var lines = [];
+
+  for (var i = 0; i < waypoints.length - 1; i++) {
+    lines.push([ waypoints[i], waypoints[i + 1] ]);
+  }
+
+  return lines;
+}
+
+/**
  * Returns the nearest line for a given point by the distance to the
  * closest point on each (clamped) line segment.
  *

--- a/lib/util/LineUtil.js
+++ b/lib/util/LineUtil.js
@@ -1,0 +1,109 @@
+import {
+  sortBy
+} from 'min-dash';
+
+import {
+  getDistancePointLine,
+  perpendicularFoot
+} from 'diagram-js/lib/features/bendpoints/GeometricUtil';
+
+/**
+ * @typedef {import('diagram-js/lib/util/Types').Point} Point
+ * @typedef {import('diagram-js/lib/util/Types').Rect} Rect
+ *
+ * @typedef {Point[]} Line
+ */
+
+/**
+ * Generates the nearest point (reference point) for a given point
+ * onto a given set of lines.
+ *
+ * @param {Point} point
+ * @param {Line[]} lines
+ *
+ * @return {Point}
+ */
+export function getReferencePoint(point, lines) {
+
+  if (!lines.length) {
+    return;
+  }
+
+  var nearestLine = getNearestLine(point, lines);
+
+  return perpendicularFoot(point, nearestLine);
+}
+
+/**
+ * Convert the given bounds to a lines array containing all edges.
+ *
+ * @param {Rect|Point} bounds
+ *
+ * @return {Line[]}
+ */
+export function asEdges(bounds) {
+  return [
+    [ // top
+      {
+        x: bounds.x,
+        y: bounds.y
+      },
+      {
+        x: bounds.x + (bounds.width || 0),
+        y: bounds.y
+      }
+    ],
+    [ // right
+      {
+        x: bounds.x + (bounds.width || 0),
+        y: bounds.y
+      },
+      {
+        x: bounds.x + (bounds.width || 0),
+        y: bounds.y + (bounds.height || 0)
+      }
+    ],
+    [ // bottom
+      {
+        x: bounds.x,
+        y: bounds.y + (bounds.height || 0)
+      },
+      {
+        x: bounds.x + (bounds.width || 0),
+        y: bounds.y + (bounds.height || 0)
+      }
+    ],
+    [ // left
+      {
+        x: bounds.x,
+        y: bounds.y
+      },
+      {
+        x: bounds.x,
+        y: bounds.y + (bounds.height || 0)
+      }
+    ]
+  ];
+}
+
+/**
+ * Returns the nearest line for a given point by distance.
+ *
+ * @param {Point} point
+ * @param {Line[]} lines
+ *
+ * @return {Line}
+ */
+function getNearestLine(point, lines) {
+
+  var distances = lines.map(function(line) {
+    return {
+      line: line,
+      distance: getDistancePointLine(point, line)
+    };
+  });
+
+  var sorted = sortBy(distances, 'distance');
+
+  return sorted[0].line;
+}

--- a/test/spec/features/label-link/LabelLink.bpmn
+++ b/test/spec/features/label-link/LabelLink.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.51.0-rc.1">
   <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:startEvent id="Start_Event" name="Start Event">
       <bpmn:outgoing>Sequence</bpmn:outgoing>
@@ -10,18 +10,24 @@
       <bpmn:outgoing>Sequence_Curved</bpmn:outgoing>
       <bpmn:outgoing>Flow_08zlypo</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Sequence" name="Sequence" sourceRef="Start_Event" targetRef="Gateway" />
+    <bpmn:sequenceFlow id="Sequence" name="Above segment" sourceRef="Start_Event" targetRef="Gateway" />
     <bpmn:sequenceFlow id="Flow_1n4vntt" sourceRef="Gateway" targetRef="End_Event" />
-    <bpmn:sequenceFlow id="Sequence_Curved" name="Sequence" sourceRef="Gateway" targetRef="End_Event" />
+    <bpmn:sequenceFlow id="Sequence_Curved" name="Below segment" sourceRef="Gateway" targetRef="End_Event" />
     <bpmn:endEvent id="End_Event" name="End Event">
       <bpmn:incoming>Flow_1n4vntt</bpmn:incoming>
       <bpmn:incoming>Sequence_Curved</bpmn:incoming>
+      <bpmn:incoming>Sequence_Around</bpmn:incoming>
+      <bpmn:incoming>Sequence_Inside</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_08zlypo" sourceRef="Gateway" targetRef="Subprocess" />
     <bpmn:subProcess id="Subprocess">
       <bpmn:incoming>Flow_08zlypo</bpmn:incoming>
+      <bpmn:outgoing>Sequence_Around</bpmn:outgoing>
+      <bpmn:outgoing>Sequence_Inside</bpmn:outgoing>
       <bpmn:startEvent id="Subprocess_Event" name="Sub Event" />
     </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Sequence_Around" name="Bendpoint docked" sourceRef="Subprocess" targetRef="End_Event" />
+    <bpmn:sequenceFlow id="Sequence_Inside" name="Inside" sourceRef="Subprocess" targetRef="End_Event" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -56,7 +62,7 @@
         <di:waypoint x="158" y="210" />
         <di:waypoint x="275" y="210" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="192" y="192" width="50" height="14" />
+          <dc:Bounds x="174" y="192" width="71" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1n4vntt_di" bpmnElement="Flow_1n4vntt">
@@ -69,7 +75,7 @@
         <di:waypoint x="300" y="310" />
         <di:waypoint x="432" y="310" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="345" y="253" width="50" height="14" />
+          <dc:Bounds x="312" y="363" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08zlypo_di" bpmnElement="Flow_08zlypo">
@@ -77,6 +83,23 @@
         <di:waypoint x="450" y="210" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="645" y="183" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1th15d0_di" bpmnElement="Sequence_Around">
+        <di:waypoint x="590" y="190" />
+        <di:waypoint x="670" y="190" />
+        <di:waypoint x="670" y="310" />
+        <di:waypoint x="468" y="310" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="666" y="323" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0idyefv_di" bpmnElement="Sequence_Inside">
+        <di:waypoint x="540" y="250" />
+        <di:waypoint x="540" y="310" />
+        <di:waypoint x="468" y="310" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="455" y="263" width="30" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/test/spec/features/label-link/LabelLinkSpec.js
+++ b/test/spec/features/label-link/LabelLinkSpec.js
@@ -51,19 +51,53 @@ describe('features/label-link - label link', function() {
   );
 
 
-  it('should show for sequence flow', inject(
-    function(selection, elementRegistry) {
+  describe('should show for sequence flow', function() {
 
-      // given
-      const element = elementRegistry.get('Sequence_Curved');
+    it('below segment', inject(
+      function(selection, elementRegistry) {
 
-      // when
-      selection.select(element);
+        // given
+        const element = elementRegistry.get('Sequence_Curved');
 
-      // then
-      expectLinkWithPath('M328,310L364,267');
-    })
-  );
+        // when
+        selection.select(element);
+
+        // then
+        expectLinkWithPath('M350,310L350,363');
+      })
+    );
+
+
+    it('inside of segment', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('Sequence_Inside');
+
+        // when
+        selection.select(element);
+
+        // then
+        expectLinkWithPath('M470,310L470,277');
+      })
+    );
+
+
+    it('bendpoint docking', inject(
+      function(selection, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('Sequence_Around');
+
+        // when
+        selection.select(element);
+
+        // then
+        expectLinkWithPath('M670,310L697,323');
+      })
+    );
+
+  });
 
 
   it('should show for gateway', inject(
@@ -235,6 +269,7 @@ describe('features/label-link - label link', function() {
       expect(links).to.have.length(0);
     })
   );
+
 });
 
 // helpers

--- a/test/spec/util/LineUtilSpec.js
+++ b/test/spec/util/LineUtilSpec.js
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+
+import {
+  asEdges,
+  getReferencePoint
+} from 'lib/util/LineUtil';
+
+
+describe('util/LineUtil', function() {
+
+  describe('#getReferencePoint', function() {
+
+    it('should return undefined without lines', function() {
+
+      // when
+      const point = getReferencePoint({ x: 0, y: 0 }, []);
+
+      // then
+      expect(point).not.to.exist;
+    });
+
+
+    it('should dock to the perpendicular foot inside a segment', function() {
+
+      // given
+      const lines = asLines([
+        { x: 0, y: 0 },
+        { x: 100, y: 0 }
+      ]);
+
+      // when
+      const point = getReferencePoint({ x: 40, y: 30 }, lines);
+
+      // then
+      expect(point).to.eql({ x: 40, y: 0 });
+    });
+
+
+    it('should clamp to the segment end (dock to bendpoint)', function() {
+
+      // given
+      // an L-shaped connection with a bendpoint at (670, 310)
+      const lines = asLines([
+        { x: 590, y: 190 },
+        { x: 670, y: 190 },
+        { x: 670, y: 310 },
+        { x: 468, y: 310 }
+      ]);
+
+      // when
+      // the label is to the right of, and below, the bendpoint
+      const point = getReferencePoint({ x: 711, y: 330 }, lines);
+
+      // then
+      // the reference point is the bendpoint, NOT (711, 310) on the
+      // infinite extension of the horizontal segment
+      expect(point).to.eql({ x: 670, y: 310 });
+    });
+
+
+    it('should clamp to the nearest segment across a corner', function() {
+
+      // given
+      const lines = asLines([
+        { x: 300, y: 235 },
+        { x: 300, y: 310 },
+        { x: 432, y: 310 }
+      ]);
+
+      // when
+      // label below the horizontal segment's start
+      const point = getReferencePoint({ x: 350, y: 370 }, lines);
+
+      // then
+      expect(point).to.eql({ x: 350, y: 310 });
+    });
+
+  });
+
+
+  describe('#asEdges', function() {
+
+    it('should return the four edges of the given bounds', function() {
+
+      // when
+      const edges = asEdges({ x: 10, y: 20, width: 100, height: 50 });
+
+      // then
+      expect(edges).to.eql([
+        [ { x: 10, y: 20 }, { x: 110, y: 20 } ], // top
+        [ { x: 110, y: 20 }, { x: 110, y: 70 } ], // right
+        [ { x: 10, y: 70 }, { x: 110, y: 70 } ], // bottom
+        [ { x: 10, y: 20 }, { x: 10, y: 70 } ] // left
+      ]);
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function asLines(waypoints) {
+  const lines = [];
+
+  for (let i = 0; i < waypoints.length - 1; i++) {
+    lines.push([ waypoints[i], waypoints[i + 1] ]);
+  }
+
+  return lines;
+}

--- a/test/spec/util/LineUtilSpec.js
+++ b/test/spec/util/LineUtilSpec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import {
   asEdges,
+  asLines,
   getReferencePoint
 } from 'lib/util/LineUtil';
 
@@ -96,17 +97,26 @@ describe('util/LineUtil', function() {
 
   });
 
+
+  describe('#asLines', function() {
+
+    it('should convert waypoints to segments', function() {
+
+      // when
+      const lines = asLines([
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+        { x: 100, y: 50 }
+      ]);
+
+      // then
+      expect(lines).to.eql([
+        [ { x: 0, y: 0 }, { x: 100, y: 0 } ],
+        [ { x: 100, y: 0 }, { x: 100, y: 50 } ]
+      ]);
+    });
+
+  });
+
 });
 
-
-// helpers //////////
-
-function asLines(waypoints) {
-  const lines = [];
-
-  for (let i = 0; i < waypoints.length - 1; i++) {
-    lines.push([ waypoints[i], waypoints[i + 1] ]);
-  }
-
-  return lines;
-}


### PR DESCRIPTION
### Proposed Changes

The label link now docks to the closest point on the (visible) connection instead of its geometric mid point. The nearest-point logic is extracted into a shared `LineUtil` and clamped to the actual segments (docking to bendpoints where needed).

<img width="1129" height="861" alt="capture wiAVJx_optimized" src="https://github.com/user-attachments/assets/154db7ec-3334-475b-87f4-a5381bd744fb" />

### Try out

```
npx @bpmn-io/sr bpmn-io/bpmn-js#nikku-label-link-nearest-point
```

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
