### PR TITLE
fix(modeling): remove BPMNLabel with external label

### DIFF
--- a/lib/features/modeling/BpmnUpdater.js
+++ b/lib/features/modeling/BpmnUpdater.js
@@ -310,6 +310,45 @@ export default function BpmnUpdater(
       di.set('label', undefined);
     }
   }
+
+  this.executed('shape.delete', ifBpmn(function(event) {
+    var context = event.context,
+        shape = context.shape,
+        labelTarget = shape.labelTarget || context.labelTarget,
+        di;
+
+    if (!isLabel(shape) || !labelTarget) {
+      return;
+    }
+
+    di = getDi(labelTarget);
+
+    if (!di || !di.get('label')) {
+      return;
+    }
+
+    context.oldLabel = di.get('label');
+    di.set('label', undefined);
+  }));
+
+  this.reverted('shape.delete', ifBpmn(function(event) {
+    var context = event.context,
+        shape = context.shape,
+        labelTarget = shape.labelTarget || context.labelTarget,
+        di;
+
+    if (!isLabel(shape) || !labelTarget || !context.oldLabel) {
+      return;
+    }
+
+    di = getDi(labelTarget);
+
+    if (!di) {
+      return;
+    }
+
+    di.set('label', context.oldLabel);
+  }));
 }
 
 inherits(BpmnUpdater, CommandInterceptor);

--- a/test/spec/features/modeling/BpmnUpdaterSpec.js
+++ b/test/spec/features/modeling/BpmnUpdaterSpec.js
@@ -284,20 +284,16 @@ describe('features - bpmn-updater', function() {
 
   });
 
-
   describe('BPMNLabel', function() {
 
     describe('embedded', function() {
 
       it('should set BPMNLabel on task', inject(function(modeling, elementRegistry) {
 
-        // given
         var task = elementRegistry.get('Task_1');
 
-        // when
         modeling.updateLabel(task, 'foo');
 
-        // then
         expect(task.businessObject.name).to.equal('foo');
         expect(getDi(task).label).to.exist;
       }));
@@ -305,19 +301,61 @@ describe('features - bpmn-updater', function() {
 
       it('should unset BPMNLabel on task', inject(function(modeling, elementRegistry) {
 
-        // given
         var task = elementRegistry.get('Task_3');
 
-        // when
         modeling.updateLabel(task, '');
 
-        // then
         expect(task.businessObject.name).to.equal('');
         expect(getDi(task)).not.to.have.property('label');
       }));
+
     });
 
 
-  });
+    describe('external', function() {
 
-});
+      it('should unset BPMNLabel when external label is removed', inject(
+        function(modeling, elementRegistry) {
+
+          // given
+          var event = elementRegistry.get('StartEvent_2');
+
+          modeling.updateLabel(event, 'foo');
+
+          var label = event.label;
+
+          expect(label).to.exist;
+          expect(getDi(event).label).to.exist;
+
+          // when
+          modeling.removeElements([ label ]);
+
+          // then
+          expect(getDi(event)).not.to.have.property('label');
+        }
+      ));
+
+      it('should restore BPMNLabel when external label deletion is undone', inject(
+        function(modeling, elementRegistry, commandStack) {
+
+          // given
+          var event = elementRegistry.get('StartEvent_2');
+
+          modeling.updateLabel(event, 'foo');
+
+          var label = event.label;
+
+          // when
+          modeling.removeElements([ label ]);
+          commandStack.undo();
+
+          // then
+          expect(getDi(event).label).to.exist;
+        }
+      ));
+
+    });
+
+  }); // closes BPMNLabel
+
+}); // closes features - bpmn-updater


### PR DESCRIPTION
### Proposed Changes

Closes #1893

Removes the `bpmndi:BPMNLabel` when an external label shape is deleted.

Restores the `BPMNLabel` when the deletion is undone.

Adds regression tests for external label removal and undo behavior.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

### Steps to try out

1. Open a BPMN diagram containing an external label.
2. Delete the external label.
3. Verify that the target element's DI no longer contains a `bpmndi:BPMNLabel`.
4. Undo the deletion.
5. Verify that the `bpmndi:BPMNLabel` is restored.