### PR TITLE
fix: do not adjust group label position away from the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmn-js](https://github.com/bpmn-io/bpmn-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 18.27.1
+
+* `FIX`: do not move group label away from the group ([#2495](https://github.com/bpmn-io/bpmn-js/pull/2495))
+
 ## 18.27.0
 
 * `FEAT`: add tooltip with title and shortcut on palette entries ([#2465](https://github.com/bpmn-io/bpmn-js/pull/2465))

--- a/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
+++ b/lib/features/modeling/behavior/AdaptiveLabelPositioningBehavior.js
@@ -14,6 +14,8 @@ import {
   hasExternalLabel
 } from '../../../util/LabelUtil';
 
+import { is } from '../../../util/ModelUtil';
+
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 import { isConnection } from 'diagram-js/lib/util/ModelUtil';
 
@@ -100,6 +102,11 @@ export default function AdaptiveLabelPositioningBehavior(eventBus, modeling) {
     }
 
     if (isConnection(element)) {
+      return;
+    }
+
+    // group labels are expected to overlap their group
+    if (is(element, 'bpmn:Group')) {
       return;
     }
 

--- a/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
+++ b/test/spec/features/modeling/behavior/AdaptiveLabelPositioningBehaviorSpec.js
@@ -308,6 +308,32 @@ describe('modeling/behavior - AdaptiveLabelPositioningBehavior', function() {
 
       });
 
+
+      describe('through <modeling#updateLabel>', function() {
+
+        it('should keep group label inside the group', inject(
+          function(canvas, modeling) {
+
+            // given
+            var root = canvas.getRootElement();
+
+            var group = modeling.createShape(
+              { type: 'bpmn:Group' },
+              { x: 400, y: 400, width: 300, height: 200 },
+              root
+            );
+
+            // when
+            modeling.updateLabel(group, 'FOO BAR');
+
+            // then
+            expectLabelOrientation(group, 'intersect');
+            expect(group.label.y).to.be.above(group.y);
+          }
+        ));
+
+      });
+
     });
 
   });


### PR DESCRIPTION


https://github.com/user-attachments/assets/d100f8a6-d491-4574-a139-34777800e10f



> 🤖 **This pull request was created by an AI agent (Claude).** Please review carefully.

### Proposed Changes

`AdaptiveLabelPositioningBehavior` nudges an external label away from the shape it overlaps, e.g. when an event/gateway label drifts onto its own element. A recent change made it also fire whenever a label's orientation is already fine but happens to geometrically intersect its element.

For a `bpmn:Group`, the label is *meant* to overlap the group (it's rendered near the top edge, inside the dashed rectangle), so this new check always considered it "intersecting" and pushed the label entirely above the group — where it ends up covered by the context pad.

This PR excludes groups from the adjustment, since a group is the only labeled element whose label is intentionally placed on top of/inside its own shape.

Related to https://github.com/camunda/camunda-modeler/issues/6167

### Try out

```
npx @bpmn-io/sr bpmn-io/bpmn-js#claude/issue-6167-bpmn-js-068767
```

Create a group, add a label — it now stays inside the group instead of floating above it.

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
